### PR TITLE
Refactor: `listen_relay` and `SwarmEvent`

### DIFF
--- a/flutter_app/rust/src/api/fungi.rs
+++ b/flutter_app/rust/src/api/fungi.rs
@@ -170,10 +170,6 @@ pub async fn start_fungi_daemon(fungi_dir: Option<String>) -> Result<()> {
         daemon.swarm_control().local_peer_id()
     );
 
-    if !daemon.config().lock().network.disable_relay {
-        daemon.swarm_control().listen_relay().await;
-    }
-
     *FUNGI_DAEMON.lock() = Some(Arc::new(daemon));
     Ok(())
 }

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -18,10 +18,6 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         .unwrap();
     println!("Network info: {network_info:?}");
 
-    if !daemon.config().lock().network.disable_relay {
-        swarm_control.listen_relay().await;
-    }
-
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
             println!("Shutting down Fungi daemon...");


### PR DESCRIPTION
#10 

This PR refactors the relay listening logic to improve reliability and maintainability. The main change is the removal of the `listen_relay` method from `SwarmControl`, replacing it with an event-driven approach that automatically attempts relay connections when a new suitable listen address is detected. Additionally, the relay connection logic now includes retry and backoff mechanisms for robustness. The code handling relay listening in the daemon startup routines is also removed, as relay connection is now managed internally by the swarm event loop.