### PR TITLE
Support for self-hosted relay server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
  "home",
  "interprocess",
  "libp2p",
+ "libp2p-stream",
  "log",
  "rand 0.8.5",
  "serde",

--- a/crates/config/src/libp2p.rs
+++ b/crates/config/src/libp2p.rs
@@ -1,4 +1,5 @@
 use libp2p_identity::PeerId;
+use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -9,4 +10,8 @@ pub struct Network {
     pub listen_udp_port: u16,
     #[serde(default)]
     pub incoming_allowed_peers: Vec<PeerId>,
+    #[serde(default)]
+    pub disable_relay: bool,
+    #[serde(default)]
+    pub custom_relay_addresses: Vec<Multiaddr>,
 }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -107,6 +107,13 @@ impl FungiDaemon {
             (false, true) => fungi_swarm::get_default_relay_addrs(),
             (false, false) => config.network.custom_relay_addresses.clone(),
         };
+        if relay_addrs.is_empty() {
+            log::info!("Run without relay addresses");
+        } else {
+            for addr in &relay_addrs {
+                log::info!("Using relay address: {addr}");
+            }
+        }
 
         let (swarm_control, swarm_task) =
             FungiSwarm::start_swarm(keypair, state.clone(), relay_addrs, |swarm| {

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -99,8 +99,17 @@ impl FungiDaemon {
                 .collect(),
         );
 
+        let relay_addrs = match (
+            config.network.disable_relay,
+            config.network.custom_relay_addresses.is_empty(),
+        ) {
+            (true, _) => Vec::new(),
+            (false, true) => fungi_swarm::get_default_relay_addrs(),
+            (false, false) => config.network.custom_relay_addresses.clone(),
+        };
+
         let (swarm_control, swarm_task) =
-            FungiSwarm::start_swarm(keypair, state.clone(), |swarm| {
+            FungiSwarm::start_swarm(keypair, state.clone(), relay_addrs, |swarm| {
                 apply_listen(swarm, &config);
             })
             .await?;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -10,7 +10,11 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default, Parser)]
 pub struct DaemonArgs {
-    #[clap(short, long, help = "Path to the Fungi directory")]
+    #[clap(
+        short,
+        long,
+        help = "Path to the Fungi config directory, defaults to ~/.fungi"
+    )]
     pub fungi_dir: Option<String>,
 }
 

--- a/crates/swarm/src/libp2p.rs
+++ b/crates/swarm/src/libp2p.rs
@@ -341,6 +341,7 @@ impl SwarmControl {
             bail!("Handshake failed: empty response");
         };
 
+        println!("Listening on relay address: {relay_addr:?}");
         // 2. listen on relay
         self.invoke_swarm(|swarm| swarm.listen_on(relay_addr.with(Protocol::P2pCircuit)))
             .await??;

--- a/crates/swarm/src/libp2p.rs
+++ b/crates/swarm/src/libp2p.rs
@@ -9,7 +9,7 @@ use libp2p::{
     mdns,
     multiaddr::Protocol,
     noise,
-    swarm::{DialError, SwarmEvent},
+    swarm::{DialError, SwarmEvent, dial_opts::DialOpts},
     tcp, yamux,
 };
 use parking_lot::{Mutex, RwLock};
@@ -231,13 +231,14 @@ impl SwarmControl {
                                 "Dialing {peer_id} with relay address {:?}",
                                 relay_addresses
                             );
+                            let mut full_addrs = Vec::new();
                             for relay_addr in relay_addresses.iter() {
-                                swarm.add_peer_address(
-                                    peer_id,
+                                full_addrs.push(
                                     peer_addr_with_relay(peer_id, relay_addr.clone()),
                                 );
                             }
-                            swarm.dial(peer_id)?;
+                            let dial_opts = DialOpts::peer_id(peer_id).addresses(full_addrs).build();
+                            swarm.dial(dial_opts)?;
                         }
                         _ => return Err(e),
                     }

--- a/flutter_app/rust/src/api/fungi.rs
+++ b/flutter_app/rust/src/api/fungi.rs
@@ -170,6 +170,10 @@ pub async fn start_fungi_daemon(fungi_dir: Option<String>) -> Result<()> {
         daemon.swarm_control().local_peer_id()
     );
 
+    if !daemon.config().lock().network.disable_relay {
+        daemon.swarm_control().listen_relay().await;
+    }
+
     *FUNGI_DAEMON.lock() = Some(Arc::new(daemon));
     Ok(())
 }

--- a/fungi/Cargo.toml
+++ b/fungi/Cargo.toml
@@ -27,3 +27,4 @@ interprocess = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
 tarpc = { workspace = true }
+libp2p-stream = { workspace = true }

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 pub use fungi_daemon::DaemonArgs;
 use fungi_daemon::FungiDaemon;
-use fungi_swarm::get_default_relay_addr;
 
 pub async fn run(args: DaemonArgs) -> Result<()> {
     fungi_config::init(&args).unwrap();
@@ -19,9 +18,9 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         .unwrap();
     println!("Network info: {network_info:?}");
 
-    if let Err(e) = swarm_control.listen_relay(get_default_relay_addr()).await {
-        log::error!("Failed to listen on relay: {e:?}");
-    };
+    if !daemon.config().lock().network.disable_relay {
+        swarm_control.listen_relay().await;
+    }
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/fungi/src/commands/fungi_init.rs
+++ b/fungi/src/commands/fungi_init.rs
@@ -6,7 +6,11 @@ use fungi_config::{DEFAULT_FUNGI_DIR, FungiDir};
 
 #[derive(Debug, Clone, Default, Parser)]
 pub struct InitArgs {
-    #[clap(short, long, help = "Path to the Fungi directory")]
+    #[clap(
+        short,
+        long,
+        help = "Path to the Fungi config directory, defaults to ~/.fungi"
+    )]
     pub fungi_dir: Option<String>,
 }
 

--- a/fungi/src/commands/fungi_relay.rs
+++ b/fungi/src/commands/fungi_relay.rs
@@ -1,0 +1,182 @@
+use anyhow::Result;
+use clap::Parser;
+use fungi_util::protocols::FUNGI_RELAY_HANDSHAKE_PROTOCOL;
+use libp2p::{
+    Swarm,
+    core::{Multiaddr, multiaddr::Protocol},
+    futures::{AsyncWriteExt, StreamExt},
+    identify,
+    identity::Keypair,
+    noise, ping, relay,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux,
+};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+const DEFAULT_CONFIG_DIR: &'static str = ".fungi-relay-server";
+const DEFAULT_LISTEN_PORT: u16 = 30001;
+
+#[derive(Debug, Clone, Parser)]
+pub struct RelayArgs {
+    #[clap(
+        short,
+        long,
+        help = "Path to the Fungi relay server config directory, defaults to ~/.fungi-relay-server"
+    )]
+    pub fungi_dir: Option<String>,
+
+    #[clap(short, long, help = "Public IP address of this device")]
+    pub public_ip: IpAddr,
+
+    #[clap(
+        short,
+        long,
+        help = "Tcp listen port for the relay server, defaults to 30001",
+        default_value_t = DEFAULT_LISTEN_PORT
+    )]
+    pub tcp_listen_port: u16,
+
+    #[clap(
+        short,
+        long,
+        help = "Udp listen port for the relay server, defaults to 30001",
+        default_value_t = DEFAULT_LISTEN_PORT
+    )]
+    pub udp_listen_port: u16,
+}
+
+#[derive(NetworkBehaviour)]
+struct Behaviour {
+    relay: relay::Behaviour,
+    ping: ping::Behaviour,
+    identify: identify::Behaviour,
+    stream: libp2p_stream::Behaviour,
+}
+
+pub async fn run(args: RelayArgs) -> Result<()> {
+    let public_ip = args.public_ip;
+    let tcp_listen_port = args.tcp_listen_port;
+    let udp_listen_port = args.udp_listen_port;
+
+    let keypair = get_or_init_keypair()?;
+
+    let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )?
+        .with_quic()
+        .with_behaviour(|key| Behaviour {
+            relay: relay::Behaviour::new(key.public().to_peer_id(), Default::default()),
+            ping: ping::Behaviour::new(ping::Config::new()),
+            identify: identify::Behaviour::new(identify::Config::new(
+                "/fungi-relay/0.1.0".to_string(),
+                key.public(),
+            )),
+            stream: libp2p_stream::Behaviour::default(),
+        })?
+        .build();
+
+    println!("Local peer id: {:?}", swarm.local_peer_id());
+    listen_all_interfaces(&mut swarm, tcp_listen_port, udp_listen_port)?;
+    add_external_address(&mut swarm, public_ip, tcp_listen_port, udp_listen_port)?;
+    listen_relay_handshake_protocol(swarm.behaviour().stream.new_control());
+
+    loop {
+        match swarm.next().await.expect("Infinite Stream.") {
+            SwarmEvent::Behaviour(event) => {
+                log::info!("{event:?}")
+            }
+            SwarmEvent::NewListenAddr { address, .. } => {
+                log::info!("Listening on {address:?}");
+            }
+            _ => {}
+        }
+    }
+}
+
+fn listen_all_interfaces(
+    swarm: &mut Swarm<Behaviour>,
+    tcp_listen_port: u16,
+    udp_listen_port: u16,
+) -> Result<()> {
+    // Listen on all interfaces
+    swarm.listen_on(
+        Multiaddr::empty()
+            .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+            .with(Protocol::Tcp(tcp_listen_port)),
+    )?;
+    swarm.listen_on(
+        Multiaddr::empty()
+            .with(Protocol::from(Ipv6Addr::UNSPECIFIED))
+            .with(Protocol::Tcp(tcp_listen_port)),
+    )?;
+    swarm.listen_on(
+        Multiaddr::empty()
+            .with(Protocol::from(Ipv6Addr::UNSPECIFIED))
+            .with(Protocol::Udp(udp_listen_port))
+            .with(Protocol::QuicV1),
+    )?;
+    swarm.listen_on(
+        Multiaddr::empty()
+            .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+            .with(Protocol::Udp(udp_listen_port))
+            .with(Protocol::QuicV1),
+    )?;
+    Ok(())
+}
+
+fn add_external_address(
+    swarm: &mut Swarm<Behaviour>,
+    public_ip: IpAddr,
+    tcp_listen_port: u16,
+    udp_listen_port: u16,
+) -> Result<()> {
+    swarm.add_external_address(
+        Multiaddr::empty()
+            .with(Protocol::from(public_ip))
+            .with(Protocol::Tcp(tcp_listen_port)),
+    );
+    swarm.add_external_address(
+        Multiaddr::empty()
+            .with(Protocol::from(public_ip))
+            .with(Protocol::Udp(udp_listen_port))
+            .with(Protocol::QuicV1),
+    );
+    Ok(())
+}
+
+fn listen_relay_handshake_protocol(mut stream_control: libp2p_stream::Control) {
+    let mut listener = stream_control
+        .accept(FUNGI_RELAY_HANDSHAKE_PROTOCOL)
+        .unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Some((peer_id, mut stream)) = listener.next().await else {
+                break;
+            };
+            log::info!("Accepted stream: {:?}", peer_id);
+            // TODO: fungi relay handshake logic
+            stream.write_all(b"ok").await.ok();
+            stream.flush().await.ok();
+            stream.close().await.ok();
+        }
+    });
+}
+
+fn get_or_init_keypair() -> Result<Keypair> {
+    let config_dir = home::home_dir()
+        .ok_or(anyhow::Error::msg("Failed to get home directory"))?
+        .join(DEFAULT_CONFIG_DIR);
+    let keypair = match fungi_util::keypair::get_keypair_from_dir(&config_dir) {
+        Ok(keypair) => keypair,
+        Err(_) => {
+            println!("Initializing config dir...");
+            std::fs::create_dir(&config_dir)?;
+            fungi_util::keypair::init_keypair(&config_dir)?
+        }
+    };
+    Ok(keypair)
+}

--- a/fungi/src/commands/mod.rs
+++ b/fungi/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod fungi_daemon;
 pub mod fungi_init;
+pub mod fungi_relay;
 use clap::{Parser, Subcommand};
 
 /// A platform built for seamless multi-device integration
@@ -8,22 +9,14 @@ use clap::{Parser, Subcommand};
 pub struct FungiArgs {
     #[command(subcommand)]
     pub command: Commands,
-    // #[arg(short, long)]
-    // pub fungi_dir: Option<String>,
 }
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     /// Start a Fungi daemon
     Daemon(fungi_daemon::DaemonArgs),
+    /// Initialize a Fungi configuration, and generate a keypair
     Init(fungi_init::InitArgs),
+    /// Start a simple Fungi relay server
+    Relay(fungi_relay::RelayArgs),
 }
-
-// impl FungiDir for FungiArgs {
-//     fn fungi_dir(&self) -> PathBuf {
-//         self.fungi_dir
-//             .as_ref()
-//             .map(PathBuf::from)
-//             .unwrap_or_else(|| home::home_dir().unwrap().join(DEFAULT_FUNGI_DIR))
-//     }
-// }

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -10,6 +10,7 @@ async fn main() -> Result<()> {
     match fungi_args.command {
         Commands::Daemon(args) => fungi_daemon::run(args).await?,
         Commands::Init(args) => fungi_init::run(args).await?,
+        Commands::Relay(args) => fungi_relay::run(args).await?,
     }
     Ok(())
 }


### PR DESCRIPTION
#6 

This PR implements a built-in relay server directly in the `fungi` binary.

1. On your server, simply use `fungi relay -p ${SERVER_PUBLIC_IP}` to start a self-hosted relay server. 
It defaults to listening on TCP and UDP port 30001.

2. Then you will get your relay addresses on stdout like:
```
/ip4/{SERVER_PUBLIC_IP}/tcp/30001/p2p/16Uiu2HAmxxx
/ip4/{SERVER_PUBLIC_IP}/udp/30001/quic-v1/p2p/16Uiu2HAmxxx
``` 

3. Copy and add these addresses to the `config.toml` of your fungi clients as follows:
```
[network]
listen_tcp_port = 0
listen_udp_port = 0
incoming_allowed_peers = [...]
disable_relay = false
# add custom relay server addresses
custom_relay_addresses = [
    "/ip4/{SERVER_PUBLIC_IP}/tcp/30001/p2p/16Uiu2HAmxxx",
    "/ip4/{SERVER_PUBLIC_IP}/udp/30001/quic-v1/p2p/16Uiu2HAmxxx",
]
```

4. Restart your fungi clients to apply the changes.


Adding these addresses will replace the built-in community relay server. Clearing them will make the client fall back to the community relay server.