### PR TITLE
[codex] Implement UDP-first relay reservation

### DIFF
--- a/crates/config/src/libp2p.rs
+++ b/crates/config/src/libp2p.rs
@@ -37,11 +37,10 @@ pub struct Network {
     pub relay_enabled: bool,
     #[serde(default = "default_use_community_relays")]
     pub use_community_relays: bool,
-    /// Relay/observer multiaddrs kept in one user-facing list.
+    /// Relay multiaddrs kept in one user-facing list.
     ///
-    /// TCP entries maintain durable relay reservations and relay circuits.
-    /// UDP/QUIC entries are observer endpoints used only to refresh external
-    /// UDP address candidates before direct hole punching.
+    /// Candidates are grouped by relay peer. Each group is tried UDP/QUIC
+    /// first, then TCP for reservation and circuit availability.
     #[serde(default)]
     pub custom_relay_addresses: Vec<Multiaddr>,
     #[serde(default = "default_idle_connection_timeout_secs")]

--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -40,8 +40,8 @@ service FungiDaemon {
 
   // Adds a custom relay address to the persisted configuration.
   //
-  // TCP relay addresses maintain reservations and relay circuits. UDP/QUIC
-  // relay addresses are observer-only endpoints for UDP address refresh.
+  // Relay addresses are grouped by relay peer. Each group is tried UDP/QUIC
+  // first, then TCP for reservation and circuit availability.
   rpc AddCustomRelayAddress(RelayAddressRequest) returns (Empty) {}
 
   // Removes a custom relay address from the persisted configuration.
@@ -204,8 +204,8 @@ message RelayEnabledRequest { bool enabled = 1; }
 message UseCommunityRelaysRequest { bool enabled = 1; }
 
 message RelayAddressRequest {
-  // One relay multiaddr. TCP entries carry relay reservations/circuits; UDP/QUIC
-  // entries are observer-only for pre-hole-punch UDP address discovery.
+  // One relay multiaddr. Candidates are grouped by relay peer and tried
+  // UDP/QUIC first, then TCP.
   string address = 1;
 }
 
@@ -217,11 +217,11 @@ message EffectiveRelayAddress {
 message RelayConfigResponse {
   bool relay_enabled        = 1;
   bool use_community_relays = 2;
-  // User-facing relay list. The daemon keeps one list in config and separates
-  // TCP relay carriers from UDP/QUIC observers internally.
+  // User-facing relay list. The daemon groups candidates by relay peer and
+  // tries UDP/QUIC before TCP within each group.
   repeated string custom_relay_addresses = 3;
-  // Community plus custom relay addresses after config resolution, with the
-  // same TCP-carrier / UDP-observer semantics as custom_relay_addresses.
+  // Community plus custom relay addresses after config resolution. The daemon
+  // applies the same peer-grouped UDP-first policy to this effective list.
   repeated EffectiveRelayAddress effective_relay_addresses = 4;
 }
 

--- a/crates/daemon-grpc/src/generated/fungi_daemon.rs
+++ b/crates/daemon-grpc/src/generated/fungi_daemon.rs
@@ -58,8 +58,8 @@ pub struct UseCommunityRelaysRequest {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RelayAddressRequest {
-    /// One relay multiaddr. TCP entries carry relay reservations/circuits; UDP/QUIC
-    /// entries are observer-only for pre-hole-punch UDP address discovery.
+    /// One relay multiaddr. Candidates are grouped by relay peer and tried
+    /// UDP/QUIC first, then TCP.
     #[prost(string, tag = "1")]
     pub address: ::prost::alloc::string::String,
 }
@@ -76,12 +76,12 @@ pub struct RelayConfigResponse {
     pub relay_enabled: bool,
     #[prost(bool, tag = "2")]
     pub use_community_relays: bool,
-    /// User-facing relay list. The daemon keeps one list in config and separates
-    /// TCP relay carriers from UDP/QUIC observers internally.
+    /// User-facing relay list. The daemon groups candidates by relay peer and
+    /// tries UDP/QUIC before TCP within each group.
     #[prost(string, repeated, tag = "3")]
     pub custom_relay_addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Community plus custom relay addresses after config resolution, with the
-    /// same TCP-carrier / UDP-observer semantics as custom_relay_addresses.
+    /// Community plus custom relay addresses after config resolution. The daemon
+    /// applies the same peer-grouped UDP-first policy to this effective list.
     #[prost(message, repeated, tag = "4")]
     pub effective_relay_addresses: ::prost::alloc::vec::Vec<EffectiveRelayAddress>,
 }
@@ -935,8 +935,8 @@ pub mod fungi_daemon_client {
         }
         /// Adds a custom relay address to the persisted configuration.
         ///
-        /// TCP relay addresses maintain reservations and relay circuits. UDP/QUIC
-        /// relay addresses are observer-only endpoints for UDP address refresh.
+        /// Relay addresses are grouped by relay peer. Each group is tried UDP/QUIC
+        /// first, then TCP for reservation and circuit availability.
         pub async fn add_custom_relay_address(
             &mut self,
             request: impl tonic::IntoRequest<super::RelayAddressRequest>,
@@ -1729,8 +1729,8 @@ pub mod fungi_daemon_server {
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status>;
         /// Adds a custom relay address to the persisted configuration.
         ///
-        /// TCP relay addresses maintain reservations and relay circuits. UDP/QUIC
-        /// relay addresses are observer-only endpoints for UDP address refresh.
+        /// Relay addresses are grouped by relay peer. Each group is tried UDP/QUIC
+        /// first, then TCP for reservation and circuit availability.
         async fn add_custom_relay_address(
             &self,
             request: tonic::Request<super::RelayAddressRequest>,

--- a/crates/lab/src/util.rs
+++ b/crates/lab/src/util.rs
@@ -304,8 +304,8 @@ pub(crate) fn parse_peer_id(text: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-pub(crate) fn circuit_addr(relay_tcp_addr: &str, peer_id: &str) -> String {
-    format!("{relay_tcp_addr}/p2p-circuit/p2p/{peer_id}")
+pub(crate) fn circuit_addr(relay_addr: &str, peer_id: &str) -> String {
+    format!("{relay_addr}/p2p-circuit/p2p/{peer_id}")
 }
 
 pub(crate) fn epoch_secs() -> u64 {

--- a/crates/swarm/src/libp2p/control.rs
+++ b/crates/swarm/src/libp2p/control.rs
@@ -303,7 +303,9 @@ impl SwarmControl {
             log::info!("No relay peers available");
             return Err(ConnectError::NoDialAddresses { peer_id });
         }
-        let relay_addresses = self.relay_peers.circuit_addresses_for_target(peer_id);
+        let relay_addresses = self
+            .relay_peers
+            .circuit_addresses_for_target(peer_id, self.state());
         log::debug!(
             "Dialing relay circuit addresses for peer {peer_id} without UDP prepare refresh"
         );

--- a/crates/swarm/src/libp2p/relay.rs
+++ b/crates/swarm/src/libp2p/relay.rs
@@ -1,11 +1,11 @@
 // Relay management policy for fungi:
 //
-// TCP relay addresses are the durable carrier for libp2p relay reservations and
-// circuit traffic. UDP/QUIC relay addresses are observer endpoints only; they
-// are dialed briefly to refresh externally observed UDP addresses before hole
-// punching, but they must not become the active relay reservation carrier.
+// Relay reservation is UDP-first within each relay peer. If the UDP candidate
+// does not become ready during the current reconciliation attempt, we fall back
+// to TCP for availability. A healthy TCP fallback is not interrupted just to
+// upgrade back to UDP; the next reconcile starts from UDP again.
 use super::SwarmControl;
-use crate::{AddressTransportKind, State, behaviours::relay_refresh};
+use crate::{State, behaviours::relay_refresh};
 use anyhow::{Result, bail};
 use libp2p::{
     Multiaddr, PeerId,
@@ -85,7 +85,6 @@ pub(super) enum RelayTransportKind {
 #[derive(Clone)]
 pub(super) struct RelayEndpoint {
     addr: Multiaddr,
-    task_flag: Arc<AtomicBool>,
     peer_id: Option<PeerId>,
     transport_kind: Option<RelayTransportKind>,
 }
@@ -96,16 +95,11 @@ impl RelayEndpoint {
             peer_id: peer_id_from_addr(&addr),
             transport_kind: relay_transport_kind(&addr),
             addr,
-            task_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub(super) fn addr(&self) -> &Multiaddr {
         &self.addr
-    }
-
-    fn task_flag(&self) -> &Arc<AtomicBool> {
-        &self.task_flag
     }
 
     pub(super) fn peer_id(&self) -> Option<PeerId> {
@@ -132,11 +126,44 @@ impl RelayEndpoint {
 }
 
 #[derive(Clone)]
+pub(super) struct RelayPeerGroup {
+    peer_id: PeerId,
+    endpoints: Arc<Vec<RelayEndpoint>>,
+    task_flag: Arc<AtomicBool>,
+}
+
+impl RelayPeerGroup {
+    fn new(peer_id: PeerId, endpoints: Vec<RelayEndpoint>) -> Self {
+        Self {
+            peer_id,
+            endpoints: Arc::new(endpoints),
+            task_flag: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(super) fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub(super) fn endpoints(&self) -> std::slice::Iter<'_, RelayEndpoint> {
+        self.endpoints.iter()
+    }
+
+    fn task_flag(&self) -> Arc<AtomicBool> {
+        self.task_flag.clone()
+    }
+
+    fn contains_transport(&self, transport_kind: RelayTransportKind) -> bool {
+        self.endpoints()
+            .any(|endpoint| endpoint.transport_kind() == Some(transport_kind))
+    }
+}
+
+#[derive(Clone)]
 pub(super) struct RelayPeers {
-    relay_endpoints: Arc<Vec<RelayEndpoint>>,
-    observer_endpoints: Arc<Vec<RelayEndpoint>>,
+    groups: Arc<Vec<RelayPeerGroup>>,
     all_endpoints: Arc<Vec<RelayEndpoint>>,
-    tcp_peer_ids: Arc<Vec<PeerId>>,
+    peer_ids: Arc<Vec<PeerId>>,
 }
 
 #[derive(Debug)]
@@ -161,36 +188,50 @@ impl RelayPeers {
             .map(RelayEndpoint::new)
             .collect::<Vec<_>>();
 
-        // User configuration stays as one ordered relay address list. Internally
-        // we split it by transport so libp2p relay reservations are always
-        // driven by TCP, while UDP/QUIC entries remain address observers.
-        let relay_endpoints = all_endpoints
-            .iter()
-            .filter(|endpoint| endpoint.transport_kind() == Some(RelayTransportKind::Tcp))
-            .cloned()
-            .collect::<Vec<_>>();
-        let observer_endpoints = all_endpoints
-            .iter()
-            .filter(|endpoint| endpoint.transport_kind() == Some(RelayTransportKind::Udp))
-            .cloned()
-            .collect::<Vec<_>>();
-        let mut tcp_peer_ids = Vec::new();
+        let mut peer_order = Vec::<PeerId>::new();
+        let mut endpoints_by_peer = HashMap::<PeerId, Vec<RelayEndpoint>>::new();
 
-        for relay_endpoint in &relay_endpoints {
+        for relay_endpoint in &all_endpoints {
+            if relay_endpoint.transport_kind().is_none() {
+                continue;
+            }
             let Some(peer_id) = relay_endpoint.peer_id() else {
                 continue;
             };
 
-            if !tcp_peer_ids.contains(&peer_id) {
-                tcp_peer_ids.push(peer_id);
-            }
+            endpoints_by_peer.entry(peer_id).or_insert_with(|| {
+                peer_order.push(peer_id);
+                Vec::new()
+            });
+            endpoints_by_peer
+                .get_mut(&peer_id)
+                .expect("relay peer entry was just inserted")
+                .push(relay_endpoint.clone());
         }
 
+        let groups = peer_order
+            .iter()
+            .filter_map(|peer_id| {
+                let endpoints = endpoints_by_peer.remove(peer_id)?;
+                let mut udp_endpoints = endpoints
+                    .iter()
+                    .filter(|endpoint| endpoint.transport_kind() == Some(RelayTransportKind::Udp))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                udp_endpoints.extend(
+                    endpoints.into_iter().filter(|endpoint| {
+                        endpoint.transport_kind() == Some(RelayTransportKind::Tcp)
+                    }),
+                );
+                let endpoints = udp_endpoints;
+                Some(RelayPeerGroup::new(*peer_id, endpoints))
+            })
+            .collect::<Vec<_>>();
+
         Self {
-            relay_endpoints: Arc::new(relay_endpoints),
-            observer_endpoints: Arc::new(observer_endpoints),
             all_endpoints: Arc::new(all_endpoints),
-            tcp_peer_ids: Arc::new(tcp_peer_ids),
+            groups: Arc::new(groups),
+            peer_ids: Arc::new(peer_order),
         }
     }
 
@@ -200,12 +241,8 @@ impl RelayPeers {
         }
     }
 
-    pub(super) fn relay_endpoints(&self) -> std::slice::Iter<'_, RelayEndpoint> {
-        self.relay_endpoints.iter()
-    }
-
-    pub(super) fn observer_endpoints(&self) -> std::slice::Iter<'_, RelayEndpoint> {
-        self.observer_endpoints.iter()
+    pub(super) fn groups(&self) -> std::slice::Iter<'_, RelayPeerGroup> {
+        self.groups.iter()
     }
 
     pub(super) fn all_endpoints(&self) -> std::slice::Iter<'_, RelayEndpoint> {
@@ -213,29 +250,73 @@ impl RelayPeers {
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.relay_endpoints.is_empty()
+        self.groups.is_empty()
     }
 
     pub(super) fn peer_ids(&self) -> &[PeerId] {
-        self.tcp_peer_ids.as_slice()
+        self.peer_ids.as_slice()
     }
 
-    pub(super) fn circuit_addresses_for_target(&self, target_peer: PeerId) -> Vec<Multiaddr> {
-        self.relay_endpoints()
-            .map(|relay_endpoint| peer_addr_with_relay(target_peer, relay_endpoint.addr().clone()))
+    pub(super) fn group_for_peer(&self, relay_peer_id: PeerId) -> Option<RelayPeerGroup> {
+        self.groups()
+            .find(|group| group.peer_id() == relay_peer_id)
+            .cloned()
+    }
+
+    pub(super) fn group_for_endpoint(&self, endpoint: &RelayEndpoint) -> Option<RelayPeerGroup> {
+        endpoint
+            .peer_id()
+            .and_then(|peer_id| self.group_for_peer(peer_id))
+    }
+
+    pub(super) fn groups_for_transport(
+        &self,
+        transport_kind: RelayTransportKind,
+    ) -> Vec<RelayPeerGroup> {
+        self.groups()
+            .filter(|group| group.contains_transport(transport_kind))
+            .cloned()
+            .collect()
+    }
+
+    pub(super) fn circuit_addresses_for_target(
+        &self,
+        target_peer: PeerId,
+        state: &State,
+    ) -> Vec<Multiaddr> {
+        let mut relays = Vec::<Multiaddr>::new();
+        let mut seen = HashSet::<String>::new();
+
+        for group in self.groups() {
+            if let Some(active_addr) = state.relay_peer_active_endpoint(group.peer_id()) {
+                push_relay_addr_once(&mut relays, &mut seen, active_addr);
+            }
+        }
+
+        for group in self.groups() {
+            for endpoint in group.endpoints() {
+                push_relay_addr_once(&mut relays, &mut seen, endpoint.addr().clone());
+            }
+        }
+
+        relays
+            .into_iter()
+            .map(|relay_addr| peer_addr_with_relay(target_peer, relay_addr))
             .collect()
     }
 
     pub(super) fn udp_refresh_plan(&self, preferred_relay: Option<PeerId>) -> RelayUdpRefreshPlan {
-        // The refresh plan is intentionally observer-only. It never falls back
-        // to TCP because this path exists to refresh observed UDP addresses for
-        // direct QUIC hole punching.
+        // The refresh plan remains UDP-only because this path refreshes observed
+        // UDP addresses for direct QUIC hole punching.
         let mut plan = RelayUdpRefreshPlan::default();
         let mut seen_addrs = HashSet::<String>::new();
         let mut addresses_by_peer = HashMap::<PeerId, Vec<Multiaddr>>::new();
         let mut peer_order = Vec::<PeerId>::new();
 
-        for relay_endpoint in self.observer_endpoints() {
+        for relay_endpoint in self.all_endpoints() {
+            if relay_endpoint.transport_kind() != Some(RelayTransportKind::Udp) {
+                continue;
+            }
             let addr = relay_endpoint.addr();
             if is_circuit_addr(addr) {
                 plan.skipped_circuit += 1;
@@ -292,6 +373,16 @@ impl RelayPeers {
             .collect();
 
         plan
+    }
+}
+
+fn push_relay_addr_once(
+    relays: &mut Vec<Multiaddr>,
+    seen: &mut HashSet<String>,
+    relay_addr: Multiaddr,
+) {
+    if seen.insert(relay_addr.to_string()) {
+        relays.push(relay_addr);
     }
 }
 
@@ -360,7 +451,7 @@ impl SwarmControl {
         );
 
         let mut refresh_started = false;
-        let mut skipped_unhealthy_tcp_reservation = 0usize;
+        let mut skipped_without_active_udp_reservation = 0usize;
 
         for target in plan.targets {
             let relay_peer = target.peer_id;
@@ -368,15 +459,15 @@ impl SwarmControl {
             let address_summary = summarize_multiaddrs(&target.addresses);
             let addresses = target.addresses;
 
-            // A UDP observer dial can create or become the first direct
-            // connection to the relay peer. libp2p-relay may reuse the first
-            // direct connection for reservation work, so only probe UDP after a
-            // healthy TCP reservation carrier is already present.
-            if !self.state().relay_tcp_ready(relay_peer) {
-                skipped_unhealthy_tcp_reservation += 1;
+            let active_endpoint = self.state().relay_peer_active_endpoint(relay_peer);
+            if active_endpoint.as_ref().and_then(relay_transport_kind)
+                != Some(RelayTransportKind::Udp)
+            {
+                skipped_without_active_udp_reservation += 1;
                 log::debug!(
-                    "Skipping relay UDP refresh dial to {} because no healthy TCP relay reservation is active; candidate address(es): {}",
+                    "Skipping relay UDP refresh dial to {} because UDP is not the active relay reservation endpoint; active_endpoint={:?}, candidate address(es): {}",
                     relay_peer,
+                    active_endpoint,
                     address_summary
                 );
                 continue;
@@ -423,10 +514,10 @@ impl SwarmControl {
             }
         }
 
-        if skipped_unhealthy_tcp_reservation > 0 {
+        if skipped_without_active_udp_reservation > 0 {
             log::debug!(
-                "Skipped {} relay UDP refresh target peer(s) because their TCP relay reservation was not healthy",
-                skipped_unhealthy_tcp_reservation
+                "Skipped {} relay UDP refresh target peer(s) because UDP was not the active relay reservation endpoint",
+                skipped_without_active_udp_reservation
             );
         }
 
@@ -511,62 +602,52 @@ pub(super) async fn relay_management_loop(swarm_control: SwarmControl) {
             continue;
         }
 
-        for relay_endpoint in swarm_control.relay_peers.relay_endpoints() {
-            let listener_registered =
-                match relay_listener_registered(&swarm_control, relay_endpoint).await {
-                    Ok(value) => value,
-                    Err(error) => {
-                        swarm_control.state().record_relay_management_error(
-                            relay_endpoint.addr(),
-                            error.to_string(),
-                        );
-                        log::warn!(
-                            "Failed to inspect relay listener state for {}: {}",
-                            relay_endpoint.addr(),
-                            error
-                        );
-                        false
-                    }
-                };
+        for group in swarm_control.relay_peers.groups() {
+            let mut peer_has_listener = false;
+            for relay_endpoint in group.endpoints() {
+                let listener_registered =
+                    match relay_listener_registered(&swarm_control, relay_endpoint).await {
+                        Ok(value) => value,
+                        Err(error) => {
+                            swarm_control.state().record_relay_management_error(
+                                relay_endpoint.addr(),
+                                error.to_string(),
+                            );
+                            log::warn!(
+                                "Failed to inspect relay listener state for {}: {}",
+                                relay_endpoint.addr(),
+                                error
+                            );
+                            false
+                        }
+                    };
 
-            let has_active_direct_connection = swarm_control
-                .state()
-                .relay_endpoint_active(relay_endpoint.addr());
+                swarm_control
+                    .state()
+                    .record_relay_listener_check(relay_endpoint.addr(), listener_registered);
+                peer_has_listener |= listener_registered;
+            }
 
-            swarm_control
-                .state()
-                .record_relay_listener_check(relay_endpoint.addr(), listener_registered);
-
-            if listener_registered && has_active_direct_connection {
+            if swarm_control.state().relay_peer_ready(group.peer_id()) {
                 continue;
             }
 
-            if relay_endpoint
-                .peer_id()
-                .is_some_and(|relay_peer_id| swarm_control.state().relay_tcp_ready(relay_peer_id))
-            {
-                log::debug!(
-                    "Skipping relay reconcile for {} because another endpoint for the same relay peer is already healthy",
-                    relay_endpoint.addr()
-                );
-                continue;
-            }
-
-            let action = if !listener_registered {
-                crate::RelayManagementAction::ListenerMissingReconcile
-            } else {
+            let action = if peer_has_listener {
                 crate::RelayManagementAction::DirectConnectionMissingReconcile
+            } else {
+                crate::RelayManagementAction::ListenerMissingReconcile
             };
-            swarm_control
-                .state()
-                .record_relay_management_action(relay_endpoint.addr(), action);
+
+            for relay_endpoint in group.endpoints() {
+                swarm_control
+                    .state()
+                    .record_relay_management_action(relay_endpoint.addr(), action);
+            }
             log::info!(
-                "Relay audit re-establishing reservation for {} because listener_registered={} active_direct_connection={}",
-                relay_endpoint.addr(),
-                listener_registered,
-                has_active_direct_connection
+                "Relay audit re-establishing reservation for peer {} because no relay endpoint is ready",
+                group.peer_id(),
             );
-            spawn_relay_listen_task(&swarm_control, &relay_endpoint);
+            spawn_relay_reconcile_task(&swarm_control, group);
         }
     }
 }
@@ -585,11 +666,11 @@ pub(super) fn handle_new_listen_addr(swarm_control: &SwarmControl, new_addr: Mul
         return;
     };
 
-    for relay_endpoint in swarm_control.relay_peers.relay_endpoints() {
-        if relay_endpoint.transport_kind() != Some(transport_kind) {
-            continue;
-        }
-        spawn_relay_listen_task(swarm_control, relay_endpoint);
+    for group in swarm_control
+        .relay_peers
+        .groups_for_transport(transport_kind)
+    {
+        spawn_relay_reconcile_task(swarm_control, &group);
     }
 }
 
@@ -640,7 +721,7 @@ fn record_matching_relay_listener_state(
 ) -> Vec<RelayEndpoint> {
     let matched_endpoints = swarm_control
         .relay_peers
-        .relay_endpoints()
+        .all_endpoints()
         .filter(|relay_endpoint| relay_endpoint.matches_listener(listener_addr))
         .cloned()
         .collect::<Vec<_>>();
@@ -662,7 +743,7 @@ fn trigger_relay_reconcile(
 ) {
     if relay_endpoint
         .peer_id()
-        .is_some_and(|relay_peer_id| swarm_control.state().relay_tcp_ready(relay_peer_id))
+        .is_some_and(|relay_peer_id| swarm_control.state().relay_peer_ready(relay_peer_id))
     {
         log::debug!(
             "Skipping relay reconcile for {} because another endpoint for the same relay peer is already healthy ({})",
@@ -680,64 +761,69 @@ fn trigger_relay_reconcile(
         relay_endpoint.addr(),
         reason
     );
-    spawn_relay_listen_task(swarm_control, relay_endpoint);
+    if let Some(group) = swarm_control.relay_peers.group_for_endpoint(relay_endpoint) {
+        spawn_relay_reconcile_task(swarm_control, &group);
+    }
 }
 
-fn spawn_relay_listen_task(swarm_control: &SwarmControl, relay_endpoint: &RelayEndpoint) {
-    if relay_endpoint.transport_kind() != Some(RelayTransportKind::Tcp) {
-        log::debug!(
-            "Skipping relay listen task for non-TCP endpoint {}; UDP endpoints are observer-only",
-            relay_endpoint.addr()
-        );
-        return;
-    }
-
-    let Some(_guard) = TaskGuard::try_acquire(relay_endpoint.task_flag().clone()) else {
+fn spawn_relay_reconcile_task(swarm_control: &SwarmControl, group: &RelayPeerGroup) {
+    let Some(_guard) = TaskGuard::try_acquire(group.task_flag()) else {
         return;
     };
 
-    swarm_control
-        .state()
-        .set_relay_task_running(relay_endpoint.addr(), true);
-    swarm_control.state().record_relay_management_action(
-        relay_endpoint.addr(),
-        crate::RelayManagementAction::ListenTaskStarted,
-    );
+    for relay_endpoint in group.endpoints() {
+        swarm_control
+            .state()
+            .set_relay_task_running(relay_endpoint.addr(), true);
+        swarm_control.state().record_relay_management_action(
+            relay_endpoint.addr(),
+            crate::RelayManagementAction::ListenTaskStarted,
+        );
+    }
 
     let swarm_control_cl = swarm_control.clone();
-    let relay_addr_cl = relay_endpoint.addr().clone();
+    let group_cl = group.clone();
 
     tokio::spawn(async move {
         let _guard = _guard;
 
         let mut attempt = 1u32;
         loop {
-            match listen_relay_by_addr(swarm_control_cl.clone(), relay_addr_cl.clone()).await {
-                Ok(()) => {
+            match ensure_relay_peer_reservation(&swarm_control_cl, &group_cl).await {
+                Ok(ready_endpoint) => {
+                    for relay_endpoint in group_cl.endpoints() {
+                        swarm_control_cl
+                            .state()
+                            .set_relay_task_running(relay_endpoint.addr(), false);
+                    }
                     swarm_control_cl.state().record_relay_management_action(
-                        &relay_addr_cl,
+                        ready_endpoint.addr(),
                         crate::RelayManagementAction::ListenTaskSucceeded,
                     );
-                    swarm_control_cl
-                        .state()
-                        .set_relay_task_running(&relay_addr_cl, false);
                     log::info!(
-                        "Successfully connected to relay {relay_addr_cl:?} on attempt {attempt}"
+                        "Successfully connected to relay {} via {} on attempt {attempt}",
+                        group_cl.peer_id(),
+                        ready_endpoint.addr()
                     );
                     return;
                 }
                 Err(error) => {
                     let delay = relay_retry_delay(attempt);
-                    swarm_control_cl
-                        .state()
-                        .record_relay_management_error(&relay_addr_cl, error.to_string());
+                    for relay_endpoint in group_cl.endpoints() {
+                        swarm_control_cl.state().record_relay_management_error(
+                            relay_endpoint.addr(),
+                            error.to_string(),
+                        );
+                    }
                     if attempt <= RELAY_RETRY_FAST_ATTEMPTS {
                         log::warn!(
-                            "Failed to connect to relay {relay_addr_cl:?} on attempt {attempt}: {error}; retrying in {delay:?}"
+                            "Failed to connect to relay peer {} on attempt {attempt}: {error}; retrying in {delay:?}",
+                            group_cl.peer_id()
                         );
                     } else {
                         log::warn!(
-                            "Relay {relay_addr_cl:?} is still unavailable on attempt {attempt}: {error}; continuing background retry in {delay:?}"
+                            "Relay peer {} is still unavailable on attempt {attempt}: {error}; continuing background retry in {delay:?}",
+                            group_cl.peer_id()
                         );
                     }
 
@@ -859,78 +945,115 @@ pub(super) fn record_relay_connection_closed(
     }
 }
 
-async fn listen_relay_by_addr(swarm_control: SwarmControl, relay_addr: Multiaddr) -> Result<()> {
-    let relay_peer =
-        peer_id_from_addr(&relay_addr).ok_or_else(|| anyhow::anyhow!("Invalid relay address"))?;
-    let relay_endpoint = RelayEndpoint::new(relay_addr.clone());
-    if relay_endpoint.transport_kind() != Some(RelayTransportKind::Tcp) {
-        bail!("Only TCP relay endpoints may create relay reservations: {relay_addr}");
+async fn ensure_relay_peer_reservation(
+    swarm_control: &SwarmControl,
+    group: &RelayPeerGroup,
+) -> Result<RelayEndpoint> {
+    if let Some(active_endpoint) = group
+        .endpoints()
+        .find(|endpoint| swarm_control.state().relay_endpoint_ready(endpoint.addr()))
+        .cloned()
+    {
+        return Ok(active_endpoint);
     }
 
-    // Reserve through the configured TCP relay endpoint even if a UDP observer
-    // connection to the same peer already exists. This keeps the durable relay
-    // reservation and circuit traffic on TCP.
-    ensure_relay_tcp_carrier(&swarm_control, relay_peer, relay_addr.clone()).await?;
-    close_observer_connections_for_relay_peer(&swarm_control, relay_peer).await;
+    let mut last_error = None;
+    for endpoint in group.endpoints() {
+        match try_relay_endpoint_reservation(swarm_control, endpoint).await {
+            Ok(()) => return Ok(endpoint.clone()),
+            Err(error) => {
+                swarm_control
+                    .state()
+                    .record_relay_management_error(endpoint.addr(), error.to_string());
+                log::debug!(
+                    "Relay endpoint {} failed during UDP-first reservation attempt: {}",
+                    endpoint.addr(),
+                    error
+                );
+                last_error = Some(error);
+            }
+        }
+    }
 
-    if relay_listener_registered(&swarm_control, &relay_endpoint).await? {
-        log::debug!("Relay listener already active for {relay_addr}");
+    match last_error {
+        Some(error) => Err(error),
+        None => bail!(
+            "Relay peer {} has no usable relay endpoints",
+            group.peer_id()
+        ),
+    }
+}
+
+async fn try_relay_endpoint_reservation(
+    swarm_control: &SwarmControl,
+    relay_endpoint: &RelayEndpoint,
+) -> Result<()> {
+    let relay_peer = relay_endpoint
+        .peer_id()
+        .ok_or_else(|| anyhow::anyhow!("Invalid relay address"))?;
+    let relay_addr = relay_endpoint.addr().clone();
+
+    close_other_relay_connections_for_peer(swarm_control, relay_peer, relay_endpoint.addr()).await;
+    ensure_relay_endpoint_carrier(swarm_control, relay_peer, relay_addr.clone()).await?;
+
+    if relay_listener_registered(swarm_control, relay_endpoint).await? {
+        swarm_control
+            .state()
+            .record_relay_listener_check(relay_endpoint.addr(), true);
+        wait_relay_endpoint_ready(swarm_control, relay_endpoint).await?;
         return Ok(());
-    };
+    }
 
-    close_observer_connections_for_relay_peer(&swarm_control, relay_peer).await;
     println!("Listening on relay address: {relay_addr:?}");
     swarm_control
         .invoke_swarm(move |swarm| swarm.listen_on(relay_addr.with(Protocol::P2pCircuit)))
         .await??;
 
-    Ok(())
+    wait_relay_endpoint_ready(swarm_control, relay_endpoint).await
 }
 
-async fn close_observer_connections_for_relay_peer(
+async fn close_other_relay_connections_for_peer(
     swarm_control: &SwarmControl,
     relay_peer: PeerId,
+    active_relay_addr: &Multiaddr,
 ) {
-    // libp2p-relay tracks reservations by relay peer rather than by our
-    // configured endpoint role. Closing observer-only carrier connections before
-    // reservation work prevents a temporary UDP refresh dial from becoming the
-    // preferred relay carrier.
-    let observer_connection_ids = swarm_control
+    let connection_ids = swarm_control
         .state()
         .list_relay_endpoint_statuses()
         .into_iter()
         .filter(|status| {
-            status.relay_peer_id == Some(relay_peer)
-                && status.transport_kind != AddressTransportKind::Tcp
+            status.relay_peer_id == Some(relay_peer) && status.relay_addr != *active_relay_addr
         })
         .filter_map(|status| status.current_direct_connection_id)
         .collect::<Vec<_>>();
 
-    if observer_connection_ids.is_empty() {
+    if connection_ids.is_empty() {
         return;
     }
 
-    for connection_id in &observer_connection_ids {
+    for connection_id in &connection_ids {
         match swarm_control.close_connection(*connection_id).await {
             Ok(true) => {
                 log::debug!(
-                    "Closing observer-only relay carrier connection {} for peer {} before TCP reservation",
+                    "Closing non-selected relay carrier connection {} for peer {} before reservation on {}",
                     connection_id,
-                    relay_peer
+                    relay_peer,
+                    active_relay_addr
                 );
             }
             Ok(false) => {
                 log::debug!(
-                    "Observer-only relay carrier connection {} for peer {} was already closing or absent",
+                    "Non-selected relay carrier connection {} for peer {} was already closing or absent",
                     connection_id,
                     relay_peer
                 );
             }
             Err(error) => {
                 log::debug!(
-                    "Failed to close observer-only relay carrier connection {} for peer {} before TCP reservation: {}",
+                    "Failed to close non-selected relay carrier connection {} for peer {} before reservation on {}: {}",
                     connection_id,
                     relay_peer,
+                    active_relay_addr,
                     error
                 );
             }
@@ -940,7 +1063,7 @@ async fn close_observer_connections_for_relay_peer(
     tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
-async fn ensure_relay_tcp_carrier(
+async fn ensure_relay_endpoint_carrier(
     swarm_control: &SwarmControl,
     relay_peer: PeerId,
     relay_addr: Multiaddr,
@@ -967,7 +1090,8 @@ async fn ensure_relay_tcp_carrier(
         Ok(()) => {}
         Err(DialError::DialPeerConditionFalse(PeerCondition::NotDialing)) => {
             log::debug!(
-                "Relay peer {relay_peer} already has an in-flight dial; waiting for TCP carrier"
+                "Relay peer {relay_peer} already has an in-flight dial; waiting for carrier {}",
+                relay_addr
             );
         }
         Err(error) => bail!("Failed to dial relay {relay_peer} via {relay_addr}: {error}"),
@@ -980,7 +1104,36 @@ async fn ensure_relay_tcp_carrier(
         }
 
         if Instant::now() >= deadline {
-            bail!("Timed out waiting for relay TCP carrier {relay_peer} via {relay_addr}");
+            bail!("Timed out waiting for relay carrier {relay_peer} via {relay_addr}");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_relay_endpoint_ready(
+    swarm_control: &SwarmControl,
+    relay_endpoint: &RelayEndpoint,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let listener_registered = relay_listener_registered(swarm_control, relay_endpoint).await?;
+        swarm_control
+            .state()
+            .record_relay_listener_check(relay_endpoint.addr(), listener_registered);
+
+        if swarm_control
+            .state()
+            .relay_endpoint_ready(relay_endpoint.addr())
+        {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            bail!(
+                "Timed out waiting for relay endpoint to become ready: {}",
+                relay_endpoint.addr()
+            );
         }
 
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -989,10 +1142,10 @@ async fn ensure_relay_tcp_carrier(
 
 pub fn get_default_relay_addrs() -> Vec<Multiaddr> {
     vec![
-        "/ip4/160.16.206.21/tcp/30001/p2p/16Uiu2HAmGXFS6aYsKKYRkEDo1tNigZKN8TAYrsfSnEdC5sZLNkiE"
+        "/ip4/160.16.206.21/udp/30001/quic-v1/p2p/16Uiu2HAmGXFS6aYsKKYRkEDo1tNigZKN8TAYrsfSnEdC5sZLNkiE"
             .parse()
             .unwrap(),
-        "/ip4/160.16.206.21/udp/30001/quic-v1/p2p/16Uiu2HAmGXFS6aYsKKYRkEDo1tNigZKN8TAYrsfSnEdC5sZLNkiE"
+        "/ip4/160.16.206.21/tcp/30001/p2p/16Uiu2HAmGXFS6aYsKKYRkEDo1tNigZKN8TAYrsfSnEdC5sZLNkiE"
             .parse()
             .unwrap(),
     ]

--- a/crates/swarm/src/libp2p/relay.rs
+++ b/crates/swarm/src/libp2p/relay.rs
@@ -786,7 +786,7 @@ fn spawn_relay_reconcile_task(swarm_control: &SwarmControl, group: &RelayPeerGro
             .set_relay_task_running(relay_endpoint.addr(), true);
         swarm_control.state().record_relay_management_action(
             relay_endpoint.addr(),
-            crate::RelayManagementAction::ListenTaskStarted,
+            crate::RelayManagementAction::ReconcileTaskStarted,
         );
     }
 
@@ -807,7 +807,7 @@ fn spawn_relay_reconcile_task(swarm_control: &SwarmControl, group: &RelayPeerGro
                     }
                     swarm_control_cl.state().record_relay_management_action(
                         ready_endpoint.addr(),
-                        crate::RelayManagementAction::ListenTaskSucceeded,
+                        crate::RelayManagementAction::ReconcileTaskSucceeded,
                     );
                     log::info!(
                         "Successfully connected to relay {} via {} on attempt {attempt}",

--- a/crates/swarm/src/libp2p/relay.rs
+++ b/crates/swarm/src/libp2p/relay.rs
@@ -157,6 +157,12 @@ impl RelayPeerGroup {
         self.endpoints()
             .any(|endpoint| endpoint.transport_kind() == Some(transport_kind))
     }
+
+    fn active_endpoint(&self, state: &State) -> Option<RelayEndpoint> {
+        self.endpoints()
+            .find(|endpoint| state.relay_endpoint_ready(endpoint.addr()))
+            .cloned()
+    }
 }
 
 #[derive(Clone)]
@@ -288,8 +294,8 @@ impl RelayPeers {
         let mut seen = HashSet::<String>::new();
 
         for group in self.groups() {
-            if let Some(active_addr) = state.relay_peer_active_endpoint(group.peer_id()) {
-                push_relay_addr_once(&mut relays, &mut seen, active_addr);
+            if let Some(active_endpoint) = group.active_endpoint(state) {
+                push_relay_addr_once(&mut relays, &mut seen, active_endpoint.addr().clone());
             }
         }
 
@@ -459,7 +465,11 @@ impl SwarmControl {
             let address_summary = summarize_multiaddrs(&target.addresses);
             let addresses = target.addresses;
 
-            let active_endpoint = self.state().relay_peer_active_endpoint(relay_peer);
+            let active_endpoint = self
+                .relay_peers
+                .group_for_peer(relay_peer)
+                .and_then(|group| group.active_endpoint(self.state()))
+                .map(|endpoint| endpoint.addr().clone());
             if active_endpoint.as_ref().and_then(relay_transport_kind)
                 != Some(RelayTransportKind::Udp)
             {
@@ -603,7 +613,7 @@ pub(super) async fn relay_management_loop(swarm_control: SwarmControl) {
         }
 
         for group in swarm_control.relay_peers.groups() {
-            let mut peer_has_listener = false;
+            let mut listener_states = Vec::new();
             for relay_endpoint in group.endpoints() {
                 let listener_registered =
                     match relay_listener_registered(&swarm_control, relay_endpoint).await {
@@ -625,20 +635,19 @@ pub(super) async fn relay_management_loop(swarm_control: SwarmControl) {
                 swarm_control
                     .state()
                     .record_relay_listener_check(relay_endpoint.addr(), listener_registered);
-                peer_has_listener |= listener_registered;
+                listener_states.push((relay_endpoint.clone(), listener_registered));
             }
 
             if swarm_control.state().relay_peer_ready(group.peer_id()) {
                 continue;
             }
 
-            let action = if peer_has_listener {
-                crate::RelayManagementAction::DirectConnectionMissingReconcile
-            } else {
-                crate::RelayManagementAction::ListenerMissingReconcile
-            };
-
-            for relay_endpoint in group.endpoints() {
+            for (relay_endpoint, listener_registered) in listener_states {
+                let action = if listener_registered {
+                    crate::RelayManagementAction::DirectConnectionMissingReconcile
+                } else {
+                    crate::RelayManagementAction::ListenerMissingReconcile
+                };
                 swarm_control
                     .state()
                     .record_relay_management_action(relay_endpoint.addr(), action);

--- a/crates/swarm/src/libp2p/runtime.rs
+++ b/crates/swarm/src/libp2p/runtime.rs
@@ -2,10 +2,9 @@ use super::{
     SwarmAsyncCall, SwarmControl, TSwarm,
     governance::connection_governance_loop,
     relay::{
-        RefreshThrottle, RelayPeers, RelayTransportKind, handle_expired_listen_addr,
-        handle_listener_closed, handle_new_listen_addr, handle_relay_behaviour_event,
-        handle_relay_refresh_behaviour_event, record_relay_connection_closed,
-        record_relay_connection_established, relay_management_loop, relay_transport_kind,
+        RefreshThrottle, RelayPeers, handle_expired_listen_addr, handle_listener_closed,
+        handle_new_listen_addr, handle_relay_behaviour_event, handle_relay_refresh_behaviour_event,
+        record_relay_connection_closed, record_relay_connection_established, relay_management_loop,
     },
 };
 use crate::{
@@ -142,13 +141,7 @@ async fn handle_swarm_event(
         };
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
-                if is_observer_only_relay_listen_addr(&address) {
-                    log::debug!(
-                        "[Swarm event] Ignoring observer-only relay listen addr {address:?}"
-                    );
-                } else {
-                    println!("[Swarm event] NewListenAddr {address:?}");
-                }
+                println!("[Swarm event] NewListenAddr {address:?}");
                 handle_new_listen_addr(&swarm_control, address);
             }
             SwarmEvent::ExpiredListenAddr { address, .. } => {
@@ -259,11 +252,6 @@ async fn handle_swarm_event(
             _ => {}
         }
     }
-}
-
-fn is_observer_only_relay_listen_addr(address: &Multiaddr) -> bool {
-    super::relay::is_circuit_addr(address)
-        && relay_transport_kind(address) == Some(RelayTransportKind::Udp)
 }
 
 fn handle_mdns_behaviour_event(swarm_control: &SwarmControl, event: mdns::Event) {

--- a/crates/swarm/src/libp2p/tests.rs
+++ b/crates/swarm/src/libp2p/tests.rs
@@ -220,6 +220,47 @@ fn relay_circuit_addresses_keep_active_tcp_first_without_upgrading() {
 }
 
 #[test]
+fn relay_circuit_addresses_choose_active_endpoint_by_group_order() {
+    let relay_peer = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+    let target_peer = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+
+    let tcp_addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/30001/p2p/{relay_peer}")
+        .parse()
+        .unwrap();
+    let udp_addr: Multiaddr = format!("/ip4/127.0.0.1/udp/30001/quic-v1/p2p/{relay_peer}")
+        .parse()
+        .unwrap();
+    let relay_peers = RelayPeers::new(vec![tcp_addr.clone(), udp_addr.clone()]);
+    let state = State::new(HashSet::new());
+    relay_peers.register_with_state(&state);
+
+    state.record_relay_connection_established(
+        relay_peer,
+        ConnectionId::new_unchecked(8),
+        &tcp_addr,
+    );
+    state.record_relay_listener_check(&tcp_addr, true);
+    state.record_relay_connection_established(
+        relay_peer,
+        ConnectionId::new_unchecked(9),
+        &udp_addr,
+    );
+    state.record_relay_listener_check(&udp_addr, true);
+
+    assert_eq!(
+        relay_peers.circuit_addresses_for_target(target_peer, &state),
+        vec![
+            super::relay::peer_addr_with_relay(target_peer, udp_addr),
+            super::relay::peer_addr_with_relay(target_peer, tcp_addr)
+        ]
+    );
+}
+
+#[test]
 fn relay_retry_delay_switches_from_fast_backoff_to_persistent_cap() {
     assert_eq!(relay_retry_delay(1), Duration::from_millis(500));
     assert_eq!(relay_retry_delay(2), Duration::from_secs(1));

--- a/crates/swarm/src/libp2p/tests.rs
+++ b/crates/swarm/src/libp2p/tests.rs
@@ -109,7 +109,7 @@ fn relay_udp_refresh_plan_deduplicates_udp_addresses_and_prioritizes_preferred_r
 }
 
 #[test]
-fn relay_circuit_addresses_only_use_tcp_relay_endpoints() {
+fn relay_circuit_addresses_prefer_udp_relay_endpoints() {
     let relay_peer = libp2p::identity::Keypair::generate_ed25519()
         .public()
         .to_peer_id();
@@ -124,12 +124,98 @@ fn relay_circuit_addresses_only_use_tcp_relay_endpoints() {
         .parse()
         .unwrap();
 
-    let relay_peers = RelayPeers::new(vec![tcp_addr.clone(), udp_addr]);
+    let relay_peers = RelayPeers::new(vec![tcp_addr.clone(), udp_addr.clone()]);
+    let state = State::new(HashSet::new());
+    relay_peers.register_with_state(&state);
 
     assert_eq!(relay_peers.peer_ids(), &[relay_peer]);
     assert_eq!(
-        relay_peers.circuit_addresses_for_target(target_peer),
-        vec![super::relay::peer_addr_with_relay(target_peer, tcp_addr)]
+        relay_peers.circuit_addresses_for_target(target_peer, &state),
+        vec![
+            super::relay::peer_addr_with_relay(target_peer, udp_addr),
+            super::relay::peer_addr_with_relay(target_peer, tcp_addr)
+        ]
+    );
+}
+
+#[test]
+fn relay_circuit_addresses_keep_peer_order_and_sort_candidates_udp_first() {
+    let first_relay = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+    let second_relay = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+    let target_peer = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+
+    let first_tcp: Multiaddr = format!("/ip4/127.0.0.1/tcp/30001/p2p/{first_relay}")
+        .parse()
+        .unwrap();
+    let first_udp: Multiaddr = format!("/ip4/127.0.0.1/udp/30001/quic-v1/p2p/{first_relay}")
+        .parse()
+        .unwrap();
+    let second_tcp: Multiaddr = format!("/ip4/127.0.0.1/tcp/30002/p2p/{second_relay}")
+        .parse()
+        .unwrap();
+    let second_udp: Multiaddr = format!("/ip4/127.0.0.1/udp/30002/quic-v1/p2p/{second_relay}")
+        .parse()
+        .unwrap();
+
+    let relay_peers = RelayPeers::new(vec![
+        first_tcp.clone(),
+        second_tcp.clone(),
+        first_udp.clone(),
+        second_udp.clone(),
+    ]);
+    let state = State::new(HashSet::new());
+    relay_peers.register_with_state(&state);
+
+    assert_eq!(relay_peers.peer_ids(), &[first_relay, second_relay]);
+    assert_eq!(
+        relay_peers.circuit_addresses_for_target(target_peer, &state),
+        vec![
+            super::relay::peer_addr_with_relay(target_peer, first_udp),
+            super::relay::peer_addr_with_relay(target_peer, first_tcp),
+            super::relay::peer_addr_with_relay(target_peer, second_udp),
+            super::relay::peer_addr_with_relay(target_peer, second_tcp),
+        ]
+    );
+}
+
+#[test]
+fn relay_circuit_addresses_keep_active_tcp_first_without_upgrading() {
+    let relay_peer = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+    let target_peer = libp2p::identity::Keypair::generate_ed25519()
+        .public()
+        .to_peer_id();
+
+    let tcp_addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/30001/p2p/{relay_peer}")
+        .parse()
+        .unwrap();
+    let udp_addr: Multiaddr = format!("/ip4/127.0.0.1/udp/30001/quic-v1/p2p/{relay_peer}")
+        .parse()
+        .unwrap();
+    let relay_peers = RelayPeers::new(vec![tcp_addr.clone(), udp_addr.clone()]);
+    let state = State::new(HashSet::new());
+    relay_peers.register_with_state(&state);
+
+    state.record_relay_connection_established(
+        relay_peer,
+        ConnectionId::new_unchecked(8),
+        &tcp_addr,
+    );
+    state.record_relay_listener_check(&tcp_addr, true);
+
+    assert_eq!(
+        relay_peers.circuit_addresses_for_target(target_peer, &state),
+        vec![
+            super::relay::peer_addr_with_relay(target_peer, tcp_addr),
+            super::relay::peer_addr_with_relay(target_peer, udp_addr)
+        ]
     );
 }
 

--- a/crates/swarm/src/state/connectivity.rs
+++ b/crates/swarm/src/state/connectivity.rs
@@ -405,14 +405,6 @@ impl ConnectivityState {
         })
     }
 
-    pub fn relay_peer_active_endpoint(&self, relay_peer_id: PeerId) -> Option<Multiaddr> {
-        self.relay_endpoint_statuses
-            .values()
-            .filter(|status| status.relay_peer_id == Some(relay_peer_id))
-            .find(|status| relay_endpoint_status_ready(status))
-            .map(|status| status.relay_addr.clone())
-    }
-
     pub fn record_external_address_candidate(
         &mut self,
         address: Multiaddr,
@@ -1008,10 +1000,7 @@ mod tests {
         assert!(!state.relay_peer_ready(relay_peer_id));
         state.record_relay_listener_check(&udp_addr, true);
         assert!(state.relay_peer_ready(relay_peer_id));
-        assert_eq!(
-            state.relay_peer_active_endpoint(relay_peer_id),
-            Some(udp_addr.clone())
-        );
+        assert!(state.relay_endpoint_ready(&udp_addr));
 
         assert!(state.record_relay_connection_closed(
             relay_peer_id,

--- a/crates/swarm/src/state/connectivity.rs
+++ b/crates/swarm/src/state/connectivity.rs
@@ -88,21 +88,20 @@ impl AddressFreshness {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum RelayManagementAction {
-    ListenTaskStarted,
-    ListenTaskSucceeded,
+    ReconcileTaskStarted,
+    ReconcileTaskSucceeded,
     ListenerMissingReconcile,
     DirectConnectionMissingReconcile,
     ReservationEstablished,
     ReservationRenewed,
     DirectConnectionClosed,
-    DirectConnectionClosedAwaitingManagementLoop,
 }
 
 impl RelayManagementAction {
     pub fn as_str(&self) -> &'static str {
         match self {
-            RelayManagementAction::ListenTaskStarted => "listen-task-started",
-            RelayManagementAction::ListenTaskSucceeded => "listen-task-succeeded",
+            RelayManagementAction::ReconcileTaskStarted => "reconcile-task-started",
+            RelayManagementAction::ReconcileTaskSucceeded => "reconcile-task-succeeded",
             RelayManagementAction::ListenerMissingReconcile => "listener-missing-reconcile",
             RelayManagementAction::DirectConnectionMissingReconcile => {
                 "direct-connection-missing-reconcile"
@@ -110,9 +109,6 @@ impl RelayManagementAction {
             RelayManagementAction::ReservationEstablished => "reservation-established",
             RelayManagementAction::ReservationRenewed => "reservation-renewed",
             RelayManagementAction::DirectConnectionClosed => "direct-connection-closed",
-            RelayManagementAction::DirectConnectionClosedAwaitingManagementLoop => {
-                "direct-connection-closed-awaiting-management-loop"
-            }
         }
     }
 }

--- a/crates/swarm/src/state/connectivity.rs
+++ b/crates/swarm/src/state/connectivity.rs
@@ -316,13 +316,15 @@ impl ConnectivityState {
         let now = SystemTime::now();
 
         for status in self.relay_endpoint_statuses.values_mut() {
-            if status.relay_peer_id == Some(relay_peer_id)
-                && status.transport_kind == AddressTransportKind::Tcp
-            {
-                status.current_direct_connection_id = direct_connections
+            if status.relay_peer_id == Some(relay_peer_id) {
+                let Some(direct_connection) = direct_connections
                     .iter()
                     .find(|snapshot| snapshot.transport_kind == status.transport_kind)
-                    .map(|snapshot| snapshot.connection_id);
+                else {
+                    continue;
+                };
+
+                status.current_direct_connection_id = Some(direct_connection.connection_id);
                 status.last_reservation_accepted_at = Some(now);
                 match change {
                     RelayManagementAction::ReservationEstablished => {
@@ -391,16 +393,24 @@ impl ConnectivityState {
             .is_some()
     }
 
-    pub fn relay_tcp_ready(&self, relay_peer_id: PeerId) -> bool {
-        // UDP/QUIC relay endpoints are observer-only. A UDP refresh is allowed
-        // only when the same relay peer already has an active TCP reservation
-        // carrier and a registered relay listener.
+    pub fn relay_endpoint_ready(&self, relay_addr: &Multiaddr) -> bool {
+        self.relay_endpoint_statuses
+            .get(relay_addr)
+            .is_some_and(relay_endpoint_status_ready)
+    }
+
+    pub fn relay_peer_ready(&self, relay_peer_id: PeerId) -> bool {
         self.relay_endpoint_statuses.values().any(|status| {
-            status.relay_peer_id == Some(relay_peer_id)
-                && status.transport_kind == AddressTransportKind::Tcp
-                && status.listener_registered
-                && status.current_direct_connection_id.is_some()
+            status.relay_peer_id == Some(relay_peer_id) && relay_endpoint_status_ready(status)
         })
+    }
+
+    pub fn relay_peer_active_endpoint(&self, relay_peer_id: PeerId) -> Option<Multiaddr> {
+        self.relay_endpoint_statuses
+            .values()
+            .filter(|status| status.relay_peer_id == Some(relay_peer_id))
+            .find(|status| relay_endpoint_status_ready(status))
+            .map(|status| status.relay_addr.clone())
     }
 
     pub fn record_external_address_candidate(
@@ -616,6 +626,10 @@ pub fn address_transport_kind(addr: &Multiaddr) -> AddressTransportKind {
     }
 
     AddressTransportKind::Other
+}
+
+fn relay_endpoint_status_ready(status: &RelayEndpointStatusRecord) -> bool {
+    status.listener_registered && status.current_direct_connection_id.is_some()
 }
 
 fn relay_peer_id(addr: &Multiaddr) -> Option<PeerId> {
@@ -973,7 +987,7 @@ mod tests {
     }
 
     #[test]
-    fn relay_peer_tcp_health_requires_tcp_listener_and_direct_connection() {
+    fn relay_peer_health_requires_listener_and_direct_connection() {
         let relay_peer_id = PeerId::random();
         let tcp_addr: Multiaddr = format!("/ip4/160.16.206.21/tcp/30001/p2p/{relay_peer_id}")
             .parse()
@@ -991,29 +1005,41 @@ mod tests {
             ConnectionId::new_unchecked(7),
             &udp_addr,
         );
+        assert!(!state.relay_peer_ready(relay_peer_id));
         state.record_relay_listener_check(&udp_addr, true);
-        assert!(!state.relay_tcp_ready(relay_peer_id));
+        assert!(state.relay_peer_ready(relay_peer_id));
+        assert_eq!(
+            state.relay_peer_active_endpoint(relay_peer_id),
+            Some(udp_addr.clone())
+        );
+
+        assert!(state.record_relay_connection_closed(
+            relay_peer_id,
+            ConnectionId::new_unchecked(7),
+            &udp_addr
+        ));
+        assert!(!state.relay_peer_ready(relay_peer_id));
 
         state.record_relay_connection_established(
             relay_peer_id,
             ConnectionId::new_unchecked(8),
             &tcp_addr,
         );
-        assert!(!state.relay_tcp_ready(relay_peer_id));
+        assert!(!state.relay_peer_ready(relay_peer_id));
 
         state.record_relay_listener_check(&tcp_addr, true);
-        assert!(state.relay_tcp_ready(relay_peer_id));
+        assert!(state.relay_peer_ready(relay_peer_id));
 
         assert!(state.record_relay_connection_closed(
             relay_peer_id,
             ConnectionId::new_unchecked(8),
             &tcp_addr
         ));
-        assert!(!state.relay_tcp_ready(relay_peer_id));
+        assert!(!state.relay_peer_ready(relay_peer_id));
     }
 
     #[test]
-    fn relay_reservation_accept_updates_only_tcp_endpoint() {
+    fn relay_reservation_accept_updates_udp_endpoint() {
         let relay_peer_id = PeerId::random();
         let tcp_addr: Multiaddr = format!("/ip4/160.16.206.21/tcp/30001/p2p/{relay_peer_id}")
             .parse()
@@ -1026,18 +1052,11 @@ mod tests {
         state.register_relay_endpoint(tcp_addr.clone());
         state.register_relay_endpoint(udp_addr.clone());
 
-        let tcp_connection_id = ConnectionId::new_unchecked(8);
         let udp_connection_id = ConnectionId::new_unchecked(9);
-        let direct_connections = vec![
-            RelayDirectConnectionSnapshot {
-                transport_kind: AddressTransportKind::Tcp,
-                connection_id: tcp_connection_id,
-            },
-            RelayDirectConnectionSnapshot {
-                transport_kind: AddressTransportKind::Udp,
-                connection_id: udp_connection_id,
-            },
-        ];
+        let direct_connections = vec![RelayDirectConnectionSnapshot {
+            transport_kind: AddressTransportKind::Udp,
+            connection_id: udp_connection_id,
+        }];
 
         state.record_relay_reservation_accepted(
             relay_peer_id,
@@ -1056,16 +1075,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            tcp_status.last_management_action,
+            udp_status.last_management_action,
             Some(RelayManagementAction::ReservationEstablished)
         );
         assert_eq!(
-            tcp_status.current_direct_connection_id,
-            Some(tcp_connection_id)
+            udp_status.current_direct_connection_id,
+            Some(udp_connection_id)
         );
-        assert!(tcp_status.last_reservation_established_at.is_some());
-        assert_eq!(udp_status.last_management_action, None);
-        assert_eq!(udp_status.current_direct_connection_id, None);
-        assert!(udp_status.last_reservation_established_at.is_none());
+        assert!(udp_status.last_reservation_established_at.is_some());
+        assert_eq!(tcp_status.last_management_action, None);
+        assert_eq!(tcp_status.current_direct_connection_id, None);
+        assert!(tcp_status.last_reservation_established_at.is_none());
     }
 }

--- a/crates/swarm/src/state/registry.rs
+++ b/crates/swarm/src/state/registry.rs
@@ -247,10 +247,22 @@ impl State {
             .relay_endpoint_active(relay_addr)
     }
 
-    pub fn relay_tcp_ready(&self, relay_peer_id: PeerId) -> bool {
+    pub fn relay_endpoint_ready(&self, relay_addr: &Multiaddr) -> bool {
         self.connectivity_state
             .lock()
-            .relay_tcp_ready(relay_peer_id)
+            .relay_endpoint_ready(relay_addr)
+    }
+
+    pub fn relay_peer_ready(&self, relay_peer_id: PeerId) -> bool {
+        self.connectivity_state
+            .lock()
+            .relay_peer_ready(relay_peer_id)
+    }
+
+    pub fn relay_peer_active_endpoint(&self, relay_peer_id: PeerId) -> Option<Multiaddr> {
+        self.connectivity_state
+            .lock()
+            .relay_peer_active_endpoint(relay_peer_id)
     }
 
     pub fn record_external_address_candidate(

--- a/crates/swarm/src/state/registry.rs
+++ b/crates/swarm/src/state/registry.rs
@@ -259,12 +259,6 @@ impl State {
             .relay_peer_ready(relay_peer_id)
     }
 
-    pub fn relay_peer_active_endpoint(&self, relay_peer_id: PeerId) -> Option<Multiaddr> {
-        self.connectivity_state
-            .lock()
-            .relay_peer_active_endpoint(relay_peer_id)
-    }
-
     pub fn record_external_address_candidate(
         &self,
         address: Multiaddr,

--- a/crates/tests/src/bin/test_allowlist_relay_ping_cli.rs
+++ b/crates/tests/src/bin/test_allowlist_relay_ping_cli.rs
@@ -559,7 +559,7 @@ fn write_test_config(
     let relay_tcp = format!("/ip4/127.0.0.1/tcp/{relay_tcp_port}/p2p/{relay_peer_id}");
     let relay_udp = format!("/ip4/127.0.0.1/udp/{relay_udp_port}/quic-v1/p2p/{relay_peer_id}");
     let config = format!(
-        "[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {listen_tcp_port}\nlisten_udp_port = {listen_udp_port}\nrelay_enabled = true\nuse_community_relays = false\ncustom_relay_addresses = [\"{relay_tcp}\", \"{relay_udp}\"]\n"
+        "[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {listen_tcp_port}\nlisten_udp_port = {listen_udp_port}\nrelay_enabled = true\nuse_community_relays = false\ncustom_relay_addresses = [\"{relay_udp}\", \"{relay_tcp}\"]\n"
     );
 
     fs::write(fungi_dir.join("config.toml"), config).with_context(|| {

--- a/crates/tests/src/bin/test_relay_runtime_cli.rs
+++ b/crates/tests/src/bin/test_relay_runtime_cli.rs
@@ -144,7 +144,7 @@ impl RelayRuntimeTestContext {
                 .find(']')
                 .map(|offset| start + offset)
                 .context("failed to find end of custom_relay_addresses")?;
-            let replacement = format!("custom_relay_addresses = [{}, {}]", relay_tcp, relay_udp);
+            let replacement = format!("custom_relay_addresses = [{}, {}]", relay_udp, relay_tcp);
             content.replace_range(start..=end, &replacement);
         } else {
             bail!("custom_relay_addresses field not found in config file");

--- a/fungi/src/commands/fungi_control/relay_config.rs
+++ b/fungi/src/commands/fungi_control/relay_config.rs
@@ -28,7 +28,7 @@ pub enum RelayCommands {
         #[arg(value_enum)]
         mode: RelayMode,
     },
-    /// Add a custom relay multiaddr. TCP entries carry relay reservations; UDP/QUIC entries are observer-only.
+    /// Add a custom relay multiaddr. Candidates are grouped by relay peer and tried UDP/QUIC first, then TCP.
     Add { address: String },
     /// Remove a custom relay multiaddr
     Remove { address: String },
@@ -255,6 +255,6 @@ fn print_local_relay_config(config: &FungiConfig) {
 
 fn print_relay_transport_policy_note() {
     println!(
-        "note: TCP relay addresses maintain reservations/circuits; UDP/QUIC relay addresses are observer-only for UDP address refresh."
+        "note: relay candidates are grouped by relay peer; each group tries UDP/QUIC first and falls back to TCP for reservation/circuit availability."
     );
 }

--- a/fungi/src/commands/fungi_relay.rs
+++ b/fungi/src/commands/fungi_relay.rs
@@ -29,7 +29,7 @@ pub struct RelayArgs {
     #[clap(
         short,
         long,
-        help = "Tcp listen port for the relay server, defaults to 30001",
+        help = "TCP listen port for the relay server, defaults to 30001",
         default_value_t = DEFAULT_LISTEN_PORT
     )]
     pub tcp_listen_port: u16,
@@ -37,7 +37,7 @@ pub struct RelayArgs {
     #[clap(
         short,
         long,
-        help = "Udp listen port for QUIC observer traffic, defaults to 30001",
+        help = "UDP listen port for QUIC relay traffic, defaults to 30001",
         default_value_t = DEFAULT_LISTEN_PORT
     )]
     pub udp_listen_port: u16,
@@ -110,8 +110,8 @@ pub async fn run(args: RelayArgs) -> Result<()> {
     let tcp_listen_addr = Multiaddr::empty()
         .with(Protocol::from(public_ip))
         .with(Protocol::Tcp(tcp_listen_port));
-    // Clients use the TCP address for relay reservations/circuits and the
-    // UDP/QUIC address as an observer for external UDP address discovery.
+    // Clients can use both addresses for relay reservations/circuits. The
+    // daemon prefers UDP/QUIC and falls back to TCP per relay peer.
     let udp_listen_addr = Multiaddr::empty()
         .with(Protocol::from(public_ip))
         .with(Protocol::Udp(udp_listen_port))


### PR DESCRIPTION
### **User description**
## Summary

This PR changes relay reservation management from a TCP-durable / UDP-observer model to peer-level UDP-first reservation with TCP fallback. Relay endpoints are now grouped by relay peer, preserving relay peer order while trying UDP/QUIC candidates before TCP within each peer.

## What changed

- Groups relay candidates by relay peer and sorts each group as UDP/QUIC first, then TCP.
- Replaces TCP-only relay health checks with generic peer/endpoint readiness checks.
- Runs relay reconcile as a peer-level task: try UDP first, fall back to TCP for this attempt, and do not hot-upgrade a healthy TCP fallback back to UDP.
- Updates circuit dial ordering to prefer the currently active ready endpoint, then UDP candidates, then TCP candidates.
- Allows relay reservation acceptance to update UDP endpoints instead of only TCP endpoints.
- Keeps UDP refresh separate and only runs it when UDP is already the active relay reservation endpoint.
- Updates the default relay address order to list UDP before TCP.

## Why

The previous split made TCP the only durable relay carrier while UDP was used as an observer path. That made it hard to move toward UDP-first relay behavior and could also make relay state reasoning more confusing. The new model treats UDP and TCP as candidates for the same relay peer while keeping at most one durable active endpoint per relay peer.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p fungi-swarm`
- `cargo check --workspace`

## Notes

This PR intentionally does not reintroduce `prepare_for_relay_fallback()`. UDP failures are attempt-local and are not stored as a long-lived unavailable state. A healthy TCP fallback is not interrupted just to upgrade to UDP; the next reconcile or daemon restart starts from UDP again.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Relay endpoints are grouped by relay peer, each group prioritized UDP/QUIC first then TCP.

- Relay health checks replaced with transport-agnostic peer readiness, evaluating any active endpoint.

- Reservation reconcile per peer: attempt UDP, fall back to TCP; healthy TCP not upgraded to UDP.

- Circuit dial ordering prefers active endpoint, then UDP candidates, then TCP; state now passed in.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Group relay addresses by peer"] --> B["Try UDP/QUIC reservation"]
  B -->|Success| C["Use UDP as active endpoint"]
  B -->|Failure| D["Fall back to TCP"]
  D --> E["Keep TCP without hot upgrade"]
  E --> F["Next reconcile starts from UDP again"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>libp2p.rs</strong><dd><code>Update relay address documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-4ba8f3ccfb604042187554df94e86d2a56ea16c4ee9c1473f7d4b314a70e8012">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fungi_daemon.rs</strong><dd><code>Update gRPC relay address documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-de430bb5fc0842519b2cf7230a2d925a14e209629f57d1429ad8252bf45c6414">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>relay_config.rs</strong><dd><code>Update CLI relay transport policy note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-21e5cf2c2ef100a4f8fb3c8f4e23da9d12d67e8f09228c93dd0e2345e8e0129f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fungi_relay.rs</strong><dd><code>Update relay CLI help text for UDP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-a0f5c48976e23cc538d4d89bc96f4aab2d82f49f2af355d7128b6c76e4389203">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fungi_daemon.proto</strong><dd><code>Update proto relay address documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-a79e7c36fa291f08f12da21a18acb87ddbf0a2e0364e8ae8dfc2c35643b5c467">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>util.rs</strong><dd><code>Rename relay_tcp_addr to relay_addr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-32b469705a88ebd349d2cb17d051bc239a8e66d6e318f01b368aeb1162a0e30e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>control.rs</strong><dd><code>Pass state to circuit_addresses_for_target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-98384733db97f8aa9bc2437479f0d7f6134a600e7b73df9cf191db5da2b8d93e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>relay.rs</strong><dd><code>Implement UDP-first relay reservation per peer group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-eee563123f465b57d2b69334e35f1f4da03e75d21b49c4015b9edf7ae8a12593">+346/-184</a></td>

</tr>

<tr>
  <td><strong>runtime.rs</strong><dd><code>Remove observer-only listen addr filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-be757f10488bec3a6859d4745320af7bfb8007d3c035648aff61ec16a213f9d0">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>connectivity.rs</strong><dd><code>Implement transport-agnostic relay readiness checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-af8b304a7d41a0372256e192739c425cecc09b92be9f7d2ec0bb37aaef583384">+49/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>registry.rs</strong><dd><code>Delegate relay_peer_ready and relay_endpoint_ready</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-ebd3ab8457f3fb48715fbed43ea330f67392d4a12f7476c29574bbbf885b1414">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>tests.rs</strong><dd><code>Add tests for UDP-first relay circuit ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-5dc62cb0c57c024c0950f059b368693d6ef1078ecdb9c58a6cec8a57d44b0f04">+131/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_allowlist_relay_ping_cli.rs</strong><dd><code>Order relay test config UDP first</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-23c97ace4476df962ecbfca1de7490442f535f1d85e8ca03210e1f4c5046c051">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_relay_runtime_cli.rs</strong><dd><code>Order relay test config UDP first</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/enbop/fungi/pull/45/files#diff-b2010ad1dec13d1420dba9cfeba282bbcc1d85f38df725696c2a0fb6218752fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

