### PR TITLE
Simplify remote service snapshot access model

### DIFF
--- a/crates/config/src/tcp_tunneling.rs
+++ b/crates/config/src/tcp_tunneling.rs
@@ -26,7 +26,8 @@ pub struct ForwardingRule {
     pub remote_peer_id: String,
     #[serde(default)]
     pub remote_protocol: Option<String>,
-    pub remote_port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_port: Option<u16>,
     #[serde(default)]
     pub remote_service_id: Option<String>,
     #[serde(default)]

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -657,12 +657,8 @@ fn merge_device_service_snapshot(
         services_by_name
             .entry(service.name.clone())
             .and_modify(|existing| {
-                existing.usage = service.usage.clone();
-                existing.icon_url = service.icon_url.clone();
+                existing.metadata = service.metadata.clone();
                 existing.endpoints = service.endpoints.clone();
-                if existing.ports.is_empty() {
-                    existing.ports = service.ports.clone();
-                }
             })
             .or_insert(service);
     }
@@ -678,9 +674,7 @@ fn device_service_from_instance(instance: ServiceInstance) -> DeviceService {
     DeviceService {
         name: instance.name,
         runtime: instance.runtime,
-        usage: None,
-        icon_url: None,
-        ports: instance.ports,
+        metadata: Default::default(),
         endpoints: Vec::new(),
         status: instance.status,
     }
@@ -736,9 +730,14 @@ mod tests {
         assert_eq!(service.status.phase, ServicePhase::Running);
         assert_eq!(service.endpoints.len(), 1);
         assert_eq!(
-            service.usage.as_ref().unwrap().kind,
+            service.metadata.usage.as_ref().unwrap().kind,
             ServiceExposeUsageKind::Web
         );
+        let snapshot_json = serde_json::to_value(&snapshot).unwrap();
+        let service_json = &snapshot_json["services"][0];
+        assert!(service_json.get("ports").is_none());
+        assert!(service_json["endpoints"][0].get("service_port").is_none());
+        assert!(service_json["endpoints"][0].get("host_port").is_none());
     }
 
     #[test]
@@ -785,9 +784,7 @@ mod tests {
             services: vec![DeviceService {
                 name: "svc-a".to_string(),
                 runtime: RuntimeKind::External,
-                usage: None,
-                icon_url: None,
-                ports: Vec::new(),
+                metadata: Default::default(),
                 endpoints: Vec::new(),
                 status: ServiceStatus::running(),
             }],
@@ -839,17 +836,16 @@ mod tests {
         DeviceService {
             name: name.to_string(),
             runtime: RuntimeKind::External,
-            usage: Some(ServiceExposeUsage {
-                kind: ServiceExposeUsageKind::Web,
-                path: Some("/".to_string()),
-            }),
-            icon_url: Some("https://example.test/icon.svg".to_string()),
-            ports: vec![service_port("web")],
+            metadata: crate::DeviceServiceMetadata {
+                usage: Some(ServiceExposeUsage {
+                    kind: ServiceExposeUsageKind::Web,
+                    path: Some("/".to_string()),
+                }),
+                icon_url: Some("https://example.test/icon.svg".to_string()),
+            },
             endpoints: vec![DeviceServiceEndpoint {
                 name: "web".to_string(),
                 protocol: format!("/fungi/service/{name}/web/0.2.0"),
-                host_port: 18080,
-                service_port: 8080,
             }],
             status,
         }

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -30,14 +30,13 @@ impl FungiDaemon {
         &self,
         record: &LocalServicePreference,
         remote_protocol: String,
-        remote_port: u16,
     ) -> Result<String> {
         let rule = ForwardingRule {
             local_host: record.local_host.clone(),
             local_port: record.local_port,
             remote_peer_id: record.remote_peer_id.clone(),
             remote_protocol: Some(remote_protocol),
-            remote_port,
+            remote_port: 0,
             remote_service_id: None,
             remote_service_name: Some(record.remote_service_name.clone()),
             remote_service_port_name: Some(record.remote_service_port_name.clone()),
@@ -50,7 +49,6 @@ impl FungiDaemon {
         record: &LocalServicePreference,
         endpoint: &DeviceServiceEndpoint,
     ) -> Result<()> {
-        let remote_port = device_service_endpoint_listen_port(endpoint);
         let existing_active_rule = find_active_rule(
             &self.get_service_access_forwarding_rules(),
             &record.remote_peer_id,
@@ -61,7 +59,6 @@ impl FungiDaemon {
         let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
             rule.local_host == record.local_host
                 && rule.local_port == record.local_port
-                && rule.remote_port == remote_port
                 && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
         });
         if active_rule_matches {
@@ -75,7 +72,7 @@ impl FungiDaemon {
         }
 
         match self
-            .start_service_access_forwarding_rule(record, endpoint.protocol.clone(), remote_port)
+            .start_service_access_forwarding_rule(record, endpoint.protocol.clone())
             .await
         {
             Ok(_) => Ok(()),
@@ -153,7 +150,6 @@ impl FungiDaemon {
         }
 
         for endpoint in endpoints {
-            let remote_port = device_service_endpoint_listen_port(&endpoint);
             let existing_record = local_preferences
                 .find_record(&peer_id_string, &service.name, &endpoint.name)
                 .cloned();
@@ -174,9 +170,7 @@ impl FungiDaemon {
             let selected_local_port = match (local_port, existing_record.as_ref()) {
                 (Some(local_port), _) => local_port,
                 (None, Some(record)) => record.local_port,
-                (None, None) => {
-                    allocate_preferred_local_port(endpoint.service_port, &reserved_local_ports)?
-                }
+                (None, None) => allocate_free_local_port(&reserved_local_ports)?,
             };
             let local_port_source = if local_port.is_some() {
                 LocalPortSource::User
@@ -190,7 +184,6 @@ impl FungiDaemon {
             let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
                 rule.local_host == "127.0.0.1"
                     && rule.local_port == selected_local_port
-                    && rule.remote_port == remote_port
                     && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
             });
             let active_rule_owns_selected_port =
@@ -223,11 +216,7 @@ impl FungiDaemon {
                 }
 
                 match self
-                    .start_service_access_forwarding_rule(
-                        &record,
-                        endpoint.protocol.clone(),
-                        remote_port,
-                    )
+                    .start_service_access_forwarding_rule(&record, endpoint.protocol.clone())
                     .await
                 {
                     Ok(rule_id) => started_rule_id = Some(rule_id),
@@ -269,7 +258,7 @@ impl FungiDaemon {
                 protocol: endpoint.protocol,
                 local_host: record.local_host,
                 local_port: record.local_port,
-                remote_port,
+                remote_port: 0,
             });
         }
 
@@ -575,14 +564,6 @@ fn find_active_rule(
         .cloned()
 }
 
-fn device_service_endpoint_listen_port(endpoint: &DeviceServiceEndpoint) -> u16 {
-    if endpoint.host_port == 0 {
-        endpoint.service_port
-    } else {
-        endpoint.host_port
-    }
-}
-
 fn ensure_local_port_available(port: u16, reserved_ports: &BTreeSet<u16>) -> Result<()> {
     if reserved_ports.contains(&port) {
         bail!(
@@ -595,17 +576,7 @@ fn ensure_local_port_available(port: u16, reserved_ports: &BTreeSet<u16>) -> Res
         .map_err(|error| anyhow::anyhow!("local port {} is not available: {}", port, error))
 }
 
-fn allocate_preferred_local_port(
-    preferred_port: u16,
-    reserved_ports: &BTreeSet<u16>,
-) -> Result<u16> {
-    if preferred_port != 0
-        && !reserved_ports.contains(&preferred_port)
-        && StdTcpListener::bind(("127.0.0.1", preferred_port)).is_ok()
-    {
-        return Ok(preferred_port);
-    }
-
+fn allocate_free_local_port(reserved_ports: &BTreeSet<u16>) -> Result<u16> {
     for _ in 0..32 {
         let listener = StdTcpListener::bind(("127.0.0.1", 0))?;
         let port = listener.local_addr()?.port();

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -36,7 +36,7 @@ impl FungiDaemon {
             local_port: record.local_port,
             remote_peer_id: record.remote_peer_id.clone(),
             remote_protocol: Some(remote_protocol),
-            remote_port: 0,
+            remote_port: None,
             remote_service_id: None,
             remote_service_name: Some(record.remote_service_name.clone()),
             remote_service_port_name: Some(record.remote_service_port_name.clone()),
@@ -258,7 +258,6 @@ impl FungiDaemon {
                 protocol: endpoint.protocol,
                 local_host: record.local_host,
                 local_port: record.local_port,
-                remote_port: 0,
             });
         }
 
@@ -519,7 +518,6 @@ impl FungiDaemon {
                     protocol: String::new(),
                     local_host: record.local_host,
                     local_port: record.local_port,
-                    remote_port: 0,
                 });
         }
 

--- a/crates/daemon/src/api/types.rs
+++ b/crates/daemon/src/api/types.rs
@@ -161,6 +161,4 @@ pub struct ServiceAccessEndpoint {
     pub protocol: String,
     pub local_host: String,
     pub local_port: u16,
-    #[serde(default)]
-    pub remote_port: u16,
 }

--- a/crates/daemon/src/controls/tcp_tunneling/tcp_tunneling_control.rs
+++ b/crates/daemon/src/controls/tcp_tunneling/tcp_tunneling_control.rs
@@ -81,12 +81,13 @@ impl TcpTunnelingControl {
             .parse()
             .map_err(|e| anyhow::anyhow!("Invalid peer ID: {}", e))?;
 
-        let target_protocol = StreamProtocol::try_from_owned(
-            rule.remote_protocol
-                .clone()
-                .unwrap_or_else(|| format!("{}/{}", FUNGI_TUNNEL_PROTOCOL, rule.remote_port)),
-        )
-        .map_err(|e| anyhow::anyhow!("Invalid protocol: {}", e))?;
+        let target_protocol_name = match (&rule.remote_protocol, rule.remote_port) {
+            (Some(remote_protocol), _) => remote_protocol.clone(),
+            (None, Some(remote_port)) => format!("{FUNGI_TUNNEL_PROTOCOL}/{remote_port}"),
+            (None, None) => bail!("Forwarding rule requires a remote protocol or remote port"),
+        };
+        let target_protocol = StreamProtocol::try_from_owned(target_protocol_name)
+            .map_err(|e| anyhow::anyhow!("Invalid protocol: {}", e))?;
 
         let swarm_control = self.swarm_control.clone();
 
@@ -240,10 +241,16 @@ impl TcpTunnelingControl {
                 rule.remote_peer_id,
                 sanitize_rule_component(remote_protocol),
             ),
-            None => format!(
-                "forward_{}:{}_to_{}_{}",
-                rule.local_host, rule.local_port, rule.remote_peer_id, rule.remote_port
-            ),
+            None => match rule.remote_port {
+                Some(remote_port) => format!(
+                    "forward_{}:{}_to_{}_{}",
+                    rule.local_host, rule.local_port, rule.remote_peer_id, remote_port
+                ),
+                None => format!(
+                    "forward_{}:{}_to_{}_missing-target",
+                    rule.local_host, rule.local_port, rule.remote_peer_id
+                ),
+            },
         }
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -24,14 +24,14 @@ pub use recipes::{
     ResolvedServiceRecipe, ServiceRecipeDetail, ServiceRecipeRuntime, ServiceRecipeSummary,
 };
 pub use runtime::{
-    DeviceService, DeviceServiceEndpoint, DeviceServiceSnapshot, ManifestResolutionPolicy,
-    RuntimeControl, RuntimeKind, ServiceExpose, ServiceExposeEndpointBinding,
-    ServiceExposeTransport, ServiceExposeTransportKind, ServiceExposeUsage, ServiceExposeUsageKind,
-    ServiceInstance, ServiceLogs, ServiceLogsOptions, ServiceManifest, ServiceMount, ServicePhase,
-    ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceRunMode, ServiceSource,
-    ServiceStatus, load_service_manifest_yaml_file, parse_service_manifest_yaml,
-    peek_service_manifest_name, service_expose_endpoint_bindings,
-    service_manifest_with_instance_name,
+    DeviceService, DeviceServiceEndpoint, DeviceServiceMetadata, DeviceServiceSnapshot,
+    ManifestResolutionPolicy, RuntimeControl, RuntimeKind, ServiceExpose,
+    ServiceExposeEndpointBinding, ServiceExposeTransport, ServiceExposeTransportKind,
+    ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance, ServiceLogs, ServiceLogsOptions,
+    ServiceManifest, ServiceMount, ServicePhase, ServicePort, ServicePortAllocation,
+    ServicePortProtocol, ServiceRunMode, ServiceSource, ServiceStatus,
+    load_service_manifest_yaml_file, parse_service_manifest_yaml, peek_service_manifest_name,
+    service_expose_endpoint_bindings, service_manifest_with_instance_name,
 };
 pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -419,16 +419,15 @@ impl RuntimeControl {
             services.push(DeviceService {
                 name: manifest.name.clone(),
                 runtime: manifest.runtime,
-                usage: expose.usage,
-                icon_url: expose.icon_url,
-                ports: manifest.ports.clone(),
+                metadata: crate::DeviceServiceMetadata {
+                    usage: expose.usage,
+                    icon_url: expose.icon_url,
+                },
                 endpoints: service_expose_endpoint_bindings(&manifest)
                     .into_iter()
                     .map(|endpoint| DeviceServiceEndpoint {
                         name: endpoint.name,
                         protocol: endpoint.protocol,
-                        host_port: endpoint.host_port,
-                        service_port: endpoint.service_port,
                     })
                     .collect(),
                 status: instance.status,

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -251,22 +251,23 @@ pub struct DeviceServiceSnapshot {
 pub struct DeviceService {
     pub name: String,
     pub runtime: RuntimeKind,
-    pub usage: Option<ServiceExposeUsage>,
-    pub icon_url: Option<String>,
     #[serde(default)]
-    pub ports: Vec<ServicePort>,
+    pub metadata: DeviceServiceMetadata,
     #[serde(default)]
     pub endpoints: Vec<DeviceServiceEndpoint>,
     pub status: ServiceStatus,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeviceServiceMetadata {
+    pub usage: Option<ServiceExposeUsage>,
+    pub icon_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceServiceEndpoint {
     pub name: String,
     pub protocol: String,
-    #[serde(default)]
-    pub host_port: u16,
-    pub service_port: u16,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 use clap::{Args, Subcommand};
 use fungi_config::{FungiConfig, FungiDir, paths::FungiPaths};
 use fungi_daemon::{
-    DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceAccess, ServiceExposeEndpointBinding,
-    ServiceExposeUsageKind, ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus,
-    parse_service_manifest_yaml, service_manifest_with_instance_name,
+    DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
+    ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus, parse_service_manifest_yaml,
+    service_manifest_with_instance_name,
 };
 use fungi_daemon_grpc::{
     Request,
@@ -185,8 +185,8 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
         ServiceCommands::List { verbose, refresh } => {
             if let Some(device) = device {
                 print_target_device(&device);
-                let instances = list_remote_service_instances(&mut client, &device.peer_id).await;
-                print_service_instances_value(instances, verbose);
+                let services = list_remote_services(&mut client, &device.peer_id).await;
+                print_remote_services_value(services, verbose);
             } else {
                 print_service_overview(&mut client, verbose, service_args.refresh || refresh).await;
             }
@@ -316,9 +316,9 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
             let device = resolve_service_device_target(&args, device, target.device);
             if let Some(device) = device {
                 print_target_device(&device);
-                let instance =
+                let service =
                     inspect_remote_service(&mut client, &device.peer_id, target.name).await;
-                print_service_instance_value(instance, verbose);
+                print_remote_service_inspect_value(service, verbose);
             } else {
                 let req = ServiceNameRequest {
                     runtime: 0,
@@ -1339,48 +1339,17 @@ async fn list_local_service_instances(client: &mut RpcClient) -> Vec<ServiceInst
     }
 }
 
-async fn list_saved_devices(client: &mut RpcClient) -> Vec<DeviceInfo> {
-    match client.list_devices(Request::new(Empty {})).await {
-        Ok(resp) => resp.into_inner().devices,
-        Err(error) => fatal_grpc(error),
-    }
-}
-
-async fn list_remote_service_instances(
-    client: &mut RpcClient,
-    peer_id: &str,
-) -> Vec<ServiceInstance> {
+async fn list_remote_services(client: &mut RpcClient, peer_id: &str) -> Vec<RemoteService> {
     match fetch_device_service_snapshot(client, peer_id, true).await {
-        Ok(snapshot) => snapshot
-            .snapshot
-            .services
-            .into_iter()
-            .map(device_service_to_instance)
-            .collect(),
+        Ok(snapshot) => snapshot.snapshot.services,
         Err(error) => fatal(error),
     }
 }
 
-fn device_service_to_instance(service: DeviceService) -> ServiceInstance {
-    ServiceInstance {
-        id: format!("remote:{}", service.name),
-        runtime: service.runtime,
-        name: service.name,
-        definition_id: None,
-        source: String::new(),
-        labels: Default::default(),
-        ports: Vec::new(),
-        exposed_endpoints: service
-            .endpoints
-            .into_iter()
-            .map(|endpoint| ServiceExposeEndpointBinding {
-                name: endpoint.name,
-                protocol: endpoint.protocol,
-                host_port: 0,
-                service_port: 0,
-            })
-            .collect(),
-        status: service.status,
+async fn list_saved_devices(client: &mut RpcClient) -> Vec<DeviceInfo> {
+    match client.list_devices(Request::new(Empty {})).await {
+        Ok(resp) => resp.into_inner().devices,
+        Err(error) => fatal_grpc(error),
     }
 }
 
@@ -1440,12 +1409,16 @@ async fn inspect_remote_service(
     client: &mut RpcClient,
     peer_id: &str,
     name: String,
-) -> ServiceInstance {
-    list_remote_service_instances(client, peer_id)
-        .await
-        .into_iter()
-        .find(|instance| instance.name == name)
-        .unwrap_or_else(|| fatal(format!("Remote service not found: {name}")))
+) -> RemoteService {
+    match fetch_device_service_snapshot(client, peer_id, true).await {
+        Ok(snapshot) => snapshot
+            .snapshot
+            .services
+            .into_iter()
+            .find(|service| service.name == name)
+            .unwrap_or_else(|| fatal(format!("Remote service not found: {name}"))),
+        Err(error) => fatal(error),
+    }
 }
 
 async fn list_accesses(client: &mut RpcClient, peer_id: &str) -> Vec<ServiceAccess> {
@@ -2000,6 +1973,29 @@ fn manifest_parse_fungi_home(args: &CommonArgs) -> std::path::PathBuf {
     }
 }
 
+struct ExistingService {
+    runtime: RuntimeKind,
+    definition_id: Option<String>,
+}
+
+impl From<ServiceInstance> for ExistingService {
+    fn from(service: ServiceInstance) -> Self {
+        Self {
+            runtime: service.runtime,
+            definition_id: service.definition_id,
+        }
+    }
+}
+
+impl From<RemoteService> for ExistingService {
+    fn from(service: RemoteService) -> Self {
+        Self {
+            runtime: service.runtime,
+            definition_id: None,
+        }
+    }
+}
+
 async fn confirm_apply_if_existing(
     client: &mut RpcClient,
     device: Option<&super::shared::ResolvedPeerTarget>,
@@ -2009,14 +2005,16 @@ async fn confirm_apply_if_existing(
 ) {
     let (service_name, new_runtime, new_definition_id) = manifest_apply_identity(created, args);
     let existing = match device {
-        Some(device) => list_remote_service_instances(client, &device.peer_id)
+        Some(device) => list_remote_services(client, &device.peer_id)
             .await
             .into_iter()
-            .find(|service| service.name == service_name),
+            .find(|service| service.name == service_name)
+            .map(ExistingService::from),
         None => list_local_service_instances(client)
             .await
             .into_iter()
-            .find(|service| service.name == service_name),
+            .find(|service| service.name == service_name)
+            .map(ExistingService::from),
     };
 
     let Some(existing) = existing else {
@@ -2078,7 +2076,7 @@ async fn confirm_apply_if_existing(
 
 fn reject_definition_id_mismatch(
     service_name: &str,
-    existing: &ServiceInstance,
+    existing: &ExistingService,
     new_definition_id: Option<&str>,
 ) {
     match (existing.definition_id.as_deref(), new_definition_id) {
@@ -2094,7 +2092,7 @@ fn reject_definition_id_mismatch(
 
 fn print_existing_apply_notice(
     service_name: &str,
-    existing: &ServiceInstance,
+    existing: &ExistingService,
     new_runtime: RuntimeKind,
     new_definition_id: Option<&str>,
 ) {
@@ -2254,6 +2252,18 @@ fn print_service_instance_value(instance: ServiceInstance, verbose: bool) {
     }
 }
 
+fn print_remote_service_inspect_value(service: RemoteService, verbose: bool) {
+    let pretty = if verbose {
+        serde_json::to_string_pretty(&RemoteServiceInspectVerboseView::from(service))
+    } else {
+        serde_json::to_string_pretty(&RemoteServiceInspectView::from(service))
+    };
+    match pretty {
+        Ok(pretty) => println!("{}", pretty),
+        Err(error) => fatal(format!("Failed to format remote service: {error}")),
+    }
+}
+
 fn decode_service_instance(resp: ServiceInstanceResponse) -> ServiceInstance {
     match serde_json::from_str::<ServiceInstance>(&resp.instance_json) {
         Ok(instance) => instance,
@@ -2261,23 +2271,23 @@ fn decode_service_instance(resp: ServiceInstanceResponse) -> ServiceInstance {
     }
 }
 
-fn print_service_instances_value(services: Vec<ServiceInstance>, verbose: bool) {
+fn print_remote_services_value(services: Vec<RemoteService>, verbose: bool) {
     let pretty = if verbose {
         let views = services
             .into_iter()
-            .map(LocalServiceListVerboseEntry::from)
+            .map(RemoteServiceListVerboseEntry::from)
             .collect::<Vec<_>>();
         serde_json::to_string_pretty(&views)
     } else {
         let views = services
             .into_iter()
-            .map(LocalServiceListEntry::from)
+            .map(RemoteServiceListEntry::from)
             .collect::<Vec<_>>();
         serde_json::to_string_pretty(&views)
     };
     match pretty {
         Ok(pretty) => println!("{}", pretty),
-        Err(error) => fatal(format!("Failed to format service list: {error}")),
+        Err(error) => fatal(format!("Failed to format remote service list: {error}")),
     }
 }
 
@@ -2508,6 +2518,7 @@ fn resolved_device_display_name(device: &super::shared::ResolvedPeerTarget) -> S
         .unwrap_or_else(|| device.peer_id.clone())
 }
 
+#[cfg(test)]
 #[derive(Debug, Serialize)]
 struct LocalServiceListEntry {
     service_name: String,
@@ -2518,13 +2529,24 @@ struct LocalServiceListEntry {
 }
 
 #[derive(Debug, Serialize)]
-struct LocalServiceListVerboseEntry {
+struct RemoteServiceListEntry {
     service_name: String,
-    runtime: RuntimeKind,
     phase: ServicePhase,
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
-    local_endpoints: Vec<LocalServiceEndpointVerboseView>,
+    entries: Vec<ServiceEntryView>,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteServiceListVerboseEntry {
+    service_name: String,
+    runtime: RuntimeKind,
+    #[serde(skip_serializing_if = "device_service_metadata_is_empty")]
+    metadata: fungi_daemon::DeviceServiceMetadata,
+    phase: ServicePhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    entries: Vec<RemoteServiceEntryVerboseView>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2552,8 +2574,35 @@ struct LocalServiceInspectVerboseView {
 }
 
 #[derive(Debug, Serialize)]
+struct RemoteServiceInspectView {
+    name: String,
+    phase: ServicePhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    entries: Vec<ServiceEntryView>,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteServiceInspectVerboseView {
+    name: String,
+    runtime: RuntimeKind,
+    #[serde(skip_serializing_if = "device_service_metadata_is_empty")]
+    metadata: fungi_daemon::DeviceServiceMetadata,
+    phase: ServicePhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    entries: Vec<RemoteServiceEntryVerboseView>,
+}
+
+#[derive(Debug, Serialize)]
 struct ServiceEntryView {
     name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteServiceEntryVerboseView {
+    name: String,
+    protocol: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -2574,6 +2623,11 @@ struct PublishedEndpointVerboseView {
     service_port: u16,
 }
 
+fn device_service_metadata_is_empty(metadata: &fungi_daemon::DeviceServiceMetadata) -> bool {
+    metadata.usage.is_none() && metadata.icon_url.is_none()
+}
+
+#[cfg(test)]
 impl From<ServiceInstance> for LocalServiceListEntry {
     fn from(instance: ServiceInstance) -> Self {
         let entries = local_entry_views(&instance);
@@ -2587,16 +2641,41 @@ impl From<ServiceInstance> for LocalServiceListEntry {
     }
 }
 
-impl From<ServiceInstance> for LocalServiceListVerboseEntry {
-    fn from(instance: ServiceInstance) -> Self {
-        let local_endpoints = local_endpoint_verbose_views(&instance);
-        let status = instance.status;
+impl From<RemoteService> for RemoteServiceListEntry {
+    fn from(service: RemoteService) -> Self {
+        let status = service.status;
         Self {
-            service_name: instance.name,
-            runtime: instance.runtime,
+            service_name: service.name,
             phase: status.phase,
             detail: status.detail,
-            local_endpoints,
+            entries: service
+                .endpoints
+                .into_iter()
+                .map(|endpoint| ServiceEntryView {
+                    name: Some(endpoint.name),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<RemoteService> for RemoteServiceListVerboseEntry {
+    fn from(service: RemoteService) -> Self {
+        let status = service.status;
+        Self {
+            service_name: service.name,
+            runtime: service.runtime,
+            metadata: service.metadata,
+            phase: status.phase,
+            detail: status.detail,
+            entries: service
+                .endpoints
+                .into_iter()
+                .map(|endpoint| RemoteServiceEntryVerboseView {
+                    name: endpoint.name,
+                    protocol: endpoint.protocol,
+                })
+                .collect(),
         }
     }
 }
@@ -2643,6 +2722,45 @@ impl From<ServiceInstance> for LocalServiceInspectVerboseView {
                     local_host: "127.0.0.1".to_string(),
                     local_port: endpoint.host_port,
                     service_port: endpoint.service_port,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<RemoteService> for RemoteServiceInspectView {
+    fn from(service: RemoteService) -> Self {
+        let status = service.status;
+        Self {
+            name: service.name,
+            phase: status.phase,
+            detail: status.detail,
+            entries: service
+                .endpoints
+                .into_iter()
+                .map(|endpoint| ServiceEntryView {
+                    name: Some(endpoint.name),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<RemoteService> for RemoteServiceInspectVerboseView {
+    fn from(service: RemoteService) -> Self {
+        let status = service.status;
+        Self {
+            name: service.name,
+            runtime: service.runtime,
+            metadata: service.metadata,
+            phase: status.phase,
+            detail: status.detail,
+            entries: service
+                .endpoints
+                .into_iter()
+                .map(|endpoint| RemoteServiceEntryVerboseView {
+                    name: endpoint.name,
+                    protocol: endpoint.protocol,
                 })
                 .collect(),
         }
@@ -2833,6 +2951,26 @@ mod tests {
     }
 
     #[test]
+    fn remote_service_inspect_view_omits_port_fields() {
+        let service = remote_web_service("/dashboard");
+
+        let view = RemoteServiceInspectVerboseView::from(service);
+        let json = serde_json::to_value(view).unwrap();
+        let text = serde_json::to_string(&json).unwrap();
+
+        assert_eq!(json["entries"][0]["name"], "web");
+        assert_eq!(
+            json["entries"][0]["protocol"],
+            "/fungi/service/demo/web/0.2.0"
+        );
+        assert!(json.get("published_endpoints").is_none());
+        assert!(!text.contains("local_port"));
+        assert!(!text.contains("service_port"));
+        assert!(!text.contains("remote_port"));
+        assert!(!text.contains("host_port"));
+    }
+
+    #[test]
     fn remote_managed_overview_row_keeps_stopped_state() {
         let mut instance = service_instance(vec![service_port("web", 28080)]);
         instance.status = ServiceStatus::exited(None);
@@ -2992,7 +3130,6 @@ publish:
             protocol: format!("/fungi/service/demo/{name}/0.2.0"),
             local_host: "127.0.0.1".to_string(),
             local_port,
-            remote_port: local_port,
         }
     }
 

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -1369,15 +1369,15 @@ fn device_service_to_instance(service: DeviceService) -> ServiceInstance {
         definition_id: None,
         source: String::new(),
         labels: Default::default(),
-        ports: service.ports,
+        ports: Vec::new(),
         exposed_endpoints: service
             .endpoints
             .into_iter()
             .map(|endpoint| ServiceExposeEndpointBinding {
                 name: endpoint.name,
                 protocol: endpoint.protocol,
-                host_port: endpoint.host_port,
-                service_port: endpoint.service_port,
+                host_port: 0,
+                service_port: 0,
             })
             .collect(),
         status: service.status,
@@ -1575,7 +1575,7 @@ fn build_web_url(
     entry: Option<&str>,
 ) -> Option<String> {
     if !matches!(
-        service.usage.as_ref().map(|usage| usage.kind),
+        service.metadata.usage.as_ref().map(|usage| usage.kind),
         Some(ServiceExposeUsageKind::Web)
     ) {
         return None;
@@ -1584,6 +1584,7 @@ fn build_web_url(
     let endpoint = select_access_endpoint(access, entry)?;
     let mut value = format!("http://{}:{}", endpoint.local_host, endpoint.local_port);
     if let Some(path) = service
+        .metadata
         .usage
         .as_ref()
         .and_then(|usage| usage.path.as_deref())
@@ -1606,7 +1607,7 @@ fn open_or_print_remote_service(
     entry: Option<&str>,
 ) {
     if matches!(
-        service.usage.as_ref().map(|usage| usage.kind),
+        service.metadata.usage.as_ref().map(|usage| usage.kind),
         Some(ServiceExposeUsageKind::Web)
     ) {
         let Some(url) = build_web_url(service, access, entry) else {
@@ -1620,7 +1621,12 @@ fn open_or_print_remote_service(
     let Some(endpoint) = select_access_endpoint(access, entry) else {
         fatal("No connectable entry is available for this service")
     };
-    print_access_details(access, endpoint, device_name, service.usage.as_ref());
+    print_access_details(
+        access,
+        endpoint,
+        device_name,
+        service.metadata.usage.as_ref(),
+    );
 }
 
 fn print_access_details(
@@ -1630,15 +1636,14 @@ fn print_access_details(
     usage: Option<&fungi_daemon::ServiceExposeUsage>,
 ) {
     let usage = service_usage_label(usage);
-    let remote_port = format_remote_port(endpoint.remote_port);
     println!("{}@{}", access.service_name, device_name);
     println!("type: {usage}");
     println!("state: connected");
     println!();
     println!("forward:");
     println!(
-        "  {}  {}:{} -> {}:{}",
-        endpoint.name, endpoint.local_host, endpoint.local_port, device_name, remote_port
+        "  {}  {}:{} -> {}",
+        endpoint.name, endpoint.local_host, endpoint.local_port, device_name
     );
     println!();
     println!("local address:");
@@ -2333,32 +2338,16 @@ impl ServiceOverviewRow {
                 .endpoints
                 .iter()
                 .map(|endpoint| {
-                    let remote_port = service
-                        .endpoints
-                        .iter()
-                        .find(|remote_endpoint| remote_endpoint.name == endpoint.name)
-                        .map(|remote_endpoint| remote_endpoint.service_port)
-                        .unwrap_or(endpoint.remote_port);
-                    let remote_port = format_remote_port(remote_port);
                     format!(
-                        "{} {}:{} -> {}:{}",
-                        endpoint.name,
-                        endpoint.local_host,
-                        endpoint.local_port,
-                        device_name,
-                        remote_port
+                        "{} {}:{} -> {}",
+                        endpoint.name, endpoint.local_host, endpoint.local_port, device_name
                     )
                 })
                 .collect(),
             None => service
                 .endpoints
                 .iter()
-                .map(|endpoint| {
-                    format!(
-                        "{} remote:{}:{}",
-                        endpoint.name, device_name, endpoint.service_port
-                    )
-                })
+                .map(|endpoint| format!("{} remote:{}", endpoint.name, device_name))
                 .collect(),
         };
 
@@ -2366,7 +2355,7 @@ impl ServiceOverviewRow {
             reference: format!("{}@{}", service.name, device_name),
             device: device_name,
             kind: "remote".to_string(),
-            usage: service_usage_label(service.usage.as_ref()).to_string(),
+            usage: service_usage_label(service.metadata.usage.as_ref()).to_string(),
             state: overview_state_label(&service.status),
             entries,
             note: saved_access.map(|_| "local address saved".to_string()),
@@ -2389,20 +2378,9 @@ impl ServiceOverviewRow {
                 .endpoints
                 .iter()
                 .map(|endpoint| {
-                    let remote_port = service
-                        .ports
-                        .iter()
-                        .find(|port| port.name.as_deref().unwrap_or("main") == endpoint.name)
-                        .map(|port| port.service_port)
-                        .unwrap_or(endpoint.remote_port);
-                    let remote_port = format_remote_port(remote_port);
                     format!(
-                        "{} {}:{} -> {}:{}",
-                        endpoint.name,
-                        endpoint.local_host,
-                        endpoint.local_port,
-                        device_name,
-                        remote_port
+                        "{} {}:{} -> {}",
+                        endpoint.name, endpoint.local_host, endpoint.local_port, device_name
                     )
                 })
                 .collect(),
@@ -2411,7 +2389,7 @@ impl ServiceOverviewRow {
                 .iter()
                 .map(|port| {
                     let name = port.name.clone().unwrap_or_else(|| "main".to_string());
-                    format!("{name} remote:{}:{}", device_name, port.service_port)
+                    format!("{name} remote:{}", device_name)
                 })
                 .collect(),
         };
@@ -2528,14 +2506,6 @@ fn resolved_device_display_name(device: &super::shared::ResolvedPeerTarget) -> S
                 .cloned()
         })
         .unwrap_or_else(|| device.peer_id.clone())
-}
-
-fn format_remote_port(port: u16) -> String {
-    if port == 0 {
-        "?".to_string()
-    } else {
-        port.to_string()
-    }
 }
 
 #[derive(Debug, Serialize)]
@@ -2875,7 +2845,7 @@ mod tests {
         assert_eq!(row.kind, "remote");
         assert_eq!(row.usage, "web");
         assert_eq!(row.state, "exited");
-        assert_eq!(row.entries, vec!["web remote:nas:80"]);
+        assert_eq!(row.entries, vec!["web remote:nas"]);
     }
 
     #[test]
@@ -3030,17 +3000,16 @@ publish:
         RemoteService {
             name: "demo".to_string(),
             runtime: RuntimeKind::Docker,
-            usage: Some(ServiceExposeUsage {
-                kind: ServiceExposeUsageKind::Web,
-                path: Some(path.to_string()),
-            }),
-            icon_url: None,
-            ports: vec![service_port("web", 28080)],
+            metadata: fungi_daemon::DeviceServiceMetadata {
+                usage: Some(ServiceExposeUsage {
+                    kind: ServiceExposeUsageKind::Web,
+                    path: Some(path.to_string()),
+                }),
+                icon_url: None,
+            },
             endpoints: vec![DeviceServiceEndpoint {
                 name: "web".to_string(),
                 protocol: "/fungi/service/demo/web/0.2.0".to_string(),
-                host_port: 28080,
-                service_port: 80,
             }],
             status: ServiceStatus::running(),
         }


### PR DESCRIPTION
## Summary

This PR removes remote port details from the control-side device service snapshot. Remote service access now depends on named libp2p protocol entries only, and optional display metadata is grouped under a dedicated `metadata` object.

This intentionally replaces draft PR #41. Once snapshot `ports` are removed, there is no longer a port-only snapshot state to special-case during startup restore.

## Changes

- Remove `DeviceService.ports` from remote device service snapshots.
- Replace top-level `usage` / `icon_url` with `DeviceServiceMetadata { usage, icon_url }`.
- Simplify `DeviceServiceEndpoint` to `name + protocol`; remove `host_port` and `service_port`.
- Stop using remote service ports to choose local forwarding ports. New service access records allocate a free local port unless the user chose one or an existing local preference is present.
- Remove `ServiceAccessEndpoint.remote_port`; service access records now expose only local access details plus the libp2p protocol entry.
- Stop adapting remote services into local `ServiceInstance` views. Remote list/inspect output now uses remote-specific views and does not show port fields.
- Keep `runtime` required on `DeviceService`; it still uses the existing `RuntimeKind` enum (`Docker`, `Wasmtime`, `External`).

## Design Notes

The control side should not need to know where a remote service really listens. The remote daemon owns that mapping:

```text
/fungi/service-port/<service>/<entry>/... -> remote local service port
```

The controller only needs:

```text
peer_id + service_name + entry_name + libp2p protocol string
```

Service access forwarding rules now model this directly: protocol-based service access uses `remote_protocol` and no remote port placeholder. Port-based forwarding remains available only for the lower-level generic tunnel path.

This is a breaking cache/schema change. No compatibility migration is included.

## Validation

- `cargo fmt --check`
- `cargo check -p fungi-daemon -p fungi`
- `cargo check --workspace`
- `cargo test -p fungi-daemon api::runtime::tests`
- `cargo test -p fungi-daemon service_access`
- `cargo test -p fungi-daemon`
- `cargo test -p fungi`
- `cargo test -p fungi commands::fungi_control::service::tests`
