### PR TITLE
[codex] Simplify service help copy

### DIFF
--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -54,7 +54,7 @@ pub struct ServiceArgs {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum ServiceCommands {
-    /// List services on this device or another device
+    /// List services
     List {
         /// Show detailed output
         #[arg(short, long, default_value_t = false)]
@@ -63,7 +63,7 @@ pub enum ServiceCommands {
         #[arg(long, default_value_t = false)]
         refresh: bool,
     },
-    /// Apply a service file to this device or another device
+    /// Apply a service file
     Apply {
         /// Service instance target to create or update
         #[arg(value_name = "NAME[@DEVICE]")]
@@ -112,11 +112,11 @@ pub enum ServiceCommands {
     Disconnect { service: String },
     /// Change a service setting
     Set { service: String, setting: String },
-    /// Start a service by name on this device or another device
+    /// Start a service
     Start { name: String },
-    /// Stop a service by name on this device or another device
+    /// Stop a service
     Stop { name: String },
-    /// Inspect a service by name on this device or another device
+    /// Inspect a service
     Inspect {
         name: String,
         /// Show detailed output
@@ -129,7 +129,7 @@ pub enum ServiceCommands {
         #[arg(long)]
         tail: Option<String>,
     },
-    /// Remove a service by name from this device or another device
+    /// Remove a service
     Remove {
         name: String,
         /// Remove only the local cached record for a device service

--- a/fungi/src/commands/fungi_control/shared.rs
+++ b/fungi/src/commands/fungi_control/shared.rs
@@ -26,7 +26,7 @@ pub struct OptionalDeviceTargetArg {
         short = 'd',
         long = "device",
         value_name = "DEVICE",
-        help = "Device name"
+        help = "Target device name"
     )]
     pub device: Option<DeviceInput>,
 }

--- a/fungi/src/commands/mod.rs
+++ b/fungi/src/commands/mod.rs
@@ -82,7 +82,7 @@ pub enum Commands {
     /// Manage runtime safety boundary settings
     #[command(subcommand, visible_alias = "sec")]
     Security(fungi_control::SecurityCommands),
-    /// Manage services on this device or another device
+    /// Manage services
     #[command(visible_alias = "svc")]
     Service(fungi_control::ServiceArgs),
     /// Browse published remote services

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -702,6 +702,7 @@ fn service_help_hides_pull_shortcut_from_main_path() {
     assert!(help.contains("  open"));
     assert!(help.contains("  connect"));
     assert!(!help.contains("  pull"));
+    assert!(!help.contains("on this device or another device"));
 }
 
 #[test]
@@ -714,6 +715,7 @@ fn service_command_help_prefers_device_language() {
 
     assert!(help.contains("--device <DEVICE>"));
     assert!(help.contains("-d"));
+    assert!(help.contains("Target device name"));
     assert!(!help.contains("--on"));
     assert!(!help.contains("--peer"));
     assert!(!help.contains("Peer ID"));


### PR DESCRIPTION
## Summary

- shorten `fungi service` and service subcommand help text so the target-device story is not repeated on every row
- make `--device <DEVICE>` carry the target-device explanation in one place
- add command help assertions to keep the repeated phrase out of the main service help

## Validation

- `cargo run -q -p fungi -- service -h`
- `cargo test -p fungi --test commands service_help_hides_pull_shortcut_from_main_path -- --nocapture`
- `cargo test -p fungi --test commands service_command_help_prefers_device_language -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`