### PR TITLE
[codex] Require explicit local service shortcuts

### DIFF
--- a/crates/config/src/devices.rs
+++ b/crates/config/src/devices.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 pub const DEFAULT_DEVICES_CONFIG_FILE: &str = "devices.toml";
+pub const LOCAL_DEVICE_NAME: &str = "local";
 const MDNS_DEVICE_TIMEOUT_SECONDS: u64 = 3600; // 60 minutes
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -266,6 +267,11 @@ impl DevicesConfig {
         if trimmed.is_empty() {
             return Err(anyhow::anyhow!("Name cannot be empty"));
         }
+        if Self::normalize_name(trimmed) == LOCAL_DEVICE_NAME {
+            return Err(anyhow::anyhow!(
+                "Device name `{LOCAL_DEVICE_NAME}` is reserved for the local device"
+            ));
+        }
         Ok(trimmed.to_string())
     }
 
@@ -485,6 +491,31 @@ mod tests {
         };
 
         assert!(config.add_or_update_device(device_info).is_err());
+    }
+
+    #[test]
+    fn test_add_peer_rejects_reserved_local_name_case_insensitive() {
+        let (config, _temp_dir) = create_temp_devices_config();
+        let device_info = DeviceInfo {
+            peer_id: PeerId::random(),
+            name: Some(" Local ".to_string()),
+            hostname: Some("host1".to_string()),
+            multiaddrs: vec![],
+            os: Os::this_device(),
+            public_ip: None,
+            private_ips: vec![],
+            version: "1.0.0".to_string(),
+            created_at: SystemTime::now(),
+            last_connected: SystemTime::now(),
+        };
+
+        let error = config.add_or_update_device(device_info).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Device name `local` is reserved"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/fungi/src/commands/fungi_control/device.rs
+++ b/fungi/src/commands/fungi_control/device.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use fungi_config::devices::DevicesConfig;
 use fungi_daemon_grpc::{
     Request,
     fungi_daemon_grpc::{
@@ -129,6 +130,8 @@ pub async fn execute_device(args: CommonArgs, device_args: DeviceArgs) {
         }
         _ => {}
     }
+
+    validate_device_command_before_connect(&cmd);
 
     let mut client = match get_rpc_client(&args).await {
         Some(c) => c,
@@ -297,6 +300,17 @@ pub async fn execute_device(args: CommonArgs, device_args: DeviceArgs) {
                 Err(e) => fatal_grpc(e),
             }
         }
+    }
+}
+
+fn validate_device_command_before_connect(cmd: &DeviceCommands) {
+    match cmd {
+        DeviceCommands::Add { name, .. } | DeviceCommands::Rename { name, .. } => {
+            if let Err(error) = DevicesConfig::validate_name(name) {
+                fatal(error)
+            }
+        }
+        _ => {}
     }
 }
 

--- a/fungi/src/commands/fungi_control/mod.rs
+++ b/fungi/src/commands/fungi_control/mod.rs
@@ -19,8 +19,8 @@ pub use relay_config::{RelayCommands, execute_relay};
 pub use security::{SecurityCommands, execute_security};
 pub use service::{
     DynamicThingInvocation, DynamicThingTarget, ServiceArgs, ServiceCommands,
-    ServiceRecipeCommands, execute_dynamic_thing, execute_service, fatal_dynamic_builtin_typo,
-    parse_dynamic_thing_invocation, parse_dynamic_thing_target,
+    ServiceRecipeCommands, execute_dynamic_thing, execute_service, parse_dynamic_thing_invocation,
+    parse_dynamic_thing_target,
 };
 pub use shared::{DeviceInput, PeerInput};
 pub use trusted_devices::{TrustedDeviceCommands, execute_trusted_device};

--- a/fungi/src/commands/fungi_control/mod.rs
+++ b/fungi/src/commands/fungi_control/mod.rs
@@ -18,9 +18,9 @@ pub use ping::execute_ping;
 pub use relay_config::{RelayCommands, execute_relay};
 pub use security::{SecurityCommands, execute_security};
 pub use service::{
-    DynamicThingInvocation, DynamicThingTarget, ServiceArgs, ServiceCommands,
-    ServiceRecipeCommands, execute_dynamic_thing, execute_service, parse_dynamic_thing_invocation,
-    parse_dynamic_thing_target,
+    DynamicServiceInvocation, DynamicServiceTarget, ServiceArgs, ServiceCommands,
+    ServiceRecipeCommands, execute_dynamic_service, execute_service,
+    parse_dynamic_service_invocation, parse_dynamic_service_target,
 };
 pub use shared::{DeviceInput, PeerInput};
 pub use trusted_devices::{TrustedDeviceCommands, execute_trusted_device};

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use std::process::Command;
 
 use clap::{Args, Subcommand};
-use fungi_config::{FungiConfig, FungiDir, paths::FungiPaths};
+use fungi_config::{FungiDir, devices::LOCAL_DEVICE_NAME, paths::FungiPaths};
 use fungi_daemon::{
     DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
     ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus, parse_service_manifest_yaml,
@@ -615,43 +615,40 @@ pub struct DynamicThingInvocation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DynamicThingTarget {
     pub name: String,
+    pub local: bool,
     pub device: Option<DeviceInput>,
     pub entry: Option<String>,
 }
 
-pub async fn execute_dynamic_thing(
-    args: CommonArgs,
-    device_context: Option<DeviceInput>,
-    tokens: Vec<String>,
-) {
-    let invocation = parse_dynamic_thing_invocation(tokens.clone()).unwrap_or_else(|error| {
-        if let Some((name, command)) =
-            crate::commands::dynamic_builtin_typo_hint_for_tokens(&tokens, device_context.as_ref())
-        {
-            fatal_dynamic_builtin_typo(&name, &command)
-        }
-        fatal(error)
-    });
+pub async fn execute_dynamic_thing(args: CommonArgs, tokens: Vec<String>) {
+    if !tokens
+        .first()
+        .is_some_and(|token| dynamic_token_has_explicit_target(token))
+    {
+        crate::commands::exit_unknown_dynamic_subcommand(&tokens)
+    }
+
+    let invocation = parse_dynamic_thing_invocation(tokens).unwrap_or_else(|error| fatal(error));
 
     if invocation.target.name.starts_with(':') {
         fatal("Shortcuts are not implemented yet")
     }
 
-    if device_context.is_some() && invocation.target.device.is_some() {
-        fatal("Device specified twice. Use either -d <device> or thing@device.")
-    }
-
-    let device = invocation.target.device.or(device_context);
-    if device.is_none() {
-        open_dynamic_service_without_device(args, invocation.target.name, invocation.target.entry)
-            .await;
+    if invocation.target.local {
+        open_local_dynamic_service(args, invocation.target.name, invocation.target.entry).await;
         return;
     }
+
+    let Some(device) = invocation.target.device else {
+        crate::commands::exit_unknown_dynamic_subcommand(&[invocation.target.name])
+    };
 
     execute_service(
         args,
         ServiceArgs {
-            device: OptionalDeviceTargetArg { device },
+            device: OptionalDeviceTargetArg {
+                device: Some(device),
+            },
             refresh: false,
             command: Some(ServiceCommands::Open {
                 service: invocation.target.name,
@@ -660,6 +657,13 @@ pub async fn execute_dynamic_thing(
         },
     )
     .await;
+}
+
+fn dynamic_token_has_explicit_target(token: &str) -> bool {
+    token
+        .split_once('/')
+        .map_or(token, |(head, _)| head)
+        .contains('@')
 }
 
 pub fn parse_dynamic_thing_invocation(
@@ -676,8 +680,9 @@ pub fn parse_dynamic_thing_invocation(
         return Err(format!(
             "Unexpected argument `{unexpected}` after `{target}`.
 
-Dynamic service shortcuts accept one service target, for example:
+Dynamic service shortcuts accept one explicit service target, for example:
 
+  fungi filebrowser@local
   fungi filebrowser@nas
 
 Use `fungi service ...` for service subcommands."
@@ -704,30 +709,36 @@ pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, S
         None => (value, None),
     };
 
-    let (name, device) =
-        match name_and_device.split_once('@') {
-            Some((name, device)) => {
-                if name.trim().is_empty() {
-                    return Err("Thing name cannot be empty".to_string());
-                }
-                if device.trim().is_empty() {
-                    return Err("Device name cannot be empty".to_string());
-                }
-                if device.contains('@') {
-                    return Err("Thing target can only include one @device suffix".to_string());
-                }
+    let (name, local, device) = match name_and_device.split_once('@') {
+        Some((name, device)) => {
+            let device = device.trim();
+            if name.trim().is_empty() {
+                return Err("Thing name cannot be empty".to_string());
+            }
+            if device.is_empty() {
+                return Err("Device name cannot be empty".to_string());
+            }
+            if device.contains('@') {
+                return Err("Thing target can only include one @device suffix".to_string());
+            }
+            if device.eq_ignore_ascii_case(LOCAL_DEVICE_NAME) {
+                (name.to_string(), true, None)
+            } else {
                 (
                     name.to_string(),
+                    false,
                     Some(device.parse::<DeviceInput>().map_err(|error| {
                         format!("Invalid device in thing target {value}: {error}")
                     })?),
                 )
             }
-            None => (name_and_device.to_string(), None),
-        };
+        }
+        None => (name_and_device.to_string(), false, None),
+    };
 
     Ok(DynamicThingTarget {
         name,
+        local,
         device,
         entry,
     })
@@ -738,20 +749,6 @@ fn parse_service_reference(value: String) -> DynamicThingTarget {
     target
 }
 
-pub fn fatal_dynamic_builtin_typo(name: &str, command: &str) -> ! {
-    fatal(format!(
-        "No service named `{name}` was found.
-
-Hint: `{name}` looks like a built-in command typo.
-Did you mean:
-
-  fungi {command}
-
-For dynamic services, use:
-
-  fungi filebrowser@nas"
-    ))
-}
 async fn apply_service_from_recipe(
     client: &mut RpcClient,
     args: &CommonArgs,
@@ -1200,33 +1197,10 @@ async fn inspect_local_service(client: &mut RpcClient, name: String) -> ServiceI
     }
 }
 
-async fn open_dynamic_service_without_device(
-    args: CommonArgs,
-    service: String,
-    entry: Option<String>,
-) {
-    let builtin_hint = if entry.is_none() {
-        let tokens = [service.clone()];
-        crate::commands::dynamic_builtin_typo_hint_for_tokens(&tokens, None)
-            .map(|(_, command)| command)
-    } else {
-        None
-    };
-
-    if let Some(command) = builtin_hint.as_ref()
-        && FungiConfig::try_read_from_dir(&args.fungi_dir()).is_err()
-    {
-        fatal_dynamic_builtin_typo(&service, command)
-    }
-
+async fn open_local_dynamic_service(args: CommonArgs, service: String, entry: Option<String>) {
     let mut client = match get_rpc_client(&args).await {
         Some(c) => c,
-        None => {
-            if let Some(command) = builtin_hint {
-                fatal_dynamic_builtin_typo(&service, &command)
-            }
-            fatal("Cannot connect to Fungi daemon. Is it running?")
-        }
+        None => fatal("Cannot connect to Fungi daemon. Is it running?"),
     };
 
     if let Some(instance) = find_local_service(&mut client, &service).await {
@@ -1238,13 +1212,10 @@ async fn open_dynamic_service_without_device(
         return;
     }
 
-    if let Some(command) = builtin_hint {
-        fatal_dynamic_builtin_typo(&service, &command)
-    }
-
     fatal(format!(
         "Local service not found: {service}
-Remote services must be addressed explicitly with `fungi <service>@<device>` or `fungi service -d <device> open <service>`."
+Local services use `fungi <service>@local`.
+Remote services use `fungi <service>@<device>` or `fungi service -d <device> open <service>`."
     ));
 }
 async fn find_local_service(client: &mut RpcClient, service: &str) -> Option<ServiceInstance> {
@@ -3046,7 +3017,28 @@ mod tests {
         let target = parse_dynamic_thing_target("filebrowser@nas/admin".to_string()).unwrap();
 
         assert_eq!(target.name, "filebrowser");
+        assert!(!target.local);
         assert!(matches!(target.device, Some(DeviceInput::Name(name)) if name == "nas"));
+        assert_eq!(target.entry.as_deref(), Some("admin"));
+    }
+
+    #[test]
+    fn parse_dynamic_thing_target_supports_explicit_local_scope() {
+        let target = parse_dynamic_thing_target("filebrowser@local/admin".to_string()).unwrap();
+
+        assert_eq!(target.name, "filebrowser");
+        assert!(target.local);
+        assert!(target.device.is_none());
+        assert_eq!(target.entry.as_deref(), Some("admin"));
+    }
+
+    #[test]
+    fn parse_dynamic_thing_target_treats_local_scope_case_insensitively() {
+        let target = parse_dynamic_thing_target("filebrowser@Local/admin".to_string()).unwrap();
+
+        assert_eq!(target.name, "filebrowser");
+        assert!(target.local);
+        assert!(target.device.is_none());
         assert_eq!(target.entry.as_deref(), Some("admin"));
     }
 
@@ -3062,7 +3054,7 @@ mod tests {
         assert!(
             result
                 .unwrap_err()
-                .contains("Dynamic service shortcuts accept one service target")
+                .contains("Dynamic service shortcuts accept one explicit service target")
         );
     }
 
@@ -3105,7 +3097,6 @@ publish:
         let current_dir = std::env::current_dir().unwrap();
         let args = CommonArgs {
             fungi_dir: Some("target/tmp_a".to_string()),
-            dynamic_device: None,
             #[cfg(target_os = "android")]
             default_device_name: String::new(),
         };

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -608,19 +608,19 @@ fn looks_like_windows_drive_path(value: &str) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DynamicThingInvocation {
-    pub target: DynamicThingTarget,
+pub struct DynamicServiceInvocation {
+    pub target: DynamicServiceTarget,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DynamicThingTarget {
+pub struct DynamicServiceTarget {
     pub name: String,
     pub local: bool,
     pub device: Option<DeviceInput>,
     pub entry: Option<String>,
 }
 
-pub async fn execute_dynamic_thing(args: CommonArgs, tokens: Vec<String>) {
+pub async fn execute_dynamic_service(args: CommonArgs, tokens: Vec<String>) {
     if !tokens
         .first()
         .is_some_and(|token| dynamic_token_has_explicit_target(token))
@@ -628,7 +628,7 @@ pub async fn execute_dynamic_thing(args: CommonArgs, tokens: Vec<String>) {
         crate::commands::exit_unknown_dynamic_subcommand(&tokens)
     }
 
-    let invocation = parse_dynamic_thing_invocation(tokens).unwrap_or_else(|error| fatal(error));
+    let invocation = parse_dynamic_service_invocation(tokens).unwrap_or_else(|error| fatal(error));
 
     if invocation.target.name.starts_with(':') {
         fatal("Shortcuts are not implemented yet")
@@ -666,16 +666,16 @@ fn dynamic_token_has_explicit_target(token: &str) -> bool {
         .contains('@')
 }
 
-pub fn parse_dynamic_thing_invocation(
+pub fn parse_dynamic_service_invocation(
     mut tokens: Vec<String>,
-) -> Result<DynamicThingInvocation, String> {
+) -> Result<DynamicServiceInvocation, String> {
     if tokens.is_empty() {
-        return Err("Missing thing name".to_string());
+        return Err("Missing service name".to_string());
     }
 
     if tokens.len() > 1 {
         let target = tokens.remove(0);
-        parse_dynamic_thing_target(target.clone())?;
+        parse_dynamic_service_target(target.clone())?;
         let unexpected = &tokens[0];
         return Err(format!(
             "Unexpected argument `{unexpected}` after `{target}`.
@@ -689,14 +689,14 @@ Use `fungi service ...` for service subcommands."
         ));
     }
 
-    let target = parse_dynamic_thing_target(tokens.remove(0))?;
-    Ok(DynamicThingInvocation { target })
+    let target = parse_dynamic_service_target(tokens.remove(0))?;
+    Ok(DynamicServiceInvocation { target })
 }
 
-pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, String> {
+pub fn parse_dynamic_service_target(value: String) -> Result<DynamicServiceTarget, String> {
     let value = value.trim();
     if value.is_empty() {
-        return Err("Thing name cannot be empty".to_string());
+        return Err("Service name cannot be empty".to_string());
     }
 
     let (name_and_device, entry) = match value.split_once('/') {
@@ -713,13 +713,13 @@ pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, S
         Some((name, device)) => {
             let device = device.trim();
             if name.trim().is_empty() {
-                return Err("Thing name cannot be empty".to_string());
+                return Err("Service name cannot be empty".to_string());
             }
             if device.is_empty() {
                 return Err("Device name cannot be empty".to_string());
             }
             if device.contains('@') {
-                return Err("Thing target can only include one @device suffix".to_string());
+                return Err("Service target can only include one @device suffix".to_string());
             }
             if device.eq_ignore_ascii_case(LOCAL_DEVICE_NAME) {
                 (name.to_string(), true, None)
@@ -728,7 +728,7 @@ pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, S
                     name.to_string(),
                     false,
                     Some(device.parse::<DeviceInput>().map_err(|error| {
-                        format!("Invalid device in thing target {value}: {error}")
+                        format!("Invalid device in service target {value}: {error}")
                     })?),
                 )
             }
@@ -736,7 +736,7 @@ pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, S
         None => (name_and_device.to_string(), false, None),
     };
 
-    Ok(DynamicThingTarget {
+    Ok(DynamicServiceTarget {
         name,
         local,
         device,
@@ -744,8 +744,8 @@ pub fn parse_dynamic_thing_target(value: String) -> Result<DynamicThingTarget, S
     })
 }
 
-fn parse_service_reference(value: String) -> DynamicThingTarget {
-    let target = parse_dynamic_thing_target(value).unwrap_or_else(|error| fatal(error));
+fn parse_service_reference(value: String) -> DynamicServiceTarget {
+    let target = parse_dynamic_service_target(value).unwrap_or_else(|error| fatal(error));
     target
 }
 
@@ -1074,7 +1074,7 @@ async fn apply_created_service(
     }
 }
 
-fn reject_service_entry(target: &DynamicThingTarget, action: &str) {
+fn reject_service_entry(target: &DynamicServiceTarget, action: &str) {
     if target.entry.is_some() {
         fatal(format!("Entry-specific {action} is not implemented yet"))
     }
@@ -1755,7 +1755,7 @@ pub(crate) fn read_manifest_yaml_file(path: &str) -> CreatedServiceManifest {
 }
 
 fn create_tcp_service_interactively(
-    target: Option<DynamicThingTarget>,
+    target: Option<DynamicServiceTarget>,
     start_flag: bool,
 ) -> (String, Option<DeviceInput>, CreatedServiceManifest) {
     if let Some(target) = &target {
@@ -3013,8 +3013,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_dynamic_thing_target_supports_device_and_entry() {
-        let target = parse_dynamic_thing_target("filebrowser@nas/admin".to_string()).unwrap();
+    fn parse_dynamic_service_target_supports_device_and_entry() {
+        let target = parse_dynamic_service_target("filebrowser@nas/admin".to_string()).unwrap();
 
         assert_eq!(target.name, "filebrowser");
         assert!(!target.local);
@@ -3023,8 +3023,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_dynamic_thing_target_supports_explicit_local_scope() {
-        let target = parse_dynamic_thing_target("filebrowser@local/admin".to_string()).unwrap();
+    fn parse_dynamic_service_target_supports_explicit_local_scope() {
+        let target = parse_dynamic_service_target("filebrowser@local/admin".to_string()).unwrap();
 
         assert_eq!(target.name, "filebrowser");
         assert!(target.local);
@@ -3033,8 +3033,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_dynamic_thing_target_treats_local_scope_case_insensitively() {
-        let target = parse_dynamic_thing_target("filebrowser@Local/admin".to_string()).unwrap();
+    fn parse_dynamic_service_target_treats_local_scope_case_insensitively() {
+        let target = parse_dynamic_service_target("filebrowser@Local/admin".to_string()).unwrap();
 
         assert_eq!(target.name, "filebrowser");
         assert!(target.local);
@@ -3043,8 +3043,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_dynamic_thing_invocation_rejects_extra_args() {
-        let result = parse_dynamic_thing_invocation(vec![
+    fn parse_dynamic_service_invocation_rejects_extra_args() {
+        let result = parse_dynamic_service_invocation(vec![
             "rg@nas".to_string(),
             "todo".to_string(),
             "/data".to_string(),
@@ -3059,8 +3059,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_dynamic_thing_target_rejects_empty_device() {
-        let result = parse_dynamic_thing_target("filebrowser@".to_string());
+    fn parse_dynamic_service_target_rejects_empty_device() {
+        let result = parse_dynamic_service_target("filebrowser@".to_string());
 
         assert!(result.is_err());
     }

--- a/fungi/src/commands/mod.rs
+++ b/fungi/src/commands/mod.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use fungi_config::{FungiDir, default_fungi_dir_name};
-use fungi_control::DeviceInput;
 
 /// A platform built for seamless multi-device integration
 #[derive(Parser)]
@@ -28,14 +27,6 @@ pub struct CommonArgs {
         help = "Path to the Fungi config directory, defaults to the channel-specific directory"
     )]
     pub fungi_dir: Option<String>,
-
-    #[clap(
-        short = 'd',
-        long = "device",
-        value_name = "DEVICE",
-        help = "Device context for dynamic service shortcuts"
-    )]
-    pub dynamic_device: Option<DeviceInput>,
 
     #[cfg(target_os = "android")]
     #[clap(
@@ -115,100 +106,15 @@ pub enum Commands {
     Dynamic(Vec<String>),
 }
 
-pub fn dynamic_builtin_typo_hint_for_tokens(
-    tokens: &[String],
-    device_context: Option<&DeviceInput>,
-) -> Option<(String, String)> {
-    if device_context.is_some() || tokens.is_empty() {
-        return None;
-    }
-
-    let target = fungi_control::parse_dynamic_thing_target(tokens[0].clone()).ok()?;
-    if target.device.is_some() || target.entry.is_some() {
-        return None;
-    }
-
+pub fn exit_unknown_dynamic_subcommand(tokens: &[String]) -> ! {
+    let mut argv = Vec::with_capacity(tokens.len() + 1);
+    argv.push("fungi".to_string());
+    argv.extend(tokens.iter().cloned());
     let mut command = FungiArgs::command();
     command.build();
     let mut command = command.allow_external_subcommands(false);
-    let err = command
-        .try_get_matches_from_mut(["fungi", target.name.as_str()])
-        .err()?;
-    if err.kind() != clap::error::ErrorKind::InvalidSubcommand {
-        return None;
-    }
-
-    let suggestion = match err.get(clap::error::ContextKind::SuggestedSubcommand)? {
-        clap::error::ContextValue::String(value) => value.clone(),
-        clap::error::ContextValue::Strings(values) => values
-            .iter()
-            .min_by_key(|value| edit_distance(&target.name, value))
-            .cloned()?,
-        _ => return None,
-    };
-
-    Some((target.name, suggestion))
-}
-
-fn edit_distance(left: &str, right: &str) -> usize {
-    let left = left.as_bytes();
-    let right = right.as_bytes();
-    let mut previous: Vec<usize> = (0..=right.len()).collect();
-    let mut current = vec![0; right.len() + 1];
-
-    for (left_index, left_byte) in left.iter().enumerate() {
-        current[0] = left_index + 1;
-        for (right_index, right_byte) in right.iter().enumerate() {
-            let substitution = previous[right_index] + usize::from(left_byte != right_byte);
-            let insertion = current[right_index] + 1;
-            let deletion = previous[right_index + 1] + 1;
-            current[right_index + 1] = substitution.min(insertion).min(deletion);
-        }
-        std::mem::swap(&mut previous, &mut current);
-    }
-
-    previous[right.len()]
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dynamic_builtin_typo_hint_uses_clap_subcommand_suggestions() {
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(&["devices".to_string()], None),
-            Some(("devices".to_string(), "device".to_string()))
-        );
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(&["devic".to_string()], None),
-            Some(("devic".to_string(), "device".to_string()))
-        );
-    }
-
-    #[test]
-    fn dynamic_builtin_typo_hint_only_checks_unscoped_dynamic_targets() {
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(
-                &["devices".to_string(), "extra".to_string()],
-                None
-            ),
-            Some(("devices".to_string(), "device".to_string()))
-        );
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(&["devices@nas".to_string()], None),
-            None
-        );
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(
-                &["devices".to_string()],
-                Some(&DeviceInput::Name("nas".to_string()))
-            ),
-            None
-        );
-        assert_eq!(
-            dynamic_builtin_typo_hint_for_tokens(&["filebrowser".to_string()], None),
-            None
-        );
+    match command.try_get_matches_from_mut(argv) {
+        Ok(_) => unreachable!("dynamic subcommand unexpectedly matched without external support"),
+        Err(error) => error.exit(),
     }
 }

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -39,14 +39,7 @@ fn main() -> Result<()> {
             interval_ms,
             verbose,
         } => block_on(execute_ping(fungi_args.common, peer, interval_ms, verbose)),
-        Commands::Dynamic(tokens) => {
-            let device_context = fungi_args.common.dynamic_device.clone();
-            block_on(execute_dynamic_thing(
-                fungi_args.common,
-                device_context,
-                tokens,
-            ))
-        }
+        Commands::Dynamic(tokens) => block_on(execute_dynamic_thing(fungi_args.common, tokens)),
     }
 
     Ok(())

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
             interval_ms,
             verbose,
         } => block_on(execute_ping(fungi_args.common, peer, interval_ms, verbose)),
-        Commands::Dynamic(tokens) => block_on(execute_dynamic_thing(fungi_args.common, tokens)),
+        Commands::Dynamic(tokens) => block_on(execute_dynamic_service(fungi_args.common, tokens)),
     }
 
     Ok(())

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -21,52 +21,6 @@ impl Drop for DaemonChild {
 }
 
 #[test]
-fn cli_suggests_builtin_command_for_dynamic_typo_without_config() {
-    let home = TempDir::new().unwrap();
-    let output = run_cli_result(home.path(), ["devices"], "");
-
-    assert!(!output.status.success());
-    assert_eq!(output.stdout, "");
-    assert_eq!(
-        output.stderr,
-        concat!(
-            "No service named `devices` was found.
-",
-            "
-",
-            "Hint: `devices` looks like a built-in command typo.
-",
-            "Did you mean:
-",
-            "
-",
-            "  fungi device
-",
-            "
-",
-            "For dynamic services, use:
-",
-            "
-",
-            "  fungi filebrowser@nas
-"
-        )
-    );
-}
-
-#[test]
-fn cli_suggests_builtin_command_for_dynamic_typo_with_trailing_arg() {
-    let home = TempDir::new().unwrap();
-    let output = run_cli_result(home.path(), ["devices", "list"], "");
-
-    assert!(!output.status.success());
-    assert_eq!(output.stdout, "");
-    assert!(output.stderr.contains("Did you mean:"));
-    assert!(output.stderr.contains("  fungi device"));
-    assert!(!output.stderr.contains("Dynamic tool execution"));
-}
-
-#[test]
 fn service_apply_file_without_target_prints_order_hint() {
     let home = TempDir::new().unwrap();
     let manifest = home.path().join("demo.fungi.md");
@@ -207,7 +161,7 @@ fn service_apply_rejects_mismatched_definition_id() {
 }
 
 #[test]
-fn cli_prefers_existing_dynamic_service_over_builtin_typo_hint() {
+fn cli_requires_local_scope_for_existing_dynamic_service() {
     let home = TempDir::new().unwrap();
     let rpc = reserve_port();
     let swarm = reserve_port();
@@ -234,9 +188,44 @@ fn cli_prefers_existing_dynamic_service_over_builtin_typo_hint() {
 
     assert!(!output.status.success());
     assert_eq!(output.stdout, "");
+    assert!(
+        output.stderr.contains("unrecognized subcommand 'devices'")
+            || output.stderr.contains("unrecognized subcommand `devices`"),
+        "{}",
+        output.stderr
+    );
+    assert!(output.stderr.contains("device"), "{}", output.stderr);
+
+    let output = run_cli_result(home.path(), ["devices@local"], "");
+
+    assert!(!output.status.success());
+    assert_eq!(output.stdout, "");
     assert_eq!(
         output.stderr,
         "No web entry is available for this service\n"
+    );
+}
+
+#[test]
+fn cli_rejects_reserved_local_device_name() {
+    let home = TempDir::new().unwrap();
+    let rpc = reserve_port();
+    let swarm = reserve_port();
+
+    init_fungi_dir(home.path(), rpc, swarm);
+    let _daemon = start_daemon(home.path());
+    let peer = wait_peer_id(home.path());
+
+    let output = run_cli_result(home.path(), ["device", "add", "local", peer.as_str()], "");
+
+    assert!(!output.status.success());
+    assert_eq!(output.stdout, "");
+    assert!(
+        output
+            .stderr
+            .contains("Device name `local` is reserved for the local device"),
+        "{}",
+        output.stderr
     );
 }
 

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -209,14 +209,8 @@ fn cli_requires_local_scope_for_existing_dynamic_service() {
 #[test]
 fn cli_rejects_reserved_local_device_name() {
     let home = TempDir::new().unwrap();
-    let rpc = reserve_port();
-    let swarm = reserve_port();
 
-    init_fungi_dir(home.path(), rpc, swarm);
-    let _daemon = start_daemon(home.path());
-    let peer = wait_peer_id(home.path());
-
-    let output = run_cli_result(home.path(), ["device", "add", "local", peer.as_str()], "");
+    let output = run_cli_result(home.path(), ["device", "add", "local", "not-a-peer-id"], "");
 
     assert!(!output.status.success());
     assert_eq!(output.stdout, "");

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -620,23 +620,7 @@ fn parses_dynamic_thing_at_device() {
         panic!("expected dynamic thing command");
     };
 
-    assert!(args.common.dynamic_device.is_none());
     assert_eq!(tokens, vec!["filebrowser@nas"]);
-}
-
-#[test]
-fn parses_dynamic_thing_with_device_context() {
-    let args = FungiArgs::try_parse_from(["fungi", "-d", "nas", "filebrowser"]).unwrap();
-
-    let Commands::Dynamic(tokens) = args.command else {
-        panic!("expected dynamic thing command");
-    };
-
-    assert!(matches!(
-        args.common.dynamic_device,
-        Some(DeviceInput::Name(name)) if name == "nas"
-    ));
-    assert_eq!(tokens, vec!["filebrowser"]);
 }
 
 #[test]

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -613,11 +613,11 @@ fn parses_device_address_add() {
 }
 
 #[test]
-fn parses_dynamic_thing_at_device() {
+fn parses_dynamic_service_at_device() {
     let args = FungiArgs::try_parse_from(["fungi", "filebrowser@nas"]).unwrap();
 
     let Commands::Dynamic(tokens) = args.command else {
-        panic!("expected dynamic thing command");
+        panic!("expected dynamic service command");
     };
 
     assert_eq!(tokens, vec!["filebrowser@nas"]);


### PR DESCRIPTION
## What changed

- Require dynamic service shortcuts to include an explicit `@` target.
- Local services now use `fungi <service>@local`; remote services continue to use `fungi <service>@<device>`.
- Treat `local` as a reserved device name across device config validation, so users cannot add or rename a saved device to `local`.
- Remove the custom dynamic typo-hint/edit-distance path; unscoped unknown commands now fall back to clap native unknown-subcommand suggestions.
- Update CLI smoke and unit coverage for unscoped shortcuts, `@local` parsing, and reserved device names.

## Why

Previously, any unknown top-level command could be interpreted as a local service shortcut. That made typo cases confusing, because commands like `fungi devices` could be routed through service lookup instead of clearly behaving like a command typo. Making local access explicit keeps quick service access while reducing accidental matches.

## Validation

- `cargo fmt`
- `cargo test -p fungi-config test_add_peer_rejects_reserved_local_name_case_insensitive`
- `cargo test -p fungi --lib`
- `cargo test -p fungi --test commands`
- `cargo test -p fungi --test cli_smoke`
