### PR TITLE
Skip UDP prepare before relay circuit dial

### DIFF
--- a/crates/swarm/src/libp2p/control.rs
+++ b/crates/swarm/src/libp2p/control.rs
@@ -304,7 +304,9 @@ impl SwarmControl {
             return Err(ConnectError::NoDialAddresses { peer_id });
         }
         let relay_addresses = self.relay_peers.circuit_addresses_for_target(peer_id);
-        self.prepare_for_relay_fallback(peer_id).await;
+        log::debug!(
+            "Dialing relay circuit addresses for peer {peer_id} without UDP prepare refresh"
+        );
         self.dial_with_addresses(peer_id, relay_addresses, PeerCondition::Always)
             .await
     }

--- a/crates/swarm/src/libp2p/relay.rs
+++ b/crates/swarm/src/libp2p/relay.rs
@@ -31,7 +31,6 @@ const RELAY_RETRY_FAST_ATTEMPTS: u32 = 4;
 const RELAY_RETRY_BASE_DELAY_MS: u64 = 500;
 const RELAY_RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
 const RELAY_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(600);
-const RELAY_PREPARE_REFRESH_GRACE_WINDOW: Duration = Duration::from_millis(800);
 const RELAY_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(2);
 
 struct TaskGuard {
@@ -444,63 +443,6 @@ impl SwarmControl {
 
         self.refresh_external_addresses_via_relays(preferred_relay)
             .await
-    }
-
-    async fn send_prepare_refresh_notification(
-        &self,
-        relay_peer: PeerId,
-        target_peer: PeerId,
-    ) -> Result<()> {
-        self.invoke_swarm(move |swarm| {
-            swarm
-                .behaviour_mut()
-                .send_relay_refresh(&relay_peer, target_peer)
-        })
-        .await?;
-
-        Ok(())
-    }
-
-    pub(super) async fn prepare_for_relay_fallback(&self, target_peer: PeerId) {
-        let local_refresh_started = self.trigger_external_address_refresh(None).await;
-        let mut remote_refresh_requested = false;
-
-        for relay_peer in self.relay_peers.peer_ids().iter().copied() {
-            // prepare-refresh rides on the existing TCP relay reservation. If
-            // that carrier is down, the relay management loop is responsible
-            // for rebuilding it; this path should not create extra relay dials.
-            if !self.state().relay_tcp_ready(relay_peer) {
-                log::debug!(
-                    "Skipping prepare-refresh via relay {} because no healthy TCP reservation is active",
-                    relay_peer
-                );
-                continue;
-            }
-
-            match self
-                .send_prepare_refresh_notification(relay_peer, target_peer)
-                .await
-            {
-                Ok(()) => {
-                    remote_refresh_requested = true;
-                    break;
-                }
-                Err(error) => {
-                    log::debug!(
-                        "Relay {} prepare-refresh notify for target {} failed: {}",
-                        relay_peer,
-                        target_peer,
-                        error
-                    );
-                }
-            }
-        }
-
-        if local_refresh_started || remote_refresh_requested {
-            // TODO: Replace this fixed grace window with an event-driven wait for a new or
-            // refreshed UDP external address candidate.
-            tokio::time::sleep(RELAY_PREPARE_REFRESH_GRACE_WINDOW).await;
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

This stopgap removes the UDP prepare step from the pure relay circuit dial path. Relay fallback now dials the configured relay circuit addresses directly instead of first triggering local UDP address refresh and remote prepare-refresh notification.

## Why

In a strict-NAT relay-only environment, the old prepare step could destabilize the target peer's TCP relay reservation/listener exactly while the controller was dialing the relay circuit. The observed failure mode was a relayed connection that appeared established, followed by probe/service streams failing or hanging.

This PR keeps TCP relay fallback stable first. A separate follow-up can experiment with UDP-first relay reservations and TCP fallback without mixing durable TCP relay carrier state with observer-only UDP refresh state.

## Changes

- Stop calling `prepare_for_relay_fallback()` before dialing relay circuit addresses.
- Remove the now-unused prepare helper and grace-window constant.
- Leave relay refresh handling intact for future experiments and existing relay-refresh behavior.

## Validation

- `cargo fmt --check`
- `cargo test -p fungi-swarm`
- `cargo check --workspace`
