### PR TITLE
[codex] Harden v0.6.1 config migration

### DIFF
--- a/crates/config-migrate/src/apply.rs
+++ b/crates/config-migrate/src/apply.rs
@@ -10,7 +10,7 @@ use crate::{
     model::{
         APPLY_ROLLBACK_DIR_NAME, BACKUP_ROOT_DIR, CURRENT_FUNGI_DIR_VERSION, DEVICES_FILE,
         DetectedVersion, LEGACY_ADDRESS_BOOK_FILE, LEGACY_SERVICE_STATE_FILE, MigrationPlan,
-        STAGING_DIR_PREFIX,
+        STAGING_DIR_PREFIX, TRUSTED_DEVICES_FILE,
     },
 };
 
@@ -126,6 +126,10 @@ pub(crate) fn validate_migrated_dir(staging_root: &Path, plan: &MigrationPlan) -
         if !staging_root.join(DEVICES_FILE).exists() {
             bail!("Migration validation failed; devices.toml was not created in staging");
         }
+    }
+
+    if plan.migrate_incoming_allowed_peers && !staging_root.join(TRUSTED_DEVICES_FILE).exists() {
+        bail!("Migration validation failed; trusted_devices.toml was not created in staging");
     }
 
     if plan.migrate_legacy_managed_services && staging_root.join(LEGACY_SERVICE_STATE_FILE).exists()

--- a/crates/config-migrate/src/apply.rs
+++ b/crates/config-migrate/src/apply.rs
@@ -42,44 +42,97 @@ impl MigrationTransaction {
             )
         })?;
 
-        let backup_dir = backup_root.join(format!(
+        let backup_dir_name = format!(
             "{timestamp}-from-{}-to-v{target_version}",
             source_version.backup_label()
-        ));
-        let staging_dir =
-            fungi_dir.join(format!("{STAGING_DIR_PREFIX}{timestamp}-v{target_version}"));
+        );
+        let staging_dir_name = format!("{STAGING_DIR_PREFIX}{timestamp}-v{target_version}");
 
-        if backup_dir.exists() {
-            bail!(
-                "Refusing to overwrite existing migration backup directory: {}",
-                backup_dir.display()
-            );
-        }
-        if staging_dir.exists() {
-            bail!(
-                "Refusing to overwrite existing migration staging directory: {}",
-                staging_dir.display()
-            );
-        }
-
-        fs::create_dir_all(&backup_dir).with_context(|| {
-            format!(
-                "Failed to create migration backup directory: {}",
-                backup_dir.display()
-            )
-        })?;
-        fs::create_dir_all(&staging_dir).with_context(|| {
-            format!(
-                "Failed to create migration staging directory: {}",
-                staging_dir.display()
-            )
-        })?;
+        let (backup_dir, staging_dir) = allocate_transaction_dirs(
+            &backup_root,
+            fungi_dir,
+            &backup_dir_name,
+            &staging_dir_name,
+        )?;
 
         Ok(Self {
             backup_dir,
             staging_dir,
         })
     }
+}
+
+fn allocate_transaction_dirs(
+    backup_root: &Path,
+    fungi_dir: &Path,
+    backup_dir_name: &str,
+    staging_dir_name: &str,
+) -> Result<(PathBuf, PathBuf)> {
+    for attempt in 0..1000 {
+        let suffix = if attempt == 0 {
+            String::new()
+        } else {
+            format!("-{attempt}")
+        };
+        let backup_dir = backup_root.join(format!("{backup_dir_name}{suffix}"));
+        let staging_dir = fungi_dir.join(format!("{staging_dir_name}{suffix}"));
+
+        if backup_dir.exists() || staging_dir.exists() {
+            continue;
+        }
+
+        if let Err(error) = fs::create_dir(&backup_dir) {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                continue;
+            }
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to create migration backup directory: {}",
+                    backup_dir.display()
+                )
+            });
+        }
+        match fs::create_dir(&staging_dir) {
+            Ok(()) => return Ok((backup_dir, staging_dir)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let _ = fs::remove_dir_all(&backup_dir);
+                continue;
+            }
+            Err(error) => {
+                let _ = fs::remove_dir_all(&backup_dir);
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to create migration staging directory: {}",
+                        staging_dir.display()
+                    )
+                });
+            }
+        }
+    }
+
+    bail!(
+        "Failed to allocate a unique migration backup directory under {}",
+        backup_root.display()
+    )
+}
+
+pub(crate) fn copy_backup_snapshot(source_root: &Path, target_root: &Path) -> Result<()> {
+    for entry in fs::read_dir(source_root).with_context(|| {
+        format!(
+            "Failed to read source directory during migration backup: {}",
+            source_root.display()
+        )
+    })? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let display_name = file_name.to_string_lossy();
+        if display_name == BACKUP_ROOT_DIR || display_name.starts_with(STAGING_DIR_PREFIX) {
+            continue;
+        }
+
+        copy_path_recursively(&entry.path(), &target_root.join(file_name))?;
+    }
+    Ok(())
 }
 
 pub(crate) fn copy_selected_paths(

--- a/crates/config-migrate/src/config_files.rs
+++ b/crates/config-migrate/src/config_files.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, fs, path::Path};
 
 use crate::model::{
     CONFIG_FILE, CURRENT_FUNGI_DIR_VERSION, DEVICES_FILE, LEGACY_ADDRESS_BOOK_FILE,
-    SERVICES_ROOT_DIR, normalize_fs_path,
+    SERVICES_ROOT_DIR, TRUSTED_DEVICES_FILE, normalize_fs_path,
 };
 
 pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Path) -> Result<()> {
@@ -25,6 +25,9 @@ pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Pa
         toml::Value::Integer(CURRENT_FUNGI_DIR_VERSION.into()),
     );
     table.remove("incoming_allowed_peers");
+    if let Some(network_table) = table.get_mut("network").and_then(toml::Value::as_table_mut) {
+        network_table.remove("incoming_allowed_peers");
+    }
 
     if let Some(runtime_table) = table.get_mut("runtime").and_then(toml::Value::as_table_mut) {
         runtime_table.remove("allowed_ports");
@@ -38,6 +41,67 @@ pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Pa
         format!(
             "Failed to write migrated config.toml into staging directory: {}",
             config_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+pub(crate) fn migrate_legacy_incoming_allowed_peers(staging_root: &Path) -> Result<()> {
+    let config_path = staging_root.join(CONFIG_FILE);
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&config_path).with_context(|| {
+        format!(
+            "Failed to read config.toml from staging directory: {}",
+            config_path.display()
+        )
+    })?;
+    let value: toml::Value =
+        toml::from_str(&content).context("Failed to parse config.toml in staging")?;
+    let Some(table) = value.as_table() else {
+        anyhow::bail!("config.toml root must be a TOML table");
+    };
+
+    let mut incoming_peers = legacy_incoming_allowed_peers(table)?;
+
+    let trusted_devices_path = staging_root.join(TRUSTED_DEVICES_FILE);
+    let mut trusted_devices_value = if trusted_devices_path.exists() {
+        let existing = fs::read_to_string(&trusted_devices_path).with_context(|| {
+            format!(
+                "Failed to read existing trusted_devices.toml from staging directory: {}",
+                trusted_devices_path.display()
+            )
+        })?;
+        toml::from_str(&existing)
+            .context("Failed to parse existing trusted_devices.toml in staging")?
+    } else {
+        toml::Value::Table(toml::map::Map::new())
+    };
+
+    let trusted_devices = ensure_toml_array_field(&mut trusted_devices_value, "trusted_devices")?;
+    let mut existing = trusted_devices
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+    incoming_peers.sort();
+    incoming_peers.dedup();
+    for peer_id in incoming_peers {
+        if existing.insert(peer_id.clone()) {
+            trusted_devices.push(toml::Value::String(peer_id));
+        }
+    }
+
+    trusted_devices.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+    let encoded = toml::to_string_pretty(&trusted_devices_value)
+        .context("Failed to encode migrated trusted_devices.toml from staging")?;
+    fs::write(&trusted_devices_path, encoded).with_context(|| {
+        format!(
+            "Failed to write migrated trusted_devices.toml into staging directory: {}",
+            trusted_devices_path.display()
         )
     })?;
 
@@ -115,6 +179,45 @@ pub(crate) fn migrate_legacy_address_book(staging_root: &Path) -> Result<()> {
             address_book_path.display()
         )
     })?;
+    Ok(())
+}
+
+fn legacy_incoming_allowed_peers(table: &toml::Table) -> Result<Vec<String>> {
+    let mut peers = Vec::new();
+    append_toml_string_array(
+        &mut peers,
+        table.get("incoming_allowed_peers"),
+        "incoming_allowed_peers",
+    )?;
+    let network_table = table.get("network").and_then(toml::Value::as_table);
+    append_toml_string_array(
+        &mut peers,
+        network_table.and_then(|table| table.get("incoming_allowed_peers")),
+        "network.incoming_allowed_peers",
+    )?;
+    Ok(peers)
+}
+
+fn append_toml_string_array(
+    output: &mut Vec<String>,
+    value: Option<&toml::Value>,
+    field_name: &str,
+) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(values) = value.as_array() else {
+        anyhow::bail!("{field_name} must be an array of peer IDs");
+    };
+    for item in values {
+        let Some(peer_id) = item.as_str() else {
+            anyhow::bail!("{field_name} must contain only peer ID strings");
+        };
+        let peer_id = peer_id.trim();
+        if !peer_id.is_empty() {
+            output.push(peer_id.to_string());
+        }
+    }
     Ok(())
 }
 

--- a/crates/config-migrate/src/detection.rs
+++ b/crates/config-migrate/src/detection.rs
@@ -7,7 +7,8 @@ use std::{
 
 use crate::model::{
     CONFIG_FILE, DATA_ROOT_DIR, DEVICES_FILE, DetectedVersion, LEGACY_ADDRESS_BOOK_FILE,
-    LEGACY_SERVICE_STATE_FILE, MigrationPlan, SERVICES_ROOT_DIR, normalize_fs_path,
+    LEGACY_SERVICE_STATE_FILE, MigrationPlan, SERVICES_ROOT_DIR, TRUSTED_DEVICES_FILE,
+    normalize_fs_path,
 };
 
 pub fn detect_source_version(fungi_dir: &Path) -> Result<DetectedVersion> {
@@ -67,9 +68,15 @@ pub(crate) fn build_migration_plan(
     }
 
     let mut touched_paths = BTreeSet::new();
-    let update_config = config_requires_current_normalization(fungi_dir, source_version)?;
+    let migrate_incoming_allowed_peers =
+        config_has_legacy_incoming_allowed_peers(fungi_dir, source_version)?;
+    let update_config = config_requires_current_normalization(fungi_dir, source_version)?
+        || migrate_incoming_allowed_peers;
     if update_config {
         touched_paths.insert(PathBuf::from(CONFIG_FILE));
+    }
+    if migrate_incoming_allowed_peers {
+        touched_paths.insert(PathBuf::from(TRUSTED_DEVICES_FILE));
     }
 
     if legacy_address_book_exists {
@@ -85,10 +92,27 @@ pub(crate) fn build_migration_plan(
 
     Ok(MigrationPlan {
         update_config,
+        migrate_incoming_allowed_peers,
         migrate_address_book: legacy_address_book_exists,
         migrate_legacy_managed_services: legacy_service_state_exists,
         touched_paths: touched_paths.into_iter().collect(),
     })
+}
+
+fn config_has_legacy_incoming_allowed_peers(
+    fungi_dir: &Path,
+    source_version: &DetectedVersion,
+) -> Result<bool> {
+    if matches!(source_version, DetectedVersion::MissingConfig) {
+        return Ok(false);
+    }
+
+    let table = read_config_table(fungi_dir, "detecting legacy incoming peer allowlist")?;
+    Ok(table.contains_key("incoming_allowed_peers")
+        || table
+            .get("network")
+            .and_then(toml::Value::as_table)
+            .is_some_and(|network_table| network_table.contains_key("incoming_allowed_peers")))
 }
 
 fn config_requires_current_normalization(
@@ -99,18 +123,7 @@ fn config_requires_current_normalization(
         return Ok(false);
     }
 
-    let config_path = fungi_dir.join(CONFIG_FILE);
-    let content = fs::read_to_string(&config_path).with_context(|| {
-        format!(
-            "Failed to read Fungi config file while building migration plan: {}",
-            config_path.display()
-        )
-    })?;
-    let value: toml::Value = toml::from_str(&content)
-        .context("Failed to parse config.toml while building migration plan")?;
-    let Some(table) = value.as_table() else {
-        bail!("config.toml root must be a TOML table while building migration plan");
-    };
+    let table = read_config_table(fungi_dir, "building migration plan")?;
 
     if !table.contains_key("version") {
         return Ok(true);
@@ -139,6 +152,22 @@ fn config_requires_current_normalization(
         });
 
     Ok(has_legacy_services_allowlist)
+}
+
+fn read_config_table(fungi_dir: &Path, action: &str) -> Result<toml::Table> {
+    let config_path = fungi_dir.join(CONFIG_FILE);
+    let content = fs::read_to_string(&config_path).with_context(|| {
+        format!(
+            "Failed to read Fungi config file while {action}: {}",
+            config_path.display()
+        )
+    })?;
+    let value: toml::Value = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse config.toml while {action}"))?;
+    let Some(table) = value.as_table() else {
+        bail!("config.toml root must be a TOML table while {action}");
+    };
+    Ok(table.clone())
 }
 
 fn ensure_no_mixed_managed_service_layout(fungi_dir: &Path) -> Result<()> {

--- a/crates/config-migrate/src/lib.rs
+++ b/crates/config-migrate/src/lib.rs
@@ -11,7 +11,10 @@ use anyhow::{Result, bail};
 use std::path::Path;
 
 use apply::{MigrationTransaction, apply_staged_paths, copy_selected_paths, validate_migrated_dir};
-use config_files::{migrate_config_toml_to_current, migrate_legacy_address_book};
+use config_files::{
+    migrate_config_toml_to_current, migrate_legacy_address_book,
+    migrate_legacy_incoming_allowed_peers,
+};
 use detection::build_migration_plan;
 pub use detection::detect_source_version;
 pub use model::{CURRENT_FUNGI_DIR_VERSION, DetectedVersion, MigrationReport};
@@ -58,6 +61,9 @@ fn migrate_with_plan(
     copy_selected_paths(fungi_dir, &transaction.backup_dir, &plan.touched_paths)?;
     copy_selected_paths(fungi_dir, &transaction.staging_dir, &plan.touched_paths)?;
 
+    if plan.migrate_incoming_allowed_peers {
+        migrate_legacy_incoming_allowed_peers(&transaction.staging_dir)?;
+    }
     if plan.update_config {
         migrate_config_toml_to_current(&transaction.staging_dir, fungi_dir)?;
     }

--- a/crates/config-migrate/src/lib.rs
+++ b/crates/config-migrate/src/lib.rs
@@ -10,7 +10,10 @@ mod tests;
 use anyhow::{Result, bail};
 use std::path::Path;
 
-use apply::{MigrationTransaction, apply_staged_paths, copy_selected_paths, validate_migrated_dir};
+use apply::{
+    MigrationTransaction, apply_staged_paths, copy_backup_snapshot, copy_selected_paths,
+    validate_migrated_dir,
+};
 use config_files::{
     migrate_config_toml_to_current, migrate_legacy_address_book,
     migrate_legacy_incoming_allowed_peers,
@@ -58,7 +61,7 @@ fn migrate_with_plan(
 
     let transaction =
         MigrationTransaction::prepare(fungi_dir, &source_version, CURRENT_FUNGI_DIR_VERSION)?;
-    copy_selected_paths(fungi_dir, &transaction.backup_dir, &plan.touched_paths)?;
+    copy_backup_snapshot(fungi_dir, &transaction.backup_dir)?;
     copy_selected_paths(fungi_dir, &transaction.staging_dir, &plan.touched_paths)?;
 
     if plan.migrate_incoming_allowed_peers {

--- a/crates/config-migrate/src/model.rs
+++ b/crates/config-migrate/src/model.rs
@@ -12,6 +12,7 @@ pub(crate) const STAGING_DIR_PREFIX: &str = ".fungi-migrate-staging-";
 pub(crate) const APPLY_ROLLBACK_DIR_NAME: &str = ".apply-rollback";
 pub(crate) const LEGACY_ADDRESS_BOOK_FILE: &str = "address_book.toml";
 pub(crate) const DEVICES_FILE: &str = "devices.toml";
+pub(crate) const TRUSTED_DEVICES_FILE: &str = "trusted_devices.toml";
 pub(crate) const LEGACY_SERVICE_STATE_FILE: &str = "services-state.json";
 pub(crate) const SERVICES_ROOT_DIR: &str = "services";
 pub(crate) const DATA_ROOT_DIR: &str = "data";
@@ -71,6 +72,7 @@ impl MigrationReport {
 #[derive(Debug, Default)]
 pub(crate) struct MigrationPlan {
     pub(crate) update_config: bool,
+    pub(crate) migrate_incoming_allowed_peers: bool,
     pub(crate) migrate_address_book: bool,
     pub(crate) migrate_legacy_managed_services: bool,
     pub(crate) touched_paths: Vec<PathBuf>,

--- a/crates/config-migrate/src/services.rs
+++ b/crates/config-migrate/src/services.rs
@@ -217,6 +217,7 @@ fn migrate_legacy_service_manifest(
                 CurrentServiceManifestEntry {
                     target: None,
                     port: Some(port.service_port),
+                    host_port: (port.host_port != 0).then_some(port.host_port),
                     protocol: (port.protocol != LegacyServicePortProtocol::Tcp)
                         .then_some(port.protocol),
                     usage,
@@ -396,7 +397,7 @@ struct LegacyServiceMount {
 struct LegacyServicePort {
     name: Option<String>,
     #[serde(rename = "host_port")]
-    _host_port: u16,
+    host_port: u16,
     service_port: u16,
     protocol: LegacyServicePortProtocol,
 }
@@ -498,6 +499,9 @@ struct CurrentServiceManifestEntry {
     target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     port: Option<u16>,
+    #[serde(rename = "hostPort")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    host_port: Option<u16>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     protocol: Option<LegacyServicePortProtocol>,

--- a/crates/config-migrate/src/tests.rs
+++ b/crates/config-migrate/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     model::{
         BACKUP_ROOT_DIR, CONFIG_FILE, CURRENT_SERVICE_STATE_SCHEMA_VERSION, DATA_ROOT_DIR,
         DEVICES_FILE, LEGACY_ADDRESS_BOOK_FILE, LEGACY_SERVICE_STATE_FILE, SERVICES_ROOT_DIR,
-        STAGING_DIR_PREFIX,
+        STAGING_DIR_PREFIX, TRUSTED_DEVICES_FILE,
     },
 };
 use serde_json::json;
@@ -147,13 +147,18 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
 #[test]
 fn migration_removes_legacy_incoming_allowed_peers_from_config() {
     let dir = TempDir::new().unwrap();
+    let root_peer = "12D3KooWQW1nMmgC9R2j8uF1pL7dV7cP8xN3d8X7p4hYt3QwD8YV";
+    let network_peer = "12D3KooWJGXfQ3X6E3FJxMeYpPvVhDhxDBBkYDpAJrYaHsxkUTdT";
     fs::write(
         dir.path().join(CONFIG_FILE),
-        concat!(
-            "incoming_allowed_peers = [\"16Uiu2HAmUSNEhHAAhJsWZU16U8kaBqqXwCPbty8q243amnT2FWe8\"]\n",
-            "\n",
-            "[rpc]\n",
-            "listen_address = \"127.0.0.1:6601\"\n",
+        format!(
+            "incoming_allowed_peers = [\"{root_peer}\"]\n\
+             \n\
+             [rpc]\n\
+             listen_address = \"127.0.0.1:6601\"\n\
+             \n\
+             [network]\n\
+             incoming_allowed_peers = [\"{network_peer}\", \"{root_peer}\"]\n",
         ),
     )
     .unwrap();
@@ -161,9 +166,67 @@ fn migration_removes_legacy_incoming_allowed_peers_from_config() {
     let report = migrate_if_needed(dir.path()).unwrap();
 
     assert!(report.changed);
+    assert_eq!(
+        report.migrated_paths,
+        vec![
+            PathBuf::from(CONFIG_FILE),
+            PathBuf::from(TRUSTED_DEVICES_FILE),
+        ]
+    );
     let migrated_config = fs::read_to_string(dir.path().join(CONFIG_FILE)).unwrap();
     assert!(migrated_config.contains("version = 2"));
     assert!(!migrated_config.contains("incoming_allowed_peers"));
+
+    let trusted_value: toml::Value =
+        toml::from_str(&fs::read_to_string(dir.path().join(TRUSTED_DEVICES_FILE)).unwrap())
+            .unwrap();
+    let trusted_devices = trusted_value
+        .as_table()
+        .and_then(|table| table.get("trusted_devices"))
+        .and_then(toml::Value::as_array)
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(trusted_devices, vec![network_peer, root_peer]);
+}
+
+#[test]
+fn migration_merges_legacy_incoming_allowed_peers_into_existing_trusted_devices_file() {
+    let dir = TempDir::new().unwrap();
+    let existing_peer = "12D3KooWQW1nMmgC9R2j8uF1pL7dV7cP8xN3d8X7p4hYt3QwD8YV";
+    let new_peer = "12D3KooWJGXfQ3X6E3FJxMeYpPvVhDhxDBBkYDpAJrYaHsxkUTdT";
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        format!(
+            "version = 2\n\
+             \n\
+             [network]\n\
+             incoming_allowed_peers = [\"{existing_peer}\", \"{new_peer}\"]\n",
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(TRUSTED_DEVICES_FILE),
+        format!("trusted_devices = [\"{existing_peer}\"]\n"),
+    )
+    .unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    let trusted_value: toml::Value =
+        toml::from_str(&fs::read_to_string(dir.path().join(TRUSTED_DEVICES_FILE)).unwrap())
+            .unwrap();
+    let trusted_devices = trusted_value
+        .as_table()
+        .and_then(|table| table.get("trusted_devices"))
+        .and_then(toml::Value::as_array)
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(trusted_devices, vec![new_peer, existing_peer]);
 }
 
 #[test]
@@ -351,6 +414,7 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
             .as_ref()
     );
     assert_eq!(manifest["spec"]["entries"]["http"]["port"], 80);
+    assert_eq!(manifest["spec"]["entries"]["http"]["hostPort"], 18080);
     assert_eq!(manifest["spec"]["entries"]["http"]["usage"], "web");
     assert_eq!(manifest["spec"]["entries"]["http"]["path"], "/");
     let mounts = manifest["spec"]["mounts"].as_sequence().unwrap();
@@ -380,6 +444,72 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
     let backup_dir = report.backup_dir.expect("backup dir should exist");
     assert!(backup_dir.join(LEGACY_SERVICE_STATE_FILE).is_file());
     assert!(backup_dir.join(SERVICES_ROOT_DIR).join("demo").is_dir());
+}
+
+#[test]
+fn migrates_legacy_service_state_without_host_port_when_legacy_port_was_auto() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        read_fixture("legacy-no-version-config.toml"),
+    )
+    .unwrap();
+
+    fs::write(
+        dir.path().join(LEGACY_SERVICE_STATE_FILE),
+        serde_json::to_string_pretty(&json!({
+            "schema_version": 1,
+            "updated_at": "2026-05-01T00:00:00Z",
+            "services": {
+                "demo": {
+                    "manifest": {
+                        "name": "demo",
+                        "runtime": "wasmtime",
+                        "source": {
+                            "WasmtimeUrl": {
+                                "url": "https://example.com/demo.wasm"
+                            }
+                        },
+                        "expose": null,
+                        "env": {},
+                        "mounts": [],
+                        "ports": [
+                            {
+                                "name": "http",
+                                "host_port": 0,
+                                "service_port": 80,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "command": [],
+                        "entrypoint": [],
+                        "working_dir": null,
+                        "labels": {}
+                    },
+                    "desired_state": "stopped"
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    migrate_if_needed(dir.path()).unwrap();
+
+    let service_entries = fs::read_dir(dir.path().join(SERVICES_ROOT_DIR))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().unwrap().is_dir())
+        .collect::<Vec<_>>();
+    assert_eq!(service_entries.len(), 1);
+    let manifest_yaml = fs::read_to_string(service_entries[0].path().join("service.yaml")).unwrap();
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_yaml).unwrap();
+    assert_eq!(manifest["spec"]["entries"]["http"]["port"], 80);
+    assert!(
+        manifest["spec"]["entries"]["http"]
+            .get("hostPort")
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/config-migrate/src/tests.rs
+++ b/crates/config-migrate/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{
     CURRENT_FUNGI_DIR_VERSION, DetectedVersion,
+    apply::MigrationTransaction,
     detection::detect_source_version_from_toml_str,
     migrate_if_needed,
     model::{
@@ -65,7 +66,7 @@ fn current_version_is_a_noop() {
 }
 
 #[test]
-fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files() {
+fn migrates_legacy_config_transactionally_and_keeps_full_backup_snapshot() {
     let dir = TempDir::new().unwrap();
     fs::write(
         dir.path().join(CONFIG_FILE),
@@ -126,9 +127,19 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
         fs::read_to_string(backup_dir.join(CONFIG_FILE)).unwrap(),
         original_config
     );
-    assert!(!backup_dir.join("devices.toml").exists());
-    assert!(!backup_dir.join("access").exists());
-    assert!(!backup_dir.join("cache").exists());
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("devices.toml")).unwrap(),
+        "version = \"0.6.1\"\n[devices]\n"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("access").join("local_access.json")).unwrap(),
+        "{\n  \"version\": 1,\n  \"entries\": []\n}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("cache").join("direct_addresses.json")).unwrap(),
+        "{\n  \"version\": 1,\n  \"addresses\": []\n}\n"
+    );
+    assert!(!backup_dir.join(BACKUP_ROOT_DIR).exists());
 
     assert!(report.staging_dir.is_none());
     let staging_count = fs::read_dir(dir.path())
@@ -142,6 +153,33 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
         })
         .count();
     assert_eq!(staging_count, 0);
+}
+
+#[test]
+fn migration_transaction_prepare_allocates_fresh_backup_dirs() {
+    let dir = TempDir::new().unwrap();
+
+    let first =
+        MigrationTransaction::prepare(dir.path(), &DetectedVersion::LegacyNoVersion, 7).unwrap();
+    let second =
+        MigrationTransaction::prepare(dir.path(), &DetectedVersion::LegacyNoVersion, 7).unwrap();
+
+    assert_ne!(first.backup_dir, second.backup_dir);
+    assert_ne!(first.staging_dir, second.staging_dir);
+    assert!(first.backup_dir.is_dir());
+    assert!(second.backup_dir.is_dir());
+    assert!(first.staging_dir.is_dir());
+    assert!(second.staging_dir.is_dir());
+    assert!(
+        first
+            .backup_dir
+            .starts_with(dir.path().join(BACKUP_ROOT_DIR))
+    );
+    assert!(
+        second
+            .backup_dir
+            .starts_with(dir.path().join(BACKUP_ROOT_DIR))
+    );
 }
 
 #[test]

--- a/fungi/tests/migrate_cli.rs
+++ b/fungi/tests/migrate_cli.rs
@@ -1,14 +1,15 @@
 use std::{
     fs,
+    net::{TcpListener, UdpSocket},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, ChildStdin, Command, Stdio},
     sync::OnceLock,
     thread,
     time::{Duration, Instant},
 };
 
-use fungi_config::{FungiConfig, devices::DevicesConfig};
-use fungi_daemon::{ServiceSource, load_service_manifest_yaml_file};
+use fungi_config::{FungiConfig, devices::DevicesConfig, trusted_devices::TrustedDevicesConfig};
+use fungi_daemon::{ServicePortAllocation, ServiceSource, load_service_manifest_yaml_file};
 use libp2p::PeerId;
 use serde_json::json;
 use tempfile::TempDir;
@@ -215,6 +216,253 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(second_migrate.stdout.contains("already at version 2"));
 }
 
+#[test]
+#[ignore = "integration test runs the v0.6.1 release daemon and current daemon; run explicitly with `cargo test -p fungi --test migrate_cli -- --ignored --nocapture`"]
+fn cli_migrate_preserves_v061_daemon_cli_written_config_and_service_state() {
+    let home = TempDir::new().unwrap();
+    let payload = TempDir::new().unwrap();
+    let legacy = legacy_fungi_bin();
+    let current = current_fungi_bin();
+
+    run_cli(legacy, home.path(), &["init"]);
+    configure_legacy_daemon_ports(home.path());
+
+    let peer_id = PeerId::random().to_string();
+    let listen_port = reserve_tcp_port();
+    let forward_port = reserve_tcp_port();
+    let allowed_port = reserve_tcp_port();
+    let service_host_port = reserve_tcp_port();
+    let legacy_service_dir = home.path().join("services").join("cli-demo");
+    fs::create_dir_all(legacy_service_dir.join("mount")).unwrap();
+    fs::write(legacy_service_dir.join("component.wasm"), b"wasm").unwrap();
+    fs::write(
+        legacy_service_dir.join("mount").join("state.txt"),
+        b"persist",
+    )
+    .unwrap();
+    let manifest_path = payload.path().join("cli-demo-service.yaml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"apiVersion: fungi.rs/v1alpha1
+kind: ServiceManifest
+metadata:
+  name: cli-demo
+  labels:
+    release-test: "1"
+spec:
+  runtime: wasmtime
+  source:
+    file: $APP_HOME/component.wasm
+  expose:
+    enabled: true
+    serviceId: cli-demo-service
+    displayName: CLI Demo
+    transport:
+      kind: tcp
+    usage:
+      kind: web
+      path: /ui
+    iconUrl: https://example.com/icon.png
+    catalogId: example/cli-demo
+  ports:
+    - name: http
+      hostPort: {service_host_port}
+      servicePort: 8080
+      protocol: tcp
+  mounts:
+    - hostPath: $APP_HOME/mount
+      runtimePath: /data
+  command:
+    - --demo
+  entrypoint: []
+  workingDir: $APP_HOME/mount
+"#
+        ),
+    )
+    .unwrap();
+
+    {
+        let _daemon = start_daemon(legacy, home.path());
+        run_cli(legacy, home.path(), &["security", "allow-path", "/tmp"]);
+        run_cli(
+            legacy,
+            home.path(),
+            &["security", "allow-port", &allowed_port.to_string()],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &["security", "allow-range", "19100", "19110"],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &[
+                "security",
+                "allowed-peers",
+                "add",
+                "--alias",
+                "demo-peer",
+                &peer_id,
+            ],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &["tunnel", "add-listen", &format!("127.0.0.1:{listen_port}")],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &[
+                "tunnel",
+                "add-forward",
+                &format!("127.0.0.1:{forward_port}"),
+                &peer_id,
+                &listen_port.to_string(),
+            ],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &["ft-client", "add", "--name", "files", "--enabled", &peer_id],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &[
+                "ft-client",
+                "ftp-update",
+                "--enabled",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "2122",
+            ],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &[
+                "ft-client",
+                "webdav-update",
+                "--enabled",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8182",
+            ],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &["service", "pull", manifest_path.to_str().unwrap()],
+        );
+    }
+
+    let legacy_config = fs::read_to_string(home.path().join("config.toml")).unwrap();
+    assert!(legacy_config.contains("incoming_allowed_peers"));
+    assert!(legacy_config.contains("allowed_ports"));
+    assert!(home.path().join("address_book.toml").exists());
+    assert!(home.path().join("services-state.json").exists());
+
+    let migrate_output = run_cli(current, home.path(), &["migrate"]);
+    assert!(migrate_output.stdout.contains("Migrated Fungi"));
+
+    let migrated_config_raw = fs::read_to_string(home.path().join("config.toml")).unwrap();
+    assert!(migrated_config_raw.contains("version = 2"));
+    assert!(!migrated_config_raw.contains("incoming_allowed_peers"));
+    assert!(!migrated_config_raw.contains("allowed_ports"));
+    assert!(!migrated_config_raw.contains("allowed_port_ranges"));
+    assert!(!migrated_config_raw.contains(&home.path().join("services").display().to_string()));
+    assert!(migrated_config_raw.contains("\"/tmp\""));
+
+    let config = FungiConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(config.version, 2);
+    assert_eq!(
+        config.runtime.allowed_host_paths,
+        vec![PathBuf::from("/tmp")]
+    );
+    assert_eq!(config.tcp_tunneling.listening.rules.len(), 1);
+    assert_eq!(config.tcp_tunneling.listening.rules[0].port, listen_port);
+    assert_eq!(config.tcp_tunneling.forwarding.rules.len(), 1);
+    assert_eq!(
+        config.tcp_tunneling.forwarding.rules[0].local_port,
+        forward_port
+    );
+    assert_eq!(config.file_transfer.client.len(), 1);
+    assert_eq!(
+        config.file_transfer.client[0].name.as_deref(),
+        Some("files")
+    );
+    assert!(config.file_transfer.client[0].enabled);
+    assert_eq!(config.file_transfer.client[0].peer_id.to_string(), peer_id);
+    assert!(config.file_transfer.proxy_ftp.enabled);
+    assert_eq!(config.file_transfer.proxy_ftp.port, 2122);
+    assert!(config.file_transfer.proxy_webdav.enabled);
+    assert_eq!(config.file_transfer.proxy_webdav.port, 8182);
+
+    let trusted = TrustedDevicesConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(trusted.trusted_devices.len(), 1);
+    assert_eq!(trusted.trusted_devices[0].to_string(), peer_id);
+
+    let devices = DevicesConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(devices.devices.len(), 1);
+    assert_eq!(devices.devices[0].peer_id.to_string(), peer_id);
+    assert_eq!(devices.devices[0].name.as_deref(), Some("demo-peer"));
+    assert!(!home.path().join("address_book.toml").exists());
+
+    assert!(!home.path().join("services-state.json").exists());
+    let service_entries = fs::read_dir(home.path().join("services"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().unwrap().is_dir())
+        .collect::<Vec<_>>();
+    assert_eq!(service_entries.len(), 1);
+    let local_service_id = service_entries[0].file_name().to_string_lossy().to_string();
+    assert!(local_service_id.starts_with("svc_"));
+    assert!(!home.path().join("services").join("cli-demo").exists());
+
+    let data_dir = home.path().join("data").join(&local_service_id);
+    assert!(data_dir.join("component.wasm").is_file());
+    assert_eq!(
+        fs::read_to_string(data_dir.join("mount").join("state.txt")).unwrap(),
+        "persist"
+    );
+
+    let migrated_manifest_path = home
+        .path()
+        .join("services")
+        .join(&local_service_id)
+        .join("service.yaml");
+    let migrated_manifest_yaml = fs::read_to_string(&migrated_manifest_path).unwrap();
+    assert!(migrated_manifest_yaml.contains(&format!("hostPort: {service_host_port}")));
+    assert!(!migrated_manifest_yaml.contains(&legacy_service_dir.display().to_string()));
+
+    let manifest = load_service_manifest_yaml_file(&migrated_manifest_path, home.path()).unwrap();
+    assert_eq!(manifest.name, "cli-demo");
+    assert_eq!(manifest.ports[0].host_port, service_host_port);
+    assert_eq!(
+        manifest.ports[0].host_port_allocation,
+        ServicePortAllocation::Fixed
+    );
+    assert_eq!(manifest.mounts[0].host_path, data_dir.join("mount"));
+    match &manifest.source {
+        ServiceSource::WasmtimeFile { component } => {
+            assert_eq!(component, &data_dir.join("component.wasm"));
+        }
+        other => panic!("unexpected migrated manifest source: {other:?}"),
+    }
+
+    {
+        let _daemon = start_daemon(current, home.path());
+        let inspect = run_cli(current, home.path(), &["service", "inspect", "cli-demo"]);
+        assert!(inspect.stdout.contains("\"name\": \"cli-demo\""));
+        assert!(inspect.stdout.contains("\"running\": false"));
+    }
+}
+
 fn current_fungi_bin() -> &'static Path {
     Path::new(env!("CARGO_BIN_EXE_fungi"))
 }
@@ -303,6 +551,85 @@ struct CliOutput {
     stdout: String,
 }
 
+struct RunningDaemon {
+    child: Child,
+    _stdin: ChildStdin,
+}
+
+impl Drop for RunningDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn configure_legacy_daemon_ports(fungi_dir: &Path) {
+    let config_path = fungi_dir.join("config.toml");
+    let rpc_port = reserve_tcp_port();
+    let tcp_port = reserve_tcp_port();
+    let udp_port = reserve_udp_port();
+    let content = fs::read_to_string(&config_path).unwrap();
+    let content = content
+        .replace(
+            "listen_address = \"127.0.0.1:5405\"",
+            &format!("listen_address = \"127.0.0.1:{rpc_port}\""),
+        )
+        .replace(
+            "listen_tcp_port = 0",
+            &format!("listen_tcp_port = {tcp_port}"),
+        )
+        .replace(
+            "listen_udp_port = 0",
+            &format!("listen_udp_port = {udp_port}"),
+        );
+    fs::write(config_path, content).unwrap();
+}
+
+fn reserve_tcp_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn reserve_udp_port() -> u16 {
+    UdpSocket::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn start_daemon(binary: &Path, fungi_dir: &Path) -> RunningDaemon {
+    let mut child = Command::new(binary)
+        .arg("--fungi-dir")
+        .arg(fungi_dir)
+        .arg("daemon")
+        .arg("--exit-on-stdin-close")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.take().unwrap();
+    let daemon = RunningDaemon {
+        child,
+        _stdin: stdin,
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if try_run_cli(binary, fungi_dir, &["info", "version"]).is_some() {
+            return daemon;
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon did not become ready");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 fn run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> CliOutput {
     let mut child = Command::new(binary)
         .arg("--fungi-dir")
@@ -337,4 +664,20 @@ fn run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> CliOutput {
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+fn try_run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> Option<CliOutput> {
+    let output = Command::new(binary)
+        .arg("--fungi-dir")
+        .arg(fungi_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(CliOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+    })
 }


### PR DESCRIPTION
## Summary

- migrate legacy `incoming_allowed_peers` from `config.toml` into `trusted_devices.toml`
- remove legacy incoming allowlist fields from both root and `[network]` config tables during migration
- preserve non-zero legacy service `host_port` as new manifest `hostPort`, while omitting `hostPort` for legacy auto-port `0`
- expand migration tests with a real v0.6.1 daemon/CLI flow that writes security, tunnel, ft-client, and service state before migrating

## Why

This is release migration hardening for the breaking config changes after v0.6.1. The previous migration path covered address book and service layout changes, but missed incoming peer trust migration and a host-port preservation edge case.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p fungi-config-migrate`
- `cargo test -p fungi-config`
- `cargo test -p fungi --test migrate_cli`
- `cargo test -p fungi --test migrate_cli -- --ignored --nocapture`

