### PR TITLE
add flexi_logger, save log to files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flexi_logger"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea7feddba9b4e83022270d49a58d4a1b3fdad04b34f78cf1ce471f698e42672"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term 0.50.3",
+ "regex",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1655,7 @@ dependencies = [
  "bincode",
  "clap",
  "env_logger 0.11.8",
+ "flexi_logger",
  "fungi-config",
  "fungi-daemon",
  "fungi-daemon-grpc",
@@ -1669,6 +1683,7 @@ dependencies = [
  "anyhow",
  "fungi-util",
  "libp2p-identity",
+ "log",
  "mdns-sd",
  "multiaddr",
  "serde",
@@ -3758,6 +3773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5697,7 +5721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,6 +12,7 @@ libp2p-identity = { workspace = true }
 multiaddr = "0.18"
 fungi-util = { path = "../util" }
 anyhow = { workspace = true }
+log = { workspace = true }
 mdns-sd = { git = "https://github.com/keepsimple1/mdns-sd", rev = "1b194de004e7290eff8c116f3e0cb88fadf2f03e" }
 
 [dev-dependencies]

--- a/crates/config/src/init.rs
+++ b/crates/config/src/init.rs
@@ -2,16 +2,35 @@ use crate::{FungiConfig, FungiDir, address_book::AddressBookConfig};
 use anyhow::Result;
 
 pub fn init(dirs: &impl FungiDir) -> Result<()> {
+    init_impl(dirs, false)
+}
+
+pub fn init_for_daemon(dirs: &impl FungiDir) -> Result<()> {
+    init_impl(dirs, true)
+}
+
+fn init_impl(dirs: &impl FungiDir, daemon_mode: bool) -> Result<()> {
     let fungi_dir = dirs.fungi_dir();
     // check if the directory exists
     if fungi_dir.exists() && fungi_dir.is_dir() && fungi_dir.read_dir()?.next().is_some() {
-        println!(
-            "Fungi directory already exists and is not empty: {}",
-            fungi_dir.display()
-        );
+        if daemon_mode {
+            log::info!(
+                "Fungi directory already exists and is not empty: {}",
+                fungi_dir.display()
+            );
+        } else {
+            println!(
+                "Fungi directory already exists and is not empty: {}",
+                fungi_dir.display()
+            );
+        }
         return Ok(());
     }
-    println!("Initializing Fungi...");
+    if daemon_mode {
+        log::info!("Initializing Fungi...");
+    } else {
+        println!("Initializing Fungi...");
+    }
     std::fs::create_dir(&fungi_dir).ok();
 
     // create config.toml
@@ -23,6 +42,10 @@ pub fn init(dirs: &impl FungiDir) -> Result<()> {
     // create .keys
     fungi_util::keypair::init_keypair(&fungi_dir)?;
 
-    println!("Fungi initialized at {}", fungi_dir.display());
+    if daemon_mode {
+        log::info!("Fungi initialized at {}", fungi_dir.display());
+    } else {
+        println!("Fungi initialized at {}", fungi_dir.display());
+    }
     Ok(())
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5,7 +5,7 @@ mod libp2p;
 mod rpc;
 pub mod tcp_tunneling;
 
-pub use init::init;
+pub use init::{init, init_for_daemon};
 
 use anyhow::Result;
 use libp2p::*;

--- a/crates/swarm/src/libp2p.rs
+++ b/crates/swarm/src/libp2p.rs
@@ -757,11 +757,6 @@ async fn handle_ping_event(
             log::debug!("Ping event channel closed");
             break;
         };
-        log::debug!(
-            "Received ping event for connection {:?} with RTT {:?}",
-            event.connection_id,
-            event.rtt
-        );
         swarm_control
             .state()
             .update_connection_ping(&event.connection_id, event.rtt);

--- a/fungi/Cargo.toml
+++ b/fungi/Cargo.toml
@@ -13,6 +13,7 @@ wasi = ["dep:wasmtime-cli"]
 [dependencies]
 log = { workspace = true }
 env_logger = "0.11"
+flexi_logger = "0.31"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { workspace = true }

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -4,20 +4,20 @@ use fungi_daemon::FungiDaemon;
 use fungi_daemon_grpc::start_grpc_server;
 
 pub async fn run(args: DaemonArgs) -> Result<()> {
-    fungi_config::init(&args).unwrap();
+    fungi_config::init_for_daemon(&args)?;
 
-    println!("Starting Fungi daemon...");
+    log::info!("Starting Fungi daemon...");
 
     let daemon = FungiDaemon::start(args.clone()).await?;
 
     let swarm_control = daemon.swarm_control().clone();
-    println!("Local Peer ID: {}", swarm_control.local_peer_id());
+    log::info!("Local Peer ID: {}", swarm_control.local_peer_id());
 
     let network_info = swarm_control
         .invoke_swarm(|swarm| swarm.network_info())
         .await
         .unwrap();
-    println!("Network info: {network_info:?}");
+    log::info!("Network info: {network_info:?}");
 
     let rpc_listen_address = daemon.config().lock().rpc.listen_address.clone();
     let server_fut = start_grpc_server(daemon, rpc_listen_address.parse().unwrap());
@@ -30,11 +30,11 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            println!("Received Ctrl+C, shutting down Fungi daemon...");
+            log::info!("Received Ctrl+C, shutting down Fungi daemon...");
         },
         res = server_fut => {
             if let Err(e) = res {
-                eprintln!("Error occurred while serving: {}", e);
+                log::error!("Error occurred while serving: {}", e);
             }
         },
         _ = async {
@@ -44,7 +44,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
                 std::future::pending::<()>().await
             }
         } => {
-            println!("Shutting down Fungi daemon...");
+            log::info!("Shutting down Fungi daemon...");
         },
     }
 
@@ -60,7 +60,7 @@ async fn stdin_monitor() {
     loop {
         match stdin.read(&mut buf).await {
             Ok(0) => {
-                println!("Stdin closed, parent process likely terminated. Shutting down...");
+                log::info!("Stdin closed, parent process likely terminated. Shutting down...");
                 break;
             }
             Ok(_) => {
@@ -68,7 +68,7 @@ async fn stdin_monitor() {
                 continue;
             }
             Err(e) => {
-                eprintln!("Error reading stdin: {}, shutting down...", e);
+                log::error!("Error reading stdin: {}, shutting down...", e);
                 break;
             }
         }

--- a/fungi/src/logging.rs
+++ b/fungi/src/logging.rs
@@ -1,0 +1,80 @@
+use anyhow::{Ok, Result};
+use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
+use fungi::commands::{Commands, CommonArgs, FungiArgs};
+use fungi_config::FungiDir;
+use std::sync::Once;
+
+static PANIC_HOOK_INIT: Once = Once::new();
+
+pub fn init_logging(fungi_args: &FungiArgs) -> Result<()> {
+    #[cfg(feature = "wasi")]
+    if matches!(&fungi_args.command, Commands::Run(_) | Commands::Serve(_)) {
+        return Ok(());
+    }
+
+    if matches!(&fungi_args.command, Commands::Daemon(_)) {
+        return init_daemon_file_logging(&fungi_args.common);
+    }
+
+    let _ = env_logger::try_init();
+    Ok(())
+}
+
+fn init_daemon_file_logging(common_args: &CommonArgs) -> Result<()> {
+    const DEFAULT_LOG_SPEC: &str = "info";
+    const MAX_LOG_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+    const MAX_LOG_FILES: usize = 5;
+
+    let log_spec = std::env::var("RUST_LOG")
+        .or_else(|_| std::env::var("FUNGI_LOG_LEVEL"))
+        .unwrap_or_else(|_| DEFAULT_LOG_SPEC.to_string());
+
+    let log_dir = common_args.fungi_dir().join("logs");
+    std::fs::create_dir_all(&log_dir)?;
+
+    let duplicate = if cfg!(debug_assertions) || std::env::var("FUNGI_LOG_STDIO").is_ok() {
+        Duplicate::All
+    } else {
+        Duplicate::Warn
+    };
+
+    Logger::try_with_str(log_spec)?
+        .log_to_file(
+            FileSpec::default()
+                .directory(log_dir)
+                .basename("daemon")
+                .suffix("log"),
+        )
+        .duplicate_to_stderr(duplicate)
+        .rotate(
+            Criterion::Size(MAX_LOG_FILE_SIZE_BYTES),
+            Naming::Numbers,
+            Cleanup::KeepLogFiles(MAX_LOG_FILES),
+        )
+        .start()?;
+
+    install_panic_hook();
+
+    Ok(())
+}
+
+fn install_panic_hook() {
+    PANIC_HOOK_INIT.call_once(|| {
+        std::panic::set_hook(Box::new(|panic_info| {
+            let location = panic_info
+                .location()
+                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .unwrap_or_else(|| "unknown location".to_string());
+
+            let payload = panic_info
+                .payload()
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+
+            log::error!("panic at {}: {}", location, payload);
+            eprintln!("panic at {}: {}", location, payload);
+        }));
+    });
+}

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -1,9 +1,15 @@
 use anyhow::{Ok, Result};
 use clap::Parser;
+use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 use fungi::commands::*;
+use fungi_config::FungiDir;
+use std::sync::Once;
+
+static PANIC_HOOK_INIT: Once = Once::new();
 
 fn main() -> Result<()> {
     let fungi_args = FungiArgs::parse();
+    init_logging(&fungi_args)?;
     use fungi_control::*;
 
     #[cfg(target_os = "android")]
@@ -46,13 +52,84 @@ fn main() -> Result<()> {
 }
 
 fn block_on<F: Future>(f: F) -> F::Output {
-    env_logger::init();
-
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap()
         .block_on(f)
+}
+
+fn init_logging(fungi_args: &FungiArgs) -> Result<()> {
+    #[cfg(feature = "wasi")]
+    if matches!(&fungi_args.command, Commands::Run(_) | Commands::Serve(_)) {
+        return Ok(());
+    }
+
+    if matches!(&fungi_args.command, Commands::Daemon(_)) {
+        return init_daemon_file_logging(&fungi_args.common);
+    }
+
+    let _ = env_logger::try_init();
+    Ok(())
+}
+
+fn init_daemon_file_logging(common_args: &CommonArgs) -> Result<()> {
+    const DEFAULT_LOG_SPEC: &str = "info";
+    const MAX_LOG_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+    const MAX_LOG_FILES: usize = 5;
+
+    let log_spec = std::env::var("RUST_LOG")
+        .or_else(|_| std::env::var("FUNGI_LOG_LEVEL"))
+        .unwrap_or_else(|_| DEFAULT_LOG_SPEC.to_string());
+
+    let log_dir = common_args.fungi_dir().join("logs");
+    std::fs::create_dir_all(&log_dir)?;
+
+    let duplicate = if cfg!(debug_assertions) || std::env::var("FUNGI_LOG_STDIO").is_ok() {
+        Duplicate::All
+    } else {
+        Duplicate::Warn
+    };
+
+    Logger::try_with_str(log_spec)?
+        .log_to_file(
+            FileSpec::default()
+                .directory(log_dir)
+                .basename("daemon")
+                .suffix("log"),
+        )
+        .duplicate_to_stderr(duplicate)
+        .rotate(
+            Criterion::Size(MAX_LOG_FILE_SIZE_BYTES),
+            Naming::Numbers,
+            Cleanup::KeepLogFiles(MAX_LOG_FILES),
+        )
+        .start()?;
+
+    install_panic_hook();
+
+    Ok(())
+}
+
+fn install_panic_hook() {
+    PANIC_HOOK_INIT.call_once(|| {
+        std::panic::set_hook(Box::new(|panic_info| {
+            let location = panic_info
+                .location()
+                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+                .unwrap_or_else(|| "unknown location".to_string());
+
+            let payload = panic_info
+                .payload()
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+
+            log::error!("panic at {}: {}", location, payload);
+            eprintln!("panic at {}: {}", location, payload);
+        }));
+    });
 }
 
 #[cfg(target_os = "android")]

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -1,15 +1,11 @@
 use anyhow::{Ok, Result};
 use clap::Parser;
-use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 use fungi::commands::*;
-use fungi_config::FungiDir;
-use std::sync::Once;
-
-static PANIC_HOOK_INIT: Once = Once::new();
+mod logging;
 
 fn main() -> Result<()> {
     let fungi_args = FungiArgs::parse();
-    init_logging(&fungi_args)?;
+    logging::init_logging(&fungi_args)?;
     use fungi_control::*;
 
     #[cfg(target_os = "android")]
@@ -57,79 +53,6 @@ fn block_on<F: Future>(f: F) -> F::Output {
         .build()
         .unwrap()
         .block_on(f)
-}
-
-fn init_logging(fungi_args: &FungiArgs) -> Result<()> {
-    #[cfg(feature = "wasi")]
-    if matches!(&fungi_args.command, Commands::Run(_) | Commands::Serve(_)) {
-        return Ok(());
-    }
-
-    if matches!(&fungi_args.command, Commands::Daemon(_)) {
-        return init_daemon_file_logging(&fungi_args.common);
-    }
-
-    let _ = env_logger::try_init();
-    Ok(())
-}
-
-fn init_daemon_file_logging(common_args: &CommonArgs) -> Result<()> {
-    const DEFAULT_LOG_SPEC: &str = "info";
-    const MAX_LOG_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
-    const MAX_LOG_FILES: usize = 5;
-
-    let log_spec = std::env::var("RUST_LOG")
-        .or_else(|_| std::env::var("FUNGI_LOG_LEVEL"))
-        .unwrap_or_else(|_| DEFAULT_LOG_SPEC.to_string());
-
-    let log_dir = common_args.fungi_dir().join("logs");
-    std::fs::create_dir_all(&log_dir)?;
-
-    let duplicate = if cfg!(debug_assertions) || std::env::var("FUNGI_LOG_STDIO").is_ok() {
-        Duplicate::All
-    } else {
-        Duplicate::Warn
-    };
-
-    Logger::try_with_str(log_spec)?
-        .log_to_file(
-            FileSpec::default()
-                .directory(log_dir)
-                .basename("daemon")
-                .suffix("log"),
-        )
-        .duplicate_to_stderr(duplicate)
-        .rotate(
-            Criterion::Size(MAX_LOG_FILE_SIZE_BYTES),
-            Naming::Numbers,
-            Cleanup::KeepLogFiles(MAX_LOG_FILES),
-        )
-        .start()?;
-
-    install_panic_hook();
-
-    Ok(())
-}
-
-fn install_panic_hook() {
-    PANIC_HOOK_INIT.call_once(|| {
-        std::panic::set_hook(Box::new(|panic_info| {
-            let location = panic_info
-                .location()
-                .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
-                .unwrap_or_else(|| "unknown location".to_string());
-
-            let payload = panic_info
-                .payload()
-                .downcast_ref::<&str>()
-                .map(|s| (*s).to_string())
-                .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
-                .unwrap_or_else(|| "non-string panic payload".to_string());
-
-            log::error!("panic at {}: {}", location, payload);
-            eprintln!("panic at {}: {}", location, payload);
-        }));
-    });
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
This pull request introduces a new logging system to the Fungi project, replacing direct use of `println!` and `eprintln!` with structured logging via the `log` crate and supporting backends (`env_logger` and `flexi_logger`). Logging is now initialized early in the application lifecycle, with special handling for daemon mode (rotating log files, panic hooks). Additionally, the configuration initialization functions are refactored to support daemon-specific logging and messaging. These changes improve observability, error reporting, and maintainability.

**Logging system overhaul:**

* Added a new `logging.rs` module that initializes logging using `env_logger` for CLI and `flexi_logger` for daemon mode, with support for rotating log files and panic hooks. (`fungi/src/logging.rs`)
* Integrated logging initialization into the main entry point, removing redundant calls to `env_logger::init` and ensuring logging is set up before any other operations. (`fungi/src/main.rs`) [[1]](diffhunk://#diff-78643e27344087d22ca2b4baccf69d226668ff568faa7f6d8ed161ed3da401e8R4-R8) [[2]](diffhunk://#diff-78643e27344087d22ca2b4baccf69d226668ff568faa7f6d8ed161ed3da401e8L49-L50)

**Daemon and CLI output refactor:**

* Replaced all direct `println!` and `eprintln!` calls in daemon startup and shutdown routines with appropriate `log::info!` and `log::error!` calls for consistent log handling. (`fungi/src/commands/fungi_daemon.rs`) [[1]](diffhunk://#diff-f1f1f50952669cd749a0b9331ce6a9d426615bdc93d34448cc706a8d72ceff14L7-R20) [[2]](diffhunk://#diff-f1f1f50952669cd749a0b9331ce6a9d426615bdc93d34448cc706a8d72ceff14L33-R37) [[3]](diffhunk://#diff-f1f1f50952669cd749a0b9331ce6a9d426615bdc93d34448cc706a8d72ceff14L47-R47) [[4]](diffhunk://#diff-f1f1f50952669cd749a0b9331ce6a9d426615bdc93d34448cc706a8d72ceff14L63-R71)

**Configuration initialization improvements:**

* Refactored config initialization to split into `init` (CLI) and `init_for_daemon` (daemon), using logging for daemon mode and printing for CLI, improving clarity and separation of concerns. (`crates/config/src/init.rs`, `crates/config/src/lib.rs`) [[1]](diffhunk://#diff-bb57d8100cc8c5415cd1d85a519aadd5aa28ec70560e1d264e3c6793df8e3f77R5-R33) [[2]](diffhunk://#diff-bb57d8100cc8c5415cd1d85a519aadd5aa28ec70560e1d264e3c6793df8e3f77R45-R49) [[3]](diffhunk://#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cL8-R8)

**Dependency updates:**

* Added `log` and `flexi_logger` as dependencies in relevant Cargo.toml files to support the new logging system. (`fungi/Cargo.toml`, `crates/config/Cargo.toml`) [[1]](diffhunk://#diff-ca3338a3686c2ce62dab21fb7fb287c05ad2759886db0e8be55353674f0eef4cR16) [[2]](diffhunk://#diff-7bf93b054cfc84c93249918fd5c3f9692e773e532cf4ef6cb49e07ed5bc29e00R15)

**Minor cleanup:**

* Removed a redundant debug log statement from the ping event handler in the swarm library. (`crates/swarm/src/libp2p.rs`)