### PR TITLE
Add service recipe v1 daemon and CLI flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
+ "ulid",
 ]
 
 [[package]]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 log = { workspace = true }
 mdns-sd = { workspace = true }
 fungi-config-migrate = { workspace = true }
+ulid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/config/src/init.rs
+++ b/crates/config/src/init.rs
@@ -1,7 +1,7 @@
 use crate::{
     DEFAULT_CONFIG_FILE, FungiConfig, FungiDir, devices::DevicesConfig,
     direct_addresses::DirectAddressCache, local_access::LocalAccessConfig, paths::FungiPaths,
-    service_cache::ServiceCache, trusted_devices::TrustedDevicesConfig,
+    recipe_cache::RecipeCache, service_cache::ServiceCache, trusted_devices::TrustedDevicesConfig,
 };
 use anyhow::{Context, Result};
 
@@ -30,6 +30,7 @@ pub fn init(dirs: &impl FungiDir, upgrade_existing: bool) -> Result<()> {
             DirectAddressCache::apply_from_dir(&fungi_dir)?;
             LocalAccessConfig::apply_from_dir(&fungi_dir)?;
             ServiceCache::apply_from_dir(&fungi_dir)?;
+            RecipeCache::apply_from_dir(&fungi_dir)?;
             TrustedDevicesConfig::apply_from_dir(&fungi_dir)?;
             println!("Configuration file upgraded at {}", config_file.display());
             return Ok(());
@@ -50,10 +51,12 @@ pub fn init(dirs: &impl FungiDir, upgrade_existing: bool) -> Result<()> {
     // create devices.toml
     DevicesConfig::apply_from_dir(&fungi_dir)?;
 
-    // create cache/direct_addresses.json, access/local_access.json, and cache/remote_services/
+    // create cache/direct_addresses.json, access/local_access.json,
+    // cache/remote_services/, and cache/recipes/
     DirectAddressCache::apply_from_dir(&fungi_dir)?;
     LocalAccessConfig::apply_from_dir(&fungi_dir)?;
     ServiceCache::apply_from_dir(&fungi_dir)?;
+    RecipeCache::apply_from_dir(&fungi_dir)?;
     TrustedDevicesConfig::apply_from_dir(&fungi_dir)?;
 
     // create .keys

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,7 @@ mod init;
 mod libp2p;
 pub mod local_access;
 pub mod paths;
+pub mod recipe_cache;
 mod rpc;
 pub mod runtime;
 pub mod service_cache;

--- a/crates/config/src/recipe_cache.rs
+++ b/crates/config/src/recipe_cache.rs
@@ -69,13 +69,7 @@ impl RecipeCache {
         self.release_dir(release_version).join("index.json")
     }
 
-    pub fn manifest_asset_path(&self, release_version: &str, asset_name: &str) -> Result<PathBuf> {
-        Ok(self
-            .assets_dir(release_version)
-            .join(validate_asset_name(asset_name)?))
-    }
-
-    pub fn readme_asset_path(&self, release_version: &str, asset_name: &str) -> Result<PathBuf> {
+    pub fn asset_path(&self, release_version: &str, asset_name: &str) -> Result<PathBuf> {
         Ok(self
             .assets_dir(release_version)
             .join(validate_asset_name(asset_name)?))
@@ -93,7 +87,7 @@ impl RecipeCache {
         asset_name: &str,
         bytes: &[u8],
     ) -> Result<PathBuf> {
-        let path = self.manifest_asset_path(release_version, asset_name)?;
+        let path = self.asset_path(release_version, asset_name)?;
         self.write_bytes(&path, bytes)?;
         Ok(path)
     }

--- a/crates/config/src/recipe_cache.rs
+++ b/crates/config/src/recipe_cache.rs
@@ -1,9 +1,9 @@
 use std::{
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     time::SystemTime,
 };
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -42,8 +42,9 @@ impl RecipeCache {
         }
         let raw = std::fs::read_to_string(&path)
             .with_context(|| format!("failed to read recipe cache metadata: {}", path.display()))?;
-        let entry: CachedOfficialRelease = serde_json::from_str(&raw)
-            .with_context(|| format!("failed to parse recipe cache metadata: {}", path.display()))?;
+        let entry: CachedOfficialRelease = serde_json::from_str(&raw).with_context(|| {
+            format!("failed to parse recipe cache metadata: {}", path.display())
+        })?;
         Ok(Some(entry.release_version))
     }
 
@@ -68,12 +69,16 @@ impl RecipeCache {
         self.release_dir(release_version).join("index.json")
     }
 
-    pub fn manifest_asset_path(&self, release_version: &str, asset_name: &str) -> PathBuf {
-        self.assets_dir(release_version).join(asset_name)
+    pub fn manifest_asset_path(&self, release_version: &str, asset_name: &str) -> Result<PathBuf> {
+        Ok(self
+            .assets_dir(release_version)
+            .join(validate_asset_name(asset_name)?))
     }
 
-    pub fn readme_asset_path(&self, release_version: &str, asset_name: &str) -> PathBuf {
-        self.assets_dir(release_version).join(asset_name)
+    pub fn readme_asset_path(&self, release_version: &str, asset_name: &str) -> Result<PathBuf> {
+        Ok(self
+            .assets_dir(release_version)
+            .join(validate_asset_name(asset_name)?))
     }
 
     pub fn write_index(&self, release_version: &str, bytes: &[u8]) -> Result<PathBuf> {
@@ -88,7 +93,7 @@ impl RecipeCache {
         asset_name: &str,
         bytes: &[u8],
     ) -> Result<PathBuf> {
-        let path = self.assets_dir(release_version).join(asset_name);
+        let path = self.manifest_asset_path(release_version, asset_name)?;
         self.write_bytes(&path, bytes)?;
         Ok(path)
     }
@@ -114,7 +119,10 @@ impl RecipeCache {
     pub fn ensure_asset_dir(&self, release_version: &str) -> Result<PathBuf> {
         let dir = self.assets_dir(release_version);
         std::fs::create_dir_all(&dir).with_context(|| {
-            format!("failed to create recipe asset cache directory: {}", dir.display())
+            format!(
+                "failed to create recipe asset cache directory: {}",
+                dir.display()
+            )
         })?;
         Ok(dir)
     }
@@ -134,11 +142,29 @@ impl RecipeCache {
     fn write_bytes(&self, path: &Path, bytes: &[u8]) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create recipe cache directory: {}", parent.display())
+                format!(
+                    "failed to create recipe cache directory: {}",
+                    parent.display()
+                )
             })?;
         }
         std::fs::write(path, bytes)
             .with_context(|| format!("failed to write recipe cache file: {}", path.display()))
+    }
+}
+
+pub fn validate_asset_name(asset_name: &str) -> Result<&str> {
+    if asset_name.is_empty() {
+        bail!("recipe asset name cannot be empty");
+    }
+    if asset_name.contains('/') || asset_name.contains('\\') {
+        bail!("recipe asset name must be a single file name: `{asset_name}`");
+    }
+
+    let mut components = Path::new(asset_name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(asset_name),
+        _ => bail!("recipe asset name must be a single file name: `{asset_name}`"),
     }
 }
 
@@ -163,17 +189,47 @@ mod tests {
         let cache = RecipeCache::apply_from_dir(dir.path()).unwrap();
 
         cache.set_latest_release_version("v0.3.1").unwrap();
-        let index_path = cache.write_index("v0.3.1", br#"{"schemaVersion":1}"#).unwrap();
+        let index_path = cache
+            .write_index("v0.3.1", br#"{"schemaVersion":1}"#)
+            .unwrap();
         let manifest_path = cache
-            .write_asset("v0.3.1", "ssh-tunnel.manifest.yaml", b"apiVersion: fungi.rs/v1alpha1\n")
+            .write_asset(
+                "v0.3.1",
+                "ssh-tunnel.manifest.yaml",
+                b"apiVersion: fungi.rs/v1alpha1\n",
+            )
             .unwrap();
         let resolved_path = cache
-            .write_resolved_manifest("v0.3.1", "ssh-tunnel", "home-ssh-tunnel", "apiVersion: fungi.rs/v1alpha1\n")
+            .write_resolved_manifest(
+                "v0.3.1",
+                "ssh-tunnel",
+                "home-ssh-tunnel",
+                "apiVersion: fungi.rs/v1alpha1\n",
+            )
             .unwrap();
 
-        assert_eq!(cache.latest_release_version().unwrap().as_deref(), Some("v0.3.1"));
+        assert_eq!(
+            cache.latest_release_version().unwrap().as_deref(),
+            Some("v0.3.1")
+        );
         assert!(index_path.exists());
         assert!(manifest_path.exists());
         assert!(resolved_path.exists());
+    }
+
+    #[test]
+    fn rejects_asset_names_with_path_traversal() {
+        let dir = TempDir::new().unwrap();
+        let cache = RecipeCache::apply_from_dir(dir.path()).unwrap();
+
+        let error = cache
+            .write_asset("v0.3.1", "../escape.yaml", b"bad")
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("recipe asset name must be a single file name")
+        );
     }
 }

--- a/crates/config/src/recipe_cache.rs
+++ b/crates/config/src/recipe_cache.rs
@@ -1,0 +1,179 @@
+use std::{
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use anyhow::{Context as _, Result};
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+const RECIPE_CACHE_DIR: &str = "cache/recipes";
+const OFFICIAL_SOURCE_DIR: &str = "official";
+const LATEST_RELEASE_FILE: &str = "latest.json";
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct RecipeCache {
+    #[serde(skip)]
+    root_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CachedOfficialRelease {
+    pub release_version: String,
+    pub updated_at: SystemTime,
+}
+
+impl RecipeCache {
+    pub fn apply_from_dir(fungi_dir: &Path) -> Result<Self> {
+        let root_dir = fungi_dir.join(RECIPE_CACHE_DIR).join(OFFICIAL_SOURCE_DIR);
+        std::fs::create_dir_all(&root_dir).with_context(|| {
+            format!(
+                "failed to create recipe cache directory: {}",
+                root_dir.display()
+            )
+        })?;
+        Ok(Self { root_dir })
+    }
+
+    pub fn latest_release_version(&self) -> Result<Option<String>> {
+        let path = self.root_dir.join(LATEST_RELEASE_FILE);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read recipe cache metadata: {}", path.display()))?;
+        let entry: CachedOfficialRelease = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse recipe cache metadata: {}", path.display()))?;
+        Ok(Some(entry.release_version))
+    }
+
+    pub fn set_latest_release_version(&self, release_version: impl Into<String>) -> Result<()> {
+        std::fs::create_dir_all(&self.root_dir).with_context(|| {
+            format!(
+                "failed to create recipe cache directory: {}",
+                self.root_dir.display()
+            )
+        })?;
+        let entry = CachedOfficialRelease {
+            release_version: release_version.into(),
+            updated_at: SystemTime::now(),
+        };
+        let raw = serde_json::to_string_pretty(&entry)?;
+        let path = self.root_dir.join(LATEST_RELEASE_FILE);
+        std::fs::write(&path, raw)
+            .with_context(|| format!("failed to write recipe cache metadata: {}", path.display()))
+    }
+
+    pub fn index_path(&self, release_version: &str) -> PathBuf {
+        self.release_dir(release_version).join("index.json")
+    }
+
+    pub fn manifest_asset_path(&self, release_version: &str, asset_name: &str) -> PathBuf {
+        self.assets_dir(release_version).join(asset_name)
+    }
+
+    pub fn readme_asset_path(&self, release_version: &str, asset_name: &str) -> PathBuf {
+        self.assets_dir(release_version).join(asset_name)
+    }
+
+    pub fn write_index(&self, release_version: &str, bytes: &[u8]) -> Result<PathBuf> {
+        let path = self.index_path(release_version);
+        self.write_bytes(&path, bytes)?;
+        Ok(path)
+    }
+
+    pub fn write_asset(
+        &self,
+        release_version: &str,
+        asset_name: &str,
+        bytes: &[u8],
+    ) -> Result<PathBuf> {
+        let path = self.assets_dir(release_version).join(asset_name);
+        self.write_bytes(&path, bytes)?;
+        Ok(path)
+    }
+
+    pub fn write_resolved_manifest(
+        &self,
+        release_version: &str,
+        recipe_id: &str,
+        service_name: &str,
+        manifest_yaml: &str,
+    ) -> Result<PathBuf> {
+        let file_name = format!(
+            "{}-{}-{}.yaml",
+            sanitize_file_component(recipe_id),
+            sanitize_file_component(service_name),
+            Ulid::new()
+        );
+        let path = self.resolved_dir(release_version).join(file_name);
+        self.write_bytes(&path, manifest_yaml.as_bytes())?;
+        Ok(path)
+    }
+
+    pub fn ensure_asset_dir(&self, release_version: &str) -> Result<PathBuf> {
+        let dir = self.assets_dir(release_version);
+        std::fs::create_dir_all(&dir).with_context(|| {
+            format!("failed to create recipe asset cache directory: {}", dir.display())
+        })?;
+        Ok(dir)
+    }
+
+    fn release_dir(&self, release_version: &str) -> PathBuf {
+        self.root_dir.join(release_version)
+    }
+
+    fn assets_dir(&self, release_version: &str) -> PathBuf {
+        self.release_dir(release_version).join("assets")
+    }
+
+    fn resolved_dir(&self, release_version: &str) -> PathBuf {
+        self.release_dir(release_version).join("resolved")
+    }
+
+    fn write_bytes(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create recipe cache directory: {}", parent.display())
+            })?;
+        }
+        std::fs::write(path, bytes)
+            .with_context(|| format!("failed to write recipe cache file: {}", path.display()))
+    }
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => ch,
+            _ => '-',
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn stores_latest_release_metadata_and_assets() {
+        let dir = TempDir::new().unwrap();
+        let cache = RecipeCache::apply_from_dir(dir.path()).unwrap();
+
+        cache.set_latest_release_version("v0.3.1").unwrap();
+        let index_path = cache.write_index("v0.3.1", br#"{"schemaVersion":1}"#).unwrap();
+        let manifest_path = cache
+            .write_asset("v0.3.1", "ssh-tunnel.manifest.yaml", b"apiVersion: fungi.rs/v1alpha1\n")
+            .unwrap();
+        let resolved_path = cache
+            .write_resolved_manifest("v0.3.1", "ssh-tunnel", "home-ssh-tunnel", "apiVersion: fungi.rs/v1alpha1\n")
+            .unwrap();
+
+        assert_eq!(cache.latest_release_version().unwrap().as_deref(), Some("v0.3.1"));
+        assert!(index_path.exists());
+        assert!(manifest_path.exists());
+        assert!(resolved_path.exists());
+    }
+}

--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -621,13 +621,13 @@ message RecipeSummary {
 }
 
 message RecipeDetail {
-  RecipeSummary     summary              = 1;
-  repeated string   tags                 = 2;
-  string            homepage             = 3;
-  string            cached_manifest_path = 4;
-  string            cached_readme_path   = 5;
-  string            remote_manifest_url  = 6;
-  string            remote_readme_url    = 7;
+  RecipeSummary   summary              = 1;
+  repeated string tags                 = 2;
+  string          homepage             = 3;
+  string          cached_manifest_path = 4;
+  string          cached_readme_path   = 5;
+  string          remote_manifest_url  = 6;
+  string          remote_readme_url    = 7;
 }
 
 message ListRecipesRequest { bool refresh = 1; }
@@ -642,18 +642,18 @@ message GetRecipeRequest {
 message GetRecipeResponse { RecipeDetail detail = 1; }
 
 message ResolveRecipeRequest {
-  string recipe_id     = 1;
-  string service_name  = 2;
-  string peer_id       = 3;
-  bool   refresh       = 4;
+  string recipe_id    = 1;
+  string service_name = 2;
+  string peer_id      = 3;
+  bool   refresh      = 4;
 }
 
 message ResolveRecipeResponse {
-  RecipeDetail     detail                  = 1;
-  string           manifest_yaml           = 2;
-  string           manifest_base_dir       = 3;
-  string           resolved_manifest_path  = 4;
-  repeated string  warnings                = 5;
+  RecipeDetail    detail                 = 1;
+  string          manifest_yaml          = 2;
+  string          manifest_base_dir      = 3;
+  string          resolved_manifest_path = 4;
+  repeated string warnings               = 5;
 }
 
 message ListPeerCatalogRequest {

--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -178,6 +178,15 @@ service FungiDaemon {
   // Lists all pulled services on the local node, including stopped ones.
   rpc ListServices(Empty) returns (ListServicesResponse) {}
 
+  // Lists official service recipes known to the local daemon.
+  rpc ListRecipes(ListRecipesRequest) returns (ListRecipesResponse) {}
+
+  // Returns detailed metadata and audit paths for one official service recipe.
+  rpc GetRecipe(GetRecipeRequest) returns (GetRecipeResponse) {}
+
+  // Resolves one official recipe into a concrete manifest for local or remote pull.
+  rpc ResolveRecipe(ResolveRecipeRequest) returns (ResolveRecipeResponse) {}
+
     // Lists services published by a remote peer for consumption.
   rpc ListPeerCatalog(ListPeerCatalogRequest)
   returns (ListPeerCatalogResponse) {}
@@ -593,6 +602,59 @@ message ServiceLogsResponse {
 }
 
 message ListServicesResponse { string services_json = 1; }
+
+enum RecipeRuntimeKind {
+  RECIPE_RUNTIME_KIND_UNSPECIFIED = 0;
+  RECIPE_RUNTIME_KIND_DOCKER      = 1;
+  RECIPE_RUNTIME_KIND_WASMTIME    = 2;
+  RECIPE_RUNTIME_KIND_LINK        = 3;
+}
+
+message RecipeSummary {
+  string            id              = 1;
+  string            name            = 2;
+  string            description     = 3;
+  RecipeRuntimeKind runtime         = 4;
+  string            stability       = 5;
+  string            source_label    = 6;
+  string            release_version = 7;
+}
+
+message RecipeDetail {
+  RecipeSummary     summary              = 1;
+  repeated string   tags                 = 2;
+  string            homepage             = 3;
+  string            cached_manifest_path = 4;
+  string            cached_readme_path   = 5;
+  string            remote_manifest_url  = 6;
+  string            remote_readme_url    = 7;
+}
+
+message ListRecipesRequest { bool refresh = 1; }
+
+message ListRecipesResponse { repeated RecipeSummary recipes = 1; }
+
+message GetRecipeRequest {
+  string recipe_id = 1;
+  bool   refresh   = 2;
+}
+
+message GetRecipeResponse { RecipeDetail detail = 1; }
+
+message ResolveRecipeRequest {
+  string recipe_id     = 1;
+  string service_name  = 2;
+  string peer_id       = 3;
+  bool   refresh       = 4;
+}
+
+message ResolveRecipeResponse {
+  RecipeDetail     detail                  = 1;
+  string           manifest_yaml           = 2;
+  string           manifest_base_dir       = 3;
+  string           resolved_manifest_path  = 4;
+  repeated string  warnings                = 5;
+}
 
 message ListPeerCatalogRequest {
   string peer_id = 1;

--- a/crates/daemon-grpc/src/generated/fungi_daemon.rs
+++ b/crates/daemon-grpc/src/generated/fungi_daemon.rs
@@ -623,6 +623,86 @@ pub struct ListServicesResponse {
     pub services_json: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RecipeSummary {
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(enumeration = "RecipeRuntimeKind", tag = "4")]
+    pub runtime: i32,
+    #[prost(string, tag = "5")]
+    pub stability: ::prost::alloc::string::String,
+    #[prost(string, tag = "6")]
+    pub source_label: ::prost::alloc::string::String,
+    #[prost(string, tag = "7")]
+    pub release_version: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RecipeDetail {
+    #[prost(message, optional, tag = "1")]
+    pub summary: ::core::option::Option<RecipeSummary>,
+    #[prost(string, repeated, tag = "2")]
+    pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, tag = "3")]
+    pub homepage: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub cached_manifest_path: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub cached_readme_path: ::prost::alloc::string::String,
+    #[prost(string, tag = "6")]
+    pub remote_manifest_url: ::prost::alloc::string::String,
+    #[prost(string, tag = "7")]
+    pub remote_readme_url: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListRecipesRequest {
+    #[prost(bool, tag = "1")]
+    pub refresh: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListRecipesResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub recipes: ::prost::alloc::vec::Vec<RecipeSummary>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetRecipeRequest {
+    #[prost(string, tag = "1")]
+    pub recipe_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub refresh: bool,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetRecipeResponse {
+    #[prost(message, optional, tag = "1")]
+    pub detail: ::core::option::Option<RecipeDetail>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveRecipeRequest {
+    #[prost(string, tag = "1")]
+    pub recipe_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub service_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub peer_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "4")]
+    pub refresh: bool,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveRecipeResponse {
+    #[prost(message, optional, tag = "1")]
+    pub detail: ::core::option::Option<RecipeDetail>,
+    #[prost(string, tag = "2")]
+    pub manifest_yaml: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub manifest_base_dir: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub resolved_manifest_path: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag = "5")]
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ListPeerCatalogRequest {
     #[prost(string, tag = "1")]
     pub peer_id: ::prost::alloc::string::String,
@@ -726,6 +806,38 @@ impl ServiceRuntimeKind {
             "SERVICE_RUNTIME_KIND_UNSPECIFIED" => Some(Self::Unspecified),
             "SERVICE_RUNTIME_KIND_DOCKER" => Some(Self::Docker),
             "SERVICE_RUNTIME_KIND_WASMTIME" => Some(Self::Wasmtime),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RecipeRuntimeKind {
+    Unspecified = 0,
+    Docker = 1,
+    Wasmtime = 2,
+    Link = 3,
+}
+impl RecipeRuntimeKind {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "RECIPE_RUNTIME_KIND_UNSPECIFIED",
+            Self::Docker => "RECIPE_RUNTIME_KIND_DOCKER",
+            Self::Wasmtime => "RECIPE_RUNTIME_KIND_WASMTIME",
+            Self::Link => "RECIPE_RUNTIME_KIND_LINK",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "RECIPE_RUNTIME_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+            "RECIPE_RUNTIME_KIND_DOCKER" => Some(Self::Docker),
+            "RECIPE_RUNTIME_KIND_WASMTIME" => Some(Self::Wasmtime),
+            "RECIPE_RUNTIME_KIND_LINK" => Some(Self::Link),
             _ => None,
         }
     }
@@ -1769,6 +1881,55 @@ pub mod fungi_daemon_client {
                 .insert(GrpcMethod::new("fungi_daemon.FungiDaemon", "ListServices"));
             self.inner.unary(req, path, codec).await
         }
+        /// Lists official service recipes known to the local daemon.
+        pub async fn list_recipes(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListRecipesRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListRecipesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/fungi_daemon.FungiDaemon/ListRecipes");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("fungi_daemon.FungiDaemon", "ListRecipes"));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Returns detailed metadata and audit paths for one official service recipe.
+        pub async fn get_recipe(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetRecipeRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetRecipeResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/fungi_daemon.FungiDaemon/GetRecipe");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("fungi_daemon.FungiDaemon", "GetRecipe"));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Resolves one official recipe into a concrete manifest for local or remote pull.
+        pub async fn resolve_recipe(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ResolveRecipeRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResolveRecipeResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/fungi_daemon.FungiDaemon/ResolveRecipe");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("fungi_daemon.FungiDaemon", "ResolveRecipe"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Lists services published by a remote peer for consumption.
         pub async fn list_peer_catalog(
             &mut self,
@@ -2260,6 +2421,21 @@ pub mod fungi_daemon_server {
             &self,
             request: tonic::Request<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::ListServicesResponse>, tonic::Status>;
+        /// Lists official service recipes known to the local daemon.
+        async fn list_recipes(
+            &self,
+            request: tonic::Request<super::ListRecipesRequest>,
+        ) -> std::result::Result<tonic::Response<super::ListRecipesResponse>, tonic::Status>;
+        /// Returns detailed metadata and audit paths for one official service recipe.
+        async fn get_recipe(
+            &self,
+            request: tonic::Request<super::GetRecipeRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetRecipeResponse>, tonic::Status>;
+        /// Resolves one official recipe into a concrete manifest for local or remote pull.
+        async fn resolve_recipe(
+            &self,
+            request: tonic::Request<super::ResolveRecipeRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResolveRecipeResponse>, tonic::Status>;
         /// Lists services published by a remote peer for consumption.
         async fn list_peer_catalog(
             &self,
@@ -4392,6 +4568,125 @@ pub mod fungi_daemon_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ListServicesSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/fungi_daemon.FungiDaemon/ListRecipes" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListRecipesSvc<T: FungiDaemon>(pub Arc<T>);
+                    impl<T: FungiDaemon> tonic::server::UnaryService<super::ListRecipesRequest> for ListRecipesSvc<T> {
+                        type Response = super::ListRecipesResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ListRecipesRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FungiDaemon>::list_recipes(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ListRecipesSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/fungi_daemon.FungiDaemon/GetRecipe" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetRecipeSvc<T: FungiDaemon>(pub Arc<T>);
+                    impl<T: FungiDaemon> tonic::server::UnaryService<super::GetRecipeRequest> for GetRecipeSvc<T> {
+                        type Response = super::GetRecipeResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetRecipeRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FungiDaemon>::get_recipe(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetRecipeSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/fungi_daemon.FungiDaemon/ResolveRecipe" => {
+                    #[allow(non_camel_case_types)]
+                    struct ResolveRecipeSvc<T: FungiDaemon>(pub Arc<T>);
+                    impl<T: FungiDaemon> tonic::server::UnaryService<super::ResolveRecipeRequest>
+                        for ResolveRecipeSvc<T>
+                    {
+                        type Response = super::ResolveRecipeResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ResolveRecipeRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FungiDaemon>::resolve_recipe(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ResolveRecipeSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -67,6 +67,41 @@ fn proto_runtime_kind(kind: i32) -> Result<Option<fungi_daemon::RuntimeKind>, St
     }
 }
 
+fn proto_recipe_runtime_kind(kind: fungi_daemon::ServiceRecipeRuntime) -> i32 {
+    match kind {
+        fungi_daemon::ServiceRecipeRuntime::Docker => RecipeRuntimeKind::Docker as i32,
+        fungi_daemon::ServiceRecipeRuntime::Wasmtime => RecipeRuntimeKind::Wasmtime as i32,
+        fungi_daemon::ServiceRecipeRuntime::Link => RecipeRuntimeKind::Link as i32,
+    }
+}
+
+fn proto_recipe_summary(summary: fungi_daemon::ServiceRecipeSummary) -> RecipeSummary {
+    RecipeSummary {
+        id: summary.id,
+        name: summary.name,
+        description: summary.description,
+        runtime: proto_recipe_runtime_kind(summary.runtime),
+        stability: summary.stability,
+        source_label: summary.source_label,
+        release_version: summary.release_version,
+    }
+}
+
+fn proto_recipe_detail(detail: fungi_daemon::ServiceRecipeDetail) -> RecipeDetail {
+    RecipeDetail {
+        summary: Some(proto_recipe_summary(detail.summary)),
+        tags: detail.tags,
+        homepage: detail.homepage.unwrap_or_default(),
+        cached_manifest_path: detail.cached_manifest_path.display().to_string(),
+        cached_readme_path: detail
+            .cached_readme_path
+            .map(|path| path.display().to_string())
+            .unwrap_or_default(),
+        remote_manifest_url: detail.remote_manifest_url,
+        remote_readme_url: detail.remote_readme_url.unwrap_or_default(),
+    }
+}
+
 impl PingPeerError {
     fn new(
         connection_id: impl Into<String>,
@@ -1224,6 +1259,68 @@ impl FungiDaemon for FungiDaemonRpcImpl {
         let services_json = serde_json::to_string(&services)
             .map_err(|e| Status::internal(format!("Failed to serialize services: {e}")))?;
         Ok(Response::new(ListServicesResponse { services_json }))
+    }
+
+    async fn list_recipes(
+        &self,
+        request: Request<ListRecipesRequest>,
+    ) -> Result<Response<ListRecipesResponse>, Status> {
+        let req = request.into_inner();
+        let recipes = self
+            .inner
+            .list_service_recipes(req.refresh)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list recipes: {e}")))?;
+        Ok(Response::new(ListRecipesResponse {
+            recipes: recipes.into_iter().map(proto_recipe_summary).collect(),
+        }))
+    }
+
+    async fn get_recipe(
+        &self,
+        request: Request<GetRecipeRequest>,
+    ) -> Result<Response<GetRecipeResponse>, Status> {
+        let req = request.into_inner();
+        let detail = self
+            .inner
+            .get_service_recipe(&req.recipe_id, req.refresh)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get recipe: {e}")))?;
+        Ok(Response::new(GetRecipeResponse {
+            detail: Some(proto_recipe_detail(detail)),
+        }))
+    }
+
+    async fn resolve_recipe(
+        &self,
+        request: Request<ResolveRecipeRequest>,
+    ) -> Result<Response<ResolveRecipeResponse>, Status> {
+        let req = request.into_inner();
+        let peer_id = if req.peer_id.trim().is_empty() {
+            None
+        } else {
+            Some(
+                PeerId::from_str(&req.peer_id)
+                    .map_err(|e| Status::invalid_argument(format!("Invalid peer_id: {}", e)))?,
+            )
+        };
+        let service_name = if req.service_name.trim().is_empty() {
+            None
+        } else {
+            Some(req.service_name.as_str())
+        };
+        let resolved = self
+            .inner
+            .resolve_service_recipe(&req.recipe_id, service_name, peer_id, req.refresh)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to resolve recipe: {e}")))?;
+        Ok(Response::new(ResolveRecipeResponse {
+            detail: Some(proto_recipe_detail(resolved.detail)),
+            manifest_yaml: resolved.manifest_yaml,
+            manifest_base_dir: resolved.manifest_base_dir.display().to_string(),
+            resolved_manifest_path: resolved.resolved_manifest_path.display().to_string(),
+            warnings: resolved.warnings,
+        }))
     }
 
     async fn list_peer_catalog(

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -248,9 +248,13 @@ impl FungiDaemon {
         refresh: bool,
     ) -> Result<ResolvedServiceRecipe> {
         let fungi_dir = self.config_fungi_dir()?;
-        let mut resolved =
-            crate::recipes::resolve_official_service_recipe(&fungi_dir, recipe_id, service_name, refresh)
-                .await?;
+        let mut resolved = crate::recipes::resolve_official_service_recipe(
+            &fungi_dir,
+            recipe_id,
+            service_name,
+            refresh,
+        )
+        .await?;
         resolved.warnings = self
             .build_service_recipe_runtime_warnings(resolved.detail.summary.runtime, target_peer_id)
             .await;
@@ -308,9 +312,10 @@ impl FungiDaemon {
         target_peer_id: Option<PeerId>,
     ) -> Vec<String> {
         match target_peer_id {
-            Some(peer_id) => self
-                .build_remote_recipe_runtime_warnings(runtime, peer_id)
-                .await,
+            Some(peer_id) => {
+                self.build_remote_recipe_runtime_warnings(runtime, peer_id)
+                    .await
+            }
             None => self.build_local_recipe_runtime_warnings(runtime),
         }
     }
@@ -345,16 +350,20 @@ impl FungiDaemon {
             Err(error) => {
                 return vec![format!(
                     "Could not verify runtime compatibility for target device {label}: {error}"
-                )]
+                )];
             }
         };
 
         match runtime {
             ServiceRecipeRuntime::Docker if !capabilities.runtimes.docker => {
-                vec![format!("Target device {label} does not report Docker runtime support")]
+                vec![format!(
+                    "Target device {label} does not report Docker runtime support"
+                )]
             }
             ServiceRecipeRuntime::Wasmtime if !capabilities.runtimes.wasmtime => {
-                vec![format!("Target device {label} does not report Wasmtime runtime support")]
+                vec![format!(
+                    "Target device {label} does not report Wasmtime runtime support"
+                )]
             }
             _ => Vec::new(),
         }
@@ -439,10 +448,16 @@ fn runtime_status_warning(
         return Vec::new();
     }
     if !config_enabled {
-        return vec![format!("{runtime_name} runtime is disabled in local config")];
+        return vec![format!(
+            "{runtime_name} runtime is disabled in local config"
+        )];
     }
     if !detected {
-        return vec![format!("{runtime_name} runtime does not appear to be available locally")];
+        return vec![format!(
+            "{runtime_name} runtime does not appear to be available locally"
+        )];
     }
-    vec![format!("{runtime_name} runtime is configured but not active locally")]
+    vec![format!(
+        "{runtime_name} runtime is configured but not active locally"
+    )]
 }

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -10,7 +10,8 @@ use crate::runtime::{
 };
 use crate::{
     FungiDaemon, LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities,
-    ServiceControlResponse, build_local_node_capabilities, build_local_runtime_status,
+    ResolvedServiceRecipe, ServiceControlResponse, ServiceRecipeDetail, ServiceRecipeRuntime,
+    ServiceRecipeSummary, build_local_node_capabilities, build_local_runtime_status,
 };
 
 impl FungiDaemon {
@@ -225,6 +226,37 @@ impl FungiDaemon {
         self.refresh_peer_services(peer_id).await
     }
 
+    pub async fn list_service_recipes(&self, refresh: bool) -> Result<Vec<ServiceRecipeSummary>> {
+        let fungi_dir = self.config_fungi_dir()?;
+        crate::recipes::list_official_service_recipes(&fungi_dir, refresh).await
+    }
+
+    pub async fn get_service_recipe(
+        &self,
+        recipe_id: &str,
+        refresh: bool,
+    ) -> Result<ServiceRecipeDetail> {
+        let fungi_dir = self.config_fungi_dir()?;
+        crate::recipes::get_official_service_recipe(&fungi_dir, recipe_id, refresh).await
+    }
+
+    pub async fn resolve_service_recipe(
+        &self,
+        recipe_id: &str,
+        service_name: Option<&str>,
+        target_peer_id: Option<PeerId>,
+        refresh: bool,
+    ) -> Result<ResolvedServiceRecipe> {
+        let fungi_dir = self.config_fungi_dir()?;
+        let mut resolved =
+            crate::recipes::resolve_official_service_recipe(&fungi_dir, recipe_id, service_name, refresh)
+                .await?;
+        resolved.warnings = self
+            .build_service_recipe_runtime_warnings(resolved.detail.summary.runtime, target_peer_id)
+            .await;
+        Ok(resolved)
+    }
+
     pub fn list_cached_peer_services(&self, peer_id: PeerId) -> Result<Vec<CatalogService>> {
         let peer_id = peer_id.to_string();
         let fungi_dir = self.config_fungi_dir()?;
@@ -268,6 +300,64 @@ impl FungiDaemon {
         self.node_capabilities_control()
             .discover_peer_capabilities(peer_id)
             .await
+    }
+
+    async fn build_service_recipe_runtime_warnings(
+        &self,
+        runtime: ServiceRecipeRuntime,
+        target_peer_id: Option<PeerId>,
+    ) -> Vec<String> {
+        match target_peer_id {
+            Some(peer_id) => self
+                .build_remote_recipe_runtime_warnings(runtime, peer_id)
+                .await,
+            None => self.build_local_recipe_runtime_warnings(runtime),
+        }
+    }
+
+    fn build_local_recipe_runtime_warnings(&self, runtime: ServiceRecipeRuntime) -> Vec<String> {
+        let status = self.local_runtime_status();
+        match runtime {
+            ServiceRecipeRuntime::Docker => runtime_status_warning(
+                "Docker",
+                status.docker.config_enabled,
+                status.docker.detected,
+                status.docker.active,
+            ),
+            ServiceRecipeRuntime::Wasmtime => runtime_status_warning(
+                "Wasmtime",
+                status.wasmtime.config_enabled,
+                status.wasmtime.detected,
+                status.wasmtime.active,
+            ),
+            ServiceRecipeRuntime::Link => Vec::new(),
+        }
+    }
+
+    async fn build_remote_recipe_runtime_warnings(
+        &self,
+        runtime: ServiceRecipeRuntime,
+        peer_id: PeerId,
+    ) -> Vec<String> {
+        let label = peer_id.to_string();
+        let capabilities = match self.get_peer_capability_summary(peer_id).await {
+            Ok(capabilities) => capabilities,
+            Err(error) => {
+                return vec![format!(
+                    "Could not verify runtime compatibility for target device {label}: {error}"
+                )]
+            }
+        };
+
+        match runtime {
+            ServiceRecipeRuntime::Docker if !capabilities.runtimes.docker => {
+                vec![format!("Target device {label} does not report Docker runtime support")]
+            }
+            ServiceRecipeRuntime::Wasmtime if !capabilities.runtimes.wasmtime => {
+                vec![format!("Target device {label} does not report Wasmtime runtime support")]
+            }
+            _ => Vec::new(),
+        }
     }
 
     pub async fn remote_pull_service(
@@ -337,4 +427,22 @@ impl FungiDaemon {
         }
         Ok(response)
     }
+}
+
+fn runtime_status_warning(
+    runtime_name: &str,
+    config_enabled: bool,
+    detected: bool,
+    active: bool,
+) -> Vec<String> {
+    if active {
+        return Vec::new();
+    }
+    if !config_enabled {
+        return vec![format!("{runtime_name} runtime is disabled in local config")];
+    }
+    if !detected {
+        return vec![format!("{runtime_name} runtime does not appear to be available locally")];
+    }
+    vec![format!("{runtime_name} runtime is configured but not active locally")]
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 mod controls;
 mod daemon;
 mod node_capabilities;
+mod recipes;
 pub mod runtime;
 mod service_control;
 mod service_state;
@@ -18,6 +19,9 @@ pub use daemon::FungiDaemon;
 pub use node_capabilities::{
     LocalRuntimeAvailability, LocalRuntimeStatus, NodeCapabilities, NodeRuntimeCapabilities,
     build_local_node_capabilities, build_local_runtime_status,
+};
+pub use recipes::{
+    ResolvedServiceRecipe, ServiceRecipeDetail, ServiceRecipeRuntime, ServiceRecipeSummary,
 };
 pub use runtime::{
     CatalogService, CatalogServiceEndpoint, ManifestResolutionPolicy, RuntimeControl, RuntimeKind,

--- a/crates/daemon/src/recipes.rs
+++ b/crates/daemon/src/recipes.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use crate::ServiceManifestDocument;
 
 const OFFICIAL_RECIPE_SOURCE_LABEL: &str = "enbop/fungi-service-recipes";
-const OFFICIAL_RECIPE_LATEST_INDEX_URL: &str =
-    "https://github.com/enbop/fungi-service-recipes/releases/latest/download/index.json";
+const OFFICIAL_RECIPE_LATEST_RELEASE_URL: &str =
+    "https://github.com/enbop/fungi-service-recipes/releases/latest";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceRecipeRuntime {
@@ -227,13 +227,18 @@ async fn load_official_recipe_index(
 }
 
 async fn refresh_latest_official_recipe_index(cache: &RecipeCache) -> Result<String> {
-    let response = reqwest::get(OFFICIAL_RECIPE_LATEST_INDEX_URL)
+    let latest_release_response = reqwest::get(OFFICIAL_RECIPE_LATEST_RELEASE_URL)
+        .await
+        .context("failed to resolve latest official recipe release")?
+        .error_for_status()
+        .context("latest official recipe release request failed")?;
+    let release_version = release_version_from_release_page_url(latest_release_response.url())?;
+
+    let response = reqwest::get(release_asset_url(&release_version, "index.json"))
         .await
         .context("failed to fetch official recipe index")?
         .error_for_status()
         .context("official recipe index request failed")?;
-    let final_url = response.url().clone();
-    let release_version = release_version_from_url(&final_url)?;
     let bytes = response
         .bytes()
         .await
@@ -271,15 +276,15 @@ fn release_asset_url(release_version: &str, asset_name: &str) -> String {
     )
 }
 
-fn release_version_from_url(url: &reqwest::Url) -> Result<String> {
+fn release_version_from_release_page_url(url: &reqwest::Url) -> Result<String> {
     let segments = url
         .path_segments()
         .map(|segments| segments.collect::<Vec<_>>())
         .unwrap_or_default();
-    let Some(download_index) = segments.iter().position(|segment| *segment == "download") else {
+    let Some(tag_index) = segments.iter().position(|segment| *segment == "tag") else {
         bail!("failed to determine recipe release version from {}", url);
     };
-    let Some(release_version) = segments.get(download_index + 1) else {
+    let Some(release_version) = segments.get(tag_index + 1) else {
         bail!("failed to determine recipe release version from {}", url);
     };
     Ok((*release_version).to_string())
@@ -308,17 +313,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_release_version_from_redirect_url() {
-        let url = reqwest::Url::parse(
-            "https://github.com/enbop/fungi-service-recipes/releases/download/v0.3.1/index.json",
-        )
-        .unwrap();
-
-        assert_eq!(release_version_from_url(&url).unwrap(), "v0.3.1");
+    fn maps_tcp_recipe_runtime_to_link() {
+        assert_eq!(parse_recipe_runtime("tcp").unwrap(), ServiceRecipeRuntime::Link);
     }
 
     #[test]
-    fn maps_tcp_recipe_runtime_to_link() {
-        assert_eq!(parse_recipe_runtime("tcp").unwrap(), ServiceRecipeRuntime::Link);
+    fn parses_release_version_from_release_page_url() {
+        let url = reqwest::Url::parse(
+            "https://github.com/enbop/fungi-service-recipes/releases/tag/v0.3.1",
+        )
+        .unwrap();
+
+        assert_eq!(release_version_from_release_page_url(&url).unwrap(), "v0.3.1");
     }
 }

--- a/crates/daemon/src/recipes.rs
+++ b/crates/daemon/src/recipes.rs
@@ -263,7 +263,7 @@ async fn ensure_cached_asset(
     release_version: &str,
     asset_name: &str,
 ) -> Result<PathBuf> {
-    let path = cache.manifest_asset_path(release_version, asset_name)?;
+    let path = cache.asset_path(release_version, asset_name)?;
     if path.exists()
         && path
             .metadata()

--- a/crates/daemon/src/recipes.rs
+++ b/crates/daemon/src/recipes.rs
@@ -1,0 +1,324 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result, bail};
+use fungi_config::recipe_cache::RecipeCache;
+use serde::Deserialize;
+
+use crate::ServiceManifestDocument;
+
+const OFFICIAL_RECIPE_SOURCE_LABEL: &str = "enbop/fungi-service-recipes";
+const OFFICIAL_RECIPE_LATEST_INDEX_URL: &str =
+    "https://github.com/enbop/fungi-service-recipes/releases/latest/download/index.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceRecipeRuntime {
+    Docker,
+    Wasmtime,
+    Link,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceRecipeSummary {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub runtime: ServiceRecipeRuntime,
+    pub stability: String,
+    pub source_label: String,
+    pub release_version: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceRecipeDetail {
+    pub summary: ServiceRecipeSummary,
+    pub tags: Vec<String>,
+    pub homepage: Option<String>,
+    pub cached_manifest_path: PathBuf,
+    pub cached_readme_path: Option<PathBuf>,
+    pub remote_manifest_url: String,
+    pub remote_readme_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedServiceRecipe {
+    pub detail: ServiceRecipeDetail,
+    pub manifest_yaml: String,
+    pub manifest_base_dir: PathBuf,
+    pub resolved_manifest_path: PathBuf,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OfficialRecipeIndex {
+    recipes: Vec<OfficialRecipeRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OfficialRecipeRecord {
+    id: String,
+    name: String,
+    description: String,
+    runtime: String,
+    manifest_asset: String,
+    readme_asset: Option<String>,
+    homepage: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    stability: String,
+}
+
+struct LoadedOfficialRecipeIndex {
+    release_version: String,
+    index: OfficialRecipeIndex,
+    cache: RecipeCache,
+}
+
+pub async fn list_official_service_recipes(
+    fungi_dir: &Path,
+    refresh: bool,
+) -> Result<Vec<ServiceRecipeSummary>> {
+    let loaded = load_official_recipe_index(fungi_dir, refresh).await?;
+    loaded
+        .index
+        .recipes
+        .iter()
+        .map(|recipe| build_recipe_summary(recipe, &loaded.release_version))
+        .collect()
+}
+
+pub async fn get_official_service_recipe(
+    fungi_dir: &Path,
+    recipe_id: &str,
+    refresh: bool,
+) -> Result<ServiceRecipeDetail> {
+    let loaded = load_official_recipe_index(fungi_dir, refresh).await?;
+    let recipe = loaded.find_recipe(recipe_id)?;
+    build_recipe_detail(&loaded, recipe).await
+}
+
+pub async fn resolve_official_service_recipe(
+    fungi_dir: &Path,
+    recipe_id: &str,
+    service_name: Option<&str>,
+    refresh: bool,
+) -> Result<ResolvedServiceRecipe> {
+    let loaded = load_official_recipe_index(fungi_dir, refresh).await?;
+    let recipe = loaded.find_recipe(recipe_id)?;
+    let detail = build_recipe_detail(&loaded, recipe).await?;
+    let manifest_yaml = std::fs::read_to_string(&detail.cached_manifest_path).with_context(|| {
+        format!(
+            "failed to read cached recipe manifest: {}",
+            detail.cached_manifest_path.display()
+        )
+    })?;
+    let mut manifest_doc: ServiceManifestDocument = serde_yaml::from_str(&manifest_yaml)
+        .with_context(|| {
+            format!(
+                "failed to parse recipe manifest: {}",
+                detail.cached_manifest_path.display()
+            )
+        })?;
+    manifest_doc.metadata.name = resolved_service_name(recipe, service_name);
+    let resolved_manifest_yaml = serde_yaml::to_string(&manifest_doc)
+        .context("failed to serialize resolved recipe manifest")?;
+
+    let resolved_manifest_path = loaded.cache.write_resolved_manifest(
+        &loaded.release_version,
+        &recipe.id,
+        &manifest_doc.metadata.name,
+        &resolved_manifest_yaml,
+    )?;
+    let manifest_base_dir = loaded.cache.ensure_asset_dir(&loaded.release_version)?;
+
+    Ok(ResolvedServiceRecipe {
+        detail,
+        manifest_yaml: resolved_manifest_yaml,
+        manifest_base_dir,
+        resolved_manifest_path,
+        warnings: Vec::new(),
+    })
+}
+
+impl LoadedOfficialRecipeIndex {
+    fn find_recipe(&self, recipe_id: &str) -> Result<&OfficialRecipeRecord> {
+        self.index
+            .recipes
+            .iter()
+            .find(|recipe| recipe.id == recipe_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown recipe `{recipe_id}`"))
+    }
+}
+
+fn build_recipe_summary(
+    recipe: &OfficialRecipeRecord,
+    release_version: &str,
+) -> Result<ServiceRecipeSummary> {
+    Ok(ServiceRecipeSummary {
+        id: recipe.id.clone(),
+        name: recipe.name.clone(),
+        description: recipe.description.clone(),
+        runtime: parse_recipe_runtime(&recipe.runtime)?,
+        stability: recipe.stability.clone(),
+        source_label: OFFICIAL_RECIPE_SOURCE_LABEL.to_string(),
+        release_version: release_version.to_string(),
+    })
+}
+
+async fn build_recipe_detail(
+    loaded: &LoadedOfficialRecipeIndex,
+    recipe: &OfficialRecipeRecord,
+) -> Result<ServiceRecipeDetail> {
+    let summary = build_recipe_summary(recipe, &loaded.release_version)?;
+    let cached_manifest_path = ensure_cached_asset(
+        &loaded.cache,
+        &loaded.release_version,
+        &recipe.manifest_asset,
+    )
+    .await?;
+    let cached_readme_path = match &recipe.readme_asset {
+        Some(readme_asset) => Some(
+            ensure_cached_asset(&loaded.cache, &loaded.release_version, readme_asset).await?,
+        ),
+        None => None,
+    };
+
+    Ok(ServiceRecipeDetail {
+        summary,
+        tags: recipe.tags.clone(),
+        homepage: recipe.homepage.clone(),
+        cached_manifest_path,
+        cached_readme_path,
+        remote_manifest_url: release_asset_url(&loaded.release_version, &recipe.manifest_asset),
+        remote_readme_url: recipe
+            .readme_asset
+            .as_ref()
+            .map(|asset| release_asset_url(&loaded.release_version, asset)),
+    })
+}
+
+async fn load_official_recipe_index(
+    fungi_dir: &Path,
+    refresh: bool,
+) -> Result<LoadedOfficialRecipeIndex> {
+    let cache = RecipeCache::apply_from_dir(fungi_dir)?;
+    let release_version = if refresh {
+        None
+    } else {
+        cache.latest_release_version()?
+    };
+
+    let release_version = match release_version {
+        Some(release_version) if cache.index_path(&release_version).exists() => release_version,
+        _ => refresh_latest_official_recipe_index(&cache).await?,
+    };
+    let index_path = cache.index_path(&release_version);
+    let raw = std::fs::read_to_string(&index_path)
+        .with_context(|| format!("failed to read cached recipe index: {}", index_path.display()))?;
+    let index: OfficialRecipeIndex = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse cached recipe index: {}", index_path.display()))?;
+
+    Ok(LoadedOfficialRecipeIndex {
+        release_version,
+        index,
+        cache,
+    })
+}
+
+async fn refresh_latest_official_recipe_index(cache: &RecipeCache) -> Result<String> {
+    let response = reqwest::get(OFFICIAL_RECIPE_LATEST_INDEX_URL)
+        .await
+        .context("failed to fetch official recipe index")?
+        .error_for_status()
+        .context("official recipe index request failed")?;
+    let final_url = response.url().clone();
+    let release_version = release_version_from_url(&final_url)?;
+    let bytes = response
+        .bytes()
+        .await
+        .context("failed to read official recipe index response body")?;
+    cache.write_index(&release_version, bytes.as_ref())?;
+    cache.set_latest_release_version(release_version.clone())?;
+    Ok(release_version)
+}
+
+async fn ensure_cached_asset(
+    cache: &RecipeCache,
+    release_version: &str,
+    asset_name: &str,
+) -> Result<PathBuf> {
+    let path = cache.manifest_asset_path(release_version, asset_name);
+    if path.exists() && path.metadata().map(|metadata| metadata.len() > 0).unwrap_or(false) {
+        return Ok(path);
+    }
+
+    let response = reqwest::get(release_asset_url(release_version, asset_name))
+        .await
+        .with_context(|| format!("failed to fetch recipe asset `{asset_name}`"))?
+        .error_for_status()
+        .with_context(|| format!("recipe asset request failed for `{asset_name}`"))?;
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read recipe asset `{asset_name}`"))?;
+    cache.write_asset(release_version, asset_name, bytes.as_ref())
+}
+
+fn release_asset_url(release_version: &str, asset_name: &str) -> String {
+    format!(
+        "https://github.com/{OFFICIAL_RECIPE_SOURCE_LABEL}/releases/download/{release_version}/{asset_name}"
+    )
+}
+
+fn release_version_from_url(url: &reqwest::Url) -> Result<String> {
+    let segments = url
+        .path_segments()
+        .map(|segments| segments.collect::<Vec<_>>())
+        .unwrap_or_default();
+    let Some(download_index) = segments.iter().position(|segment| *segment == "download") else {
+        bail!("failed to determine recipe release version from {}", url);
+    };
+    let Some(release_version) = segments.get(download_index + 1) else {
+        bail!("failed to determine recipe release version from {}", url);
+    };
+    Ok((*release_version).to_string())
+}
+
+fn parse_recipe_runtime(value: &str) -> Result<ServiceRecipeRuntime> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "docker" => Ok(ServiceRecipeRuntime::Docker),
+        "wasmtime" => Ok(ServiceRecipeRuntime::Wasmtime),
+        "tcp" | "link" => Ok(ServiceRecipeRuntime::Link),
+        other => bail!("unsupported recipe runtime `{other}`"),
+    }
+}
+
+fn resolved_service_name(recipe: &OfficialRecipeRecord, service_name: Option<&str>) -> String {
+    let value = service_name.unwrap_or_default().trim();
+    if value.is_empty() {
+        recipe.id.clone()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_release_version_from_redirect_url() {
+        let url = reqwest::Url::parse(
+            "https://github.com/enbop/fungi-service-recipes/releases/download/v0.3.1/index.json",
+        )
+        .unwrap();
+
+        assert_eq!(release_version_from_url(&url).unwrap(), "v0.3.1");
+    }
+
+    #[test]
+    fn maps_tcp_recipe_runtime_to_link() {
+        assert_eq!(parse_recipe_runtime("tcp").unwrap(), ServiceRecipeRuntime::Link);
+    }
+}

--- a/crates/daemon/src/recipes.rs
+++ b/crates/daemon/src/recipes.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail};
-use fungi_config::recipe_cache::RecipeCache;
+use fungi_config::recipe_cache::{RecipeCache, validate_asset_name};
 use serde::Deserialize;
 
 use crate::ServiceManifestDocument;
@@ -107,12 +107,13 @@ pub async fn resolve_official_service_recipe(
     let loaded = load_official_recipe_index(fungi_dir, refresh).await?;
     let recipe = loaded.find_recipe(recipe_id)?;
     let detail = build_recipe_detail(&loaded, recipe).await?;
-    let manifest_yaml = std::fs::read_to_string(&detail.cached_manifest_path).with_context(|| {
-        format!(
-            "failed to read cached recipe manifest: {}",
-            detail.cached_manifest_path.display()
-        )
-    })?;
+    let manifest_yaml =
+        std::fs::read_to_string(&detail.cached_manifest_path).with_context(|| {
+            format!(
+                "failed to read cached recipe manifest: {}",
+                detail.cached_manifest_path.display()
+            )
+        })?;
     let mut manifest_doc: ServiceManifestDocument = serde_yaml::from_str(&manifest_yaml)
         .with_context(|| {
             format!(
@@ -178,9 +179,9 @@ async fn build_recipe_detail(
     )
     .await?;
     let cached_readme_path = match &recipe.readme_asset {
-        Some(readme_asset) => Some(
-            ensure_cached_asset(&loaded.cache, &loaded.release_version, readme_asset).await?,
-        ),
+        Some(readme_asset) => {
+            Some(ensure_cached_asset(&loaded.cache, &loaded.release_version, readme_asset).await?)
+        }
         None => None,
     };
 
@@ -190,11 +191,12 @@ async fn build_recipe_detail(
         homepage: recipe.homepage.clone(),
         cached_manifest_path,
         cached_readme_path,
-        remote_manifest_url: release_asset_url(&loaded.release_version, &recipe.manifest_asset),
+        remote_manifest_url: release_asset_url(&loaded.release_version, &recipe.manifest_asset)?,
         remote_readme_url: recipe
             .readme_asset
             .as_ref()
-            .map(|asset| release_asset_url(&loaded.release_version, asset)),
+            .map(|asset| release_asset_url(&loaded.release_version, asset))
+            .transpose()?,
     })
 }
 
@@ -214,10 +216,18 @@ async fn load_official_recipe_index(
         _ => refresh_latest_official_recipe_index(&cache).await?,
     };
     let index_path = cache.index_path(&release_version);
-    let raw = std::fs::read_to_string(&index_path)
-        .with_context(|| format!("failed to read cached recipe index: {}", index_path.display()))?;
-    let index: OfficialRecipeIndex = serde_json::from_str(&raw)
-        .with_context(|| format!("failed to parse cached recipe index: {}", index_path.display()))?;
+    let raw = std::fs::read_to_string(&index_path).with_context(|| {
+        format!(
+            "failed to read cached recipe index: {}",
+            index_path.display()
+        )
+    })?;
+    let index: OfficialRecipeIndex = serde_json::from_str(&raw).with_context(|| {
+        format!(
+            "failed to parse cached recipe index: {}",
+            index_path.display()
+        )
+    })?;
 
     Ok(LoadedOfficialRecipeIndex {
         release_version,
@@ -234,7 +244,7 @@ async fn refresh_latest_official_recipe_index(cache: &RecipeCache) -> Result<Str
         .context("latest official recipe release request failed")?;
     let release_version = release_version_from_release_page_url(latest_release_response.url())?;
 
-    let response = reqwest::get(release_asset_url(&release_version, "index.json"))
+    let response = reqwest::get(release_asset_url(&release_version, "index.json")?)
         .await
         .context("failed to fetch official recipe index")?
         .error_for_status()
@@ -253,12 +263,17 @@ async fn ensure_cached_asset(
     release_version: &str,
     asset_name: &str,
 ) -> Result<PathBuf> {
-    let path = cache.manifest_asset_path(release_version, asset_name);
-    if path.exists() && path.metadata().map(|metadata| metadata.len() > 0).unwrap_or(false) {
+    let path = cache.manifest_asset_path(release_version, asset_name)?;
+    if path.exists()
+        && path
+            .metadata()
+            .map(|metadata| metadata.len() > 0)
+            .unwrap_or(false)
+    {
         return Ok(path);
     }
 
-    let response = reqwest::get(release_asset_url(release_version, asset_name))
+    let response = reqwest::get(release_asset_url(release_version, asset_name)?)
         .await
         .with_context(|| format!("failed to fetch recipe asset `{asset_name}`"))?
         .error_for_status()
@@ -270,10 +285,11 @@ async fn ensure_cached_asset(
     cache.write_asset(release_version, asset_name, bytes.as_ref())
 }
 
-fn release_asset_url(release_version: &str, asset_name: &str) -> String {
-    format!(
+fn release_asset_url(release_version: &str, asset_name: &str) -> Result<String> {
+    let asset_name = validate_asset_name(asset_name)?;
+    Ok(format!(
         "https://github.com/{OFFICIAL_RECIPE_SOURCE_LABEL}/releases/download/{release_version}/{asset_name}"
-    )
+    ))
 }
 
 fn release_version_from_release_page_url(url: &reqwest::Url) -> Result<String> {
@@ -314,7 +330,10 @@ mod tests {
 
     #[test]
     fn maps_tcp_recipe_runtime_to_link() {
-        assert_eq!(parse_recipe_runtime("tcp").unwrap(), ServiceRecipeRuntime::Link);
+        assert_eq!(
+            parse_recipe_runtime("tcp").unwrap(),
+            ServiceRecipeRuntime::Link
+        );
     }
 
     #[test]
@@ -324,6 +343,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(release_version_from_release_page_url(&url).unwrap(), "v0.3.1");
+        assert_eq!(
+            release_version_from_release_page_url(&url).unwrap(),
+            "v0.3.1"
+        );
     }
 }

--- a/fungi/src/commands/fungi_control/mod.rs
+++ b/fungi/src/commands/fungi_control/mod.rs
@@ -28,8 +28,7 @@ pub use relay_config::{RelayCommands, execute_relay};
 pub use security::{SecurityCommands, execute_security};
 pub use service::{
     DynamicThingInvocation, DynamicThingTarget, ServiceArgs, ServiceCommands,
-    ServiceRecipeCommands,
-    execute_dynamic_thing, execute_service, fatal_dynamic_builtin_typo,
+    ServiceRecipeCommands, execute_dynamic_thing, execute_service, fatal_dynamic_builtin_typo,
     parse_dynamic_thing_invocation, parse_dynamic_thing_target,
 };
 pub use shared::{DeviceInput, PeerInput};

--- a/fungi/src/commands/fungi_control/mod.rs
+++ b/fungi/src/commands/fungi_control/mod.rs
@@ -28,6 +28,7 @@ pub use relay_config::{RelayCommands, execute_relay};
 pub use security::{SecurityCommands, execute_security};
 pub use service::{
     DynamicThingInvocation, DynamicThingTarget, ServiceArgs, ServiceCommands,
+    ServiceRecipeCommands,
     execute_dynamic_thing, execute_service, fatal_dynamic_builtin_typo,
     parse_dynamic_thing_invocation, parse_dynamic_thing_target,
 };

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -16,10 +16,11 @@ use fungi_daemon_grpc::{
     Request,
     fungi_daemon_grpc::{
         AttachServiceAccessRequest, DetachServiceAccessRequest, DeviceInfo, Empty,
-        GetServiceLogsRequest, ListPeerCatalogRequest, ListServiceAccessesRequest,
-        ListServicesResponse, PullServiceRequest, RemotePeerRequest, RemotePullServiceRequest,
-        RemoteServiceControlResponse, RemoteServiceNameRequest, ServiceInstanceResponse,
-        ServiceNameRequest,
+        GetRecipeRequest, GetServiceLogsRequest, ListPeerCatalogRequest, ListRecipesRequest,
+        ListRecipesResponse, ListServiceAccessesRequest, ListServicesResponse, PullServiceRequest,
+        RecipeDetail, RecipeRuntimeKind, RecipeSummary, RemotePeerRequest,
+        RemotePullServiceRequest, RemoteServiceControlResponse, RemoteServiceNameRequest,
+        ResolveRecipeRequest, ServiceInstanceResponse, ServiceNameRequest,
     },
 };
 use serde::Serialize;
@@ -67,6 +68,20 @@ pub enum ServiceCommands {
         target_or_manifest: Option<String>,
         /// Path to a service manifest YAML file when the first argument is a service reference
         manifest: Option<String>,
+        /// Add a service from an official recipe ID instead of a local manifest
+        #[arg(long)]
+        recipe: Option<String>,
+        /// Refresh the official recipe index before resolving the recipe
+        #[arg(long, default_value_t = false)]
+        refresh: bool,
+        /// Skip the recipe confirmation prompt
+        #[arg(long, default_value_t = false)]
+        yes: bool,
+    },
+    /// Inspect official service recipes managed by the local daemon
+    Recipe {
+        #[command(subcommand)]
+        command: ServiceRecipeCommands,
     },
     /// Open a service in the default local app when possible
     Open {
@@ -112,6 +127,23 @@ pub enum ServiceCommands {
     },
 }
 
+#[derive(Subcommand, Debug, Clone)]
+pub enum ServiceRecipeCommands {
+    /// List official service recipes known to the local daemon
+    List {
+        /// Refresh the official recipe index before listing
+        #[arg(long, default_value_t = false)]
+        refresh: bool,
+    },
+    /// Show detailed metadata and audit paths for one official recipe
+    Show {
+        recipe: String,
+        /// Refresh the official recipe index before showing the recipe
+        #[arg(long, default_value_t = false)]
+        refresh: bool,
+    },
+}
+
 pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
     let mut client = match get_rpc_client(&args).await {
         Some(c) => c,
@@ -146,7 +178,24 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
         ServiceCommands::Add {
             target_or_manifest,
             manifest,
+            recipe,
+            refresh,
+            yes,
         } => {
+            if let Some(recipe_id) = recipe {
+                add_service_from_recipe(
+                    &mut client,
+                    &args,
+                    device,
+                    target_or_manifest,
+                    manifest,
+                    recipe_id,
+                    refresh,
+                    yes,
+                )
+                .await;
+                return;
+            }
             let add_input = parse_service_add_input(target_or_manifest, manifest);
             let device = resolve_service_device_target(&args, device, add_input.device);
             let target_device_name = device.as_ref().map(resolved_device_display_name);
@@ -213,6 +262,19 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
                         }
                     }
                     Err(e) => fatal_grpc(e),
+                }
+            }
+        }
+        ServiceCommands::Recipe { command } => {
+            if device.is_some() {
+                fatal("Recipe commands are local-only. Run them without --device.")
+            }
+            match command {
+                ServiceRecipeCommands::List { refresh } => {
+                    print_service_recipes(&mut client, refresh).await
+                }
+                ServiceRecipeCommands::Show { recipe, refresh } => {
+                    print_service_recipe_detail(&mut client, &recipe, refresh).await
                 }
             }
         }
@@ -639,6 +701,141 @@ fn parse_service_add_input(
     }
 }
 
+fn parse_service_recipe_add_input(
+    target_or_manifest: Option<String>,
+    manifest: Option<String>,
+) -> ServiceAddInput {
+    if manifest.is_some() {
+        fatal(
+            "`fungi service add --recipe <id>` does not accept a manifest path. Use either `--recipe <id> [service@device]` or `service add <manifest.yaml>`.",
+        )
+    }
+
+    let Some(value) = target_or_manifest else {
+        return ServiceAddInput {
+            manifest_path: None,
+            default_name: None,
+            device: None,
+        };
+    };
+
+    if looks_like_manifest_path(&value) {
+        fatal(
+            "With `--recipe`, the positional argument is the service name or `service@device`, not a manifest path.",
+        )
+    }
+
+    let target = parse_service_reference(value);
+    reject_service_entry(&target, "add");
+    ServiceAddInput {
+        manifest_path: None,
+        default_name: Some(target.name),
+        device: target.device,
+    }
+}
+
+async fn add_service_from_recipe(
+    client: &mut RpcClient,
+    args: &CommonArgs,
+    scoped_device: Option<super::shared::ResolvedPeerTarget>,
+    target_or_manifest: Option<String>,
+    manifest: Option<String>,
+    recipe_id: String,
+    refresh: bool,
+    yes: bool,
+) {
+    let add_input = parse_service_recipe_add_input(target_or_manifest, manifest);
+    let device = resolve_service_device_target(args, scoped_device, add_input.device);
+    let target_device_name = device.as_ref().map(resolved_device_display_name);
+    let requested_service_name = add_input.default_name.unwrap_or_default();
+    let req = ResolveRecipeRequest {
+        recipe_id,
+        service_name: requested_service_name.clone(),
+        peer_id: device
+            .as_ref()
+            .map(|device| device.peer_id.clone())
+            .unwrap_or_default(),
+        refresh,
+    };
+    let resolved = match client.resolve_recipe(Request::new(req)).await {
+        Ok(resp) => resp.into_inner(),
+        Err(error) => fatal_grpc(error),
+    };
+    let detail = require_recipe_detail(resolved.detail);
+    let service_name = if requested_service_name.trim().is_empty() {
+        recipe_summary(&detail).id.clone()
+    } else {
+        requested_service_name
+    };
+
+    if !yes {
+        print_recipe_add_review(
+            &detail,
+            &service_name,
+            target_device_name.as_deref(),
+            &resolved.resolved_manifest_path,
+            &resolved.warnings,
+        );
+        if !prompt_yes_no_default("Create this service from the recipe? [Y/n]", true) {
+            println!("Cancelled");
+            return;
+        }
+    } else {
+        print_recipe_warnings(&resolved.warnings);
+    }
+
+    if let Some(device) = device {
+        print_target_device(&device);
+        let req = RemotePullServiceRequest {
+            peer_id: device.peer_id.clone(),
+            manifest_yaml: resolved.manifest_yaml,
+        };
+        match client.remote_pull_service(Request::new(req)).await {
+            Ok(resp) => {
+                let response = resp.into_inner();
+                let service_name = response_service_name(&response);
+                print_remote_service_added(response);
+                refresh_remote_device_services(client, &device.peer_id).await;
+                println!("Use it:");
+                println!(
+                    "  fungi {}@{}",
+                    service_name,
+                    resolved_device_display_name(&device)
+                );
+            }
+            Err(error) => fatal_grpc(error),
+        }
+    } else {
+        let req = PullServiceRequest {
+            manifest_yaml: resolved.manifest_yaml,
+            manifest_base_dir: resolved.manifest_base_dir,
+        };
+        match client.pull_service(Request::new(req)).await {
+            Ok(resp) => print_service_instance(resp.into_inner(), false),
+            Err(error) => fatal_grpc(error),
+        }
+    }
+}
+
+async fn print_service_recipes(client: &mut RpcClient, refresh: bool) {
+    let req = ListRecipesRequest { refresh };
+    match client.list_recipes(Request::new(req)).await {
+        Ok(resp) => print_service_recipe_list_value(resp.into_inner()),
+        Err(error) => fatal_grpc(error),
+    }
+}
+
+async fn print_service_recipe_detail(client: &mut RpcClient, recipe_id: &str, refresh: bool) {
+    let req = GetRecipeRequest {
+        recipe_id: recipe_id.to_string(),
+        refresh,
+    };
+    match client.get_recipe(Request::new(req)).await {
+        Ok(resp) => print_service_recipe_detail_value(&require_recipe_detail(resp.into_inner().detail)),
+        Err(error) => fatal_grpc(error),
+    }
+}
+
 fn looks_like_manifest_path(value: &str) -> bool {
     let value = value.trim();
     let lower = value.to_ascii_lowercase();
@@ -649,6 +846,103 @@ fn looks_like_manifest_path(value: &str) -> bool {
         || value.contains(std::path::MAIN_SEPARATOR)
         || value.contains('/')
         || value.contains('\\')
+}
+
+fn require_recipe_detail(detail: Option<RecipeDetail>) -> RecipeDetail {
+    detail.unwrap_or_else(|| fatal("Recipe response was missing detail payload"))
+}
+
+fn recipe_summary(detail: &RecipeDetail) -> &RecipeSummary {
+    detail
+        .summary
+        .as_ref()
+        .unwrap_or_else(|| fatal("Recipe response was missing summary payload"))
+}
+
+fn recipe_runtime_label(kind: i32) -> &'static str {
+    match RecipeRuntimeKind::try_from(kind) {
+        Ok(RecipeRuntimeKind::Docker) => "docker",
+        Ok(RecipeRuntimeKind::Wasmtime) => "wasmtime",
+        Ok(RecipeRuntimeKind::Link) => "link",
+        _ => "unknown",
+    }
+}
+
+fn print_service_recipe_list_value(resp: ListRecipesResponse) {
+    if resp.recipes.is_empty() {
+        println!("No recipes found");
+        return;
+    }
+
+    for recipe in resp.recipes {
+        println!(
+            "{:<20} {:<9} {} [{}]",
+            recipe.id,
+            recipe_runtime_label(recipe.runtime),
+            recipe.description,
+            recipe.release_version
+        );
+    }
+}
+
+fn print_service_recipe_detail_value(detail: &RecipeDetail) {
+    let summary = recipe_summary(detail);
+    println!("Recipe: {}", summary.id);
+    println!("Name: {}", summary.name);
+    println!("Description: {}", summary.description);
+    println!("Runtime: {}", recipe_runtime_label(summary.runtime));
+    println!("Stability: {}", summary.stability);
+    println!("Source: {}", summary.source_label);
+    println!("Release: {}", summary.release_version);
+    if !detail.tags.is_empty() {
+        println!("Tags: {}", detail.tags.join(", "));
+    }
+    if !detail.homepage.is_empty() {
+        println!("Homepage: {}", detail.homepage);
+    }
+    println!("Cached manifest: {}", detail.cached_manifest_path);
+    if !detail.cached_readme_path.is_empty() {
+        println!("Cached readme: {}", detail.cached_readme_path);
+    }
+    println!("Remote manifest: {}", detail.remote_manifest_url);
+    if !detail.remote_readme_url.is_empty() {
+        println!("Remote readme: {}", detail.remote_readme_url);
+    }
+}
+
+fn print_recipe_add_review(
+    detail: &RecipeDetail,
+    service_name: &str,
+    target_device_name: Option<&str>,
+    resolved_manifest_path: &str,
+    warnings: &[String],
+) {
+    let summary = recipe_summary(detail);
+    println!("Recipe: {}", summary.id);
+    println!("Service name: {}", service_name);
+    println!(
+        "Target: {}",
+        target_device_name.unwrap_or("local node")
+    );
+    println!("Runtime: {}", recipe_runtime_label(summary.runtime));
+    println!("Source: {}", summary.source_label);
+    println!("Release: {}", summary.release_version);
+    println!("Cached manifest: {}", detail.cached_manifest_path);
+    if !detail.cached_readme_path.is_empty() {
+        println!("Cached readme: {}", detail.cached_readme_path);
+    }
+    println!("Resolved manifest: {}", resolved_manifest_path);
+    println!("Remote manifest: {}", detail.remote_manifest_url);
+    if !detail.remote_readme_url.is_empty() {
+        println!("Remote readme: {}", detail.remote_readme_url);
+    }
+    print_recipe_warnings(warnings);
+}
+
+fn print_recipe_warnings(warnings: &[String]) {
+    for warning in warnings {
+        eprintln!("Warning: {warning}");
+    }
 }
 
 fn reject_service_entry(target: &DynamicThingTarget, action: &str) {

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -888,9 +888,34 @@ fn print_service_recipe_list_value(resp: ListRecipesResponse) {
 }
 
 fn print_service_recipe_detail_value(detail: &RecipeDetail) {
+    print_recipe_metadata(detail);
+}
+
+fn print_recipe_add_review(
+    detail: &RecipeDetail,
+    service_name: &str,
+    target_device_name: Option<&str>,
+    resolved_manifest_path: &str,
+    warnings: &[String],
+) {
     let summary = recipe_summary(detail);
     println!("Recipe: {}", summary.id);
-    println!("Name: {}", summary.name);
+    println!("Service name: {}", service_name);
+    println!("Target: {}", target_device_name.unwrap_or("local node"));
+    print_recipe_metadata_with_options(detail, false);
+    println!("Resolved manifest: {}", resolved_manifest_path);
+    print_recipe_warnings(warnings);
+}
+
+fn print_recipe_metadata(detail: &RecipeDetail) {
+    print_recipe_metadata_with_options(detail, true);
+}
+
+fn print_recipe_metadata_with_options(detail: &RecipeDetail, include_name: bool) {
+    let summary = recipe_summary(detail);
+    if include_name {
+        println!("Name: {}", summary.name);
+    }
     println!("Description: {}", summary.description);
     println!("Runtime: {}", recipe_runtime_label(summary.runtime));
     println!("Stability: {}", summary.stability);
@@ -910,32 +935,6 @@ fn print_service_recipe_detail_value(detail: &RecipeDetail) {
     if !detail.remote_readme_url.is_empty() {
         println!("Remote readme: {}", detail.remote_readme_url);
     }
-}
-
-fn print_recipe_add_review(
-    detail: &RecipeDetail,
-    service_name: &str,
-    target_device_name: Option<&str>,
-    resolved_manifest_path: &str,
-    warnings: &[String],
-) {
-    let summary = recipe_summary(detail);
-    println!("Recipe: {}", summary.id);
-    println!("Service name: {}", service_name);
-    println!("Target: {}", target_device_name.unwrap_or("local node"));
-    println!("Runtime: {}", recipe_runtime_label(summary.runtime));
-    println!("Source: {}", summary.source_label);
-    println!("Release: {}", summary.release_version);
-    println!("Cached manifest: {}", detail.cached_manifest_path);
-    if !detail.cached_readme_path.is_empty() {
-        println!("Cached readme: {}", detail.cached_readme_path);
-    }
-    println!("Resolved manifest: {}", resolved_manifest_path);
-    println!("Remote manifest: {}", detail.remote_manifest_url);
-    if !detail.remote_readme_url.is_empty() {
-        println!("Remote readme: {}", detail.remote_readme_url);
-    }
-    print_recipe_warnings(warnings);
 }
 
 fn print_recipe_warnings(warnings: &[String]) {

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -831,7 +831,9 @@ async fn print_service_recipe_detail(client: &mut RpcClient, recipe_id: &str, re
         refresh,
     };
     match client.get_recipe(Request::new(req)).await {
-        Ok(resp) => print_service_recipe_detail_value(&require_recipe_detail(resp.into_inner().detail)),
+        Ok(resp) => {
+            print_service_recipe_detail_value(&require_recipe_detail(resp.into_inner().detail))
+        }
         Err(error) => fatal_grpc(error),
     }
 }
@@ -920,10 +922,7 @@ fn print_recipe_add_review(
     let summary = recipe_summary(detail);
     println!("Recipe: {}", summary.id);
     println!("Service name: {}", service_name);
-    println!(
-        "Target: {}",
-        target_device_name.unwrap_or("local node")
-    );
+    println!("Target: {}", target_device_name.unwrap_or("local node"));
     println!("Runtime: {}", recipe_runtime_label(summary.runtime));
     println!("Source: {}", summary.source_label);
     println!("Release: {}", summary.release_version);

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -3,6 +3,7 @@ use fungi::commands::{
     Commands, FungiArgs,
     fungi_control::{
         DeviceAddressCommands, DeviceCommands, DeviceInput, ServiceArgs, ServiceCommands,
+        ServiceRecipeCommands,
     },
 };
 
@@ -24,6 +25,7 @@ fn parses_service_add_with_device() {
             Some(ServiceCommands::Add {
                 target_or_manifest,
                 manifest,
+                ..
             }),
         ..
     }) = args.command
@@ -47,6 +49,7 @@ fn parses_interactive_service_add() {
             Some(ServiceCommands::Add {
                 target_or_manifest,
                 manifest,
+                ..
             }),
         ..
     }) = args.command
@@ -78,6 +81,7 @@ fn parses_service_add_reference_for_interactive_creator() {
             Some(ServiceCommands::Add {
                 target_or_manifest,
                 manifest,
+                ..
             }),
         ..
     }) = args.command
@@ -102,6 +106,7 @@ fn parses_service_add_reference_then_manifest() {
             Some(ServiceCommands::Add {
                 target_or_manifest,
                 manifest,
+                ..
             }),
         ..
     }) = args.command
@@ -112,6 +117,69 @@ fn parses_service_add_reference_then_manifest() {
     assert!(device.device.is_none());
     assert_eq!(target_or_manifest.as_deref(), Some("ssh@nas"));
     assert_eq!(manifest.as_deref(), Some("ssh.service.yaml"));
+}
+
+#[test]
+fn parses_service_add_recipe_flags() {
+    let args = FungiArgs::try_parse_from([
+        "fungi",
+        "service",
+        "add",
+        "home-ssh@nas",
+        "--recipe",
+        "ssh-tunnel",
+        "--refresh",
+        "--yes",
+    ])
+    .unwrap();
+
+    let Commands::Service(ServiceArgs {
+        command:
+            Some(ServiceCommands::Add {
+                target_or_manifest,
+                manifest,
+                recipe,
+                refresh,
+                yes,
+            }),
+        ..
+    }) = args.command
+    else {
+        panic!("expected service add command");
+    };
+
+    assert_eq!(target_or_manifest.as_deref(), Some("home-ssh@nas"));
+    assert!(manifest.is_none());
+    assert_eq!(recipe.as_deref(), Some("ssh-tunnel"));
+    assert!(refresh);
+    assert!(yes);
+}
+
+#[test]
+fn parses_service_recipe_show() {
+    let args = FungiArgs::try_parse_from([
+        "fungi",
+        "service",
+        "recipe",
+        "show",
+        "code-server",
+        "--refresh",
+    ])
+    .unwrap();
+
+    let Commands::Service(ServiceArgs {
+        command:
+            Some(ServiceCommands::Recipe {
+                command: ServiceRecipeCommands::Show { recipe, refresh },
+            }),
+        ..
+    }) = args.command
+    else {
+        panic!("expected service recipe show command");
+    };
+
+    assert_eq!(recipe, "code-server");
+    assert!(refresh);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add official service recipe cache and daemon-side fetch/resolve flow
- expose typed recipe list/show/resolve RPCs over daemon-grpc
- add CLI support for `fungi service recipe list`, `fungi service recipe show`, and `fungi service add --recipe`

## Validation
- cargo test -p fungi-daemon recipes
- cargo test -p fungi --test commands
- cargo test -p fungi-daemon-grpc --no-run
- cargo test -p fungi --no-run

## Follow-up
- run local lab smoke for real recipe list/show/add flow
