### PR TITLE
[codex] Add PR-Agent workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -3,6 +3,8 @@ name: PR-Agent
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -12,7 +14,22 @@ permissions:
 jobs:
   pr_agent:
     name: Review pull request
-    if: ${{ github.event.sender.type != 'Bot' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: >-
+      ${{
+        github.event.sender.type != 'Bot' &&
+        (
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+          ) ||
+          (
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request != null &&
+            startsWith(github.event.comment.body, '/review') &&
+            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Run PR-Agent

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,28 @@
+name: PR-Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr_agent:
+    name: Review pull request
+    if: ${{ github.event.sender.type != 'Bot' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run PR-Agent
+        uses: the-pr-agent/pr-agent@ffe1f89a4dafc7d8e88b9cf010a3233e30b49f43 # v0.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEEPSEEK.KEY: ${{ secrets.DEEPSEEK_KEY }}
+          config.model: deepseek/deepseek-v4-pro
+          config.fallback_models: '["deepseek/deepseek-v4-pro"]'
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "false"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'


### PR DESCRIPTION
## Summary

- Add a dedicated PR-Agent GitHub Actions workflow.
- Configure PR-Agent to use DeepSeek V4 Pro via the `DEEPSEEK_KEY` Actions secret.
- Enable automatic review and description generation for same-repository PRs, while keeping auto-improve disabled for the initial rollout.
- Allow trusted maintainers to manually run PR-Agent review on fork PRs by commenting `/review`.

## Security

- The workflow only references `${{ secrets.DEEPSEEK_KEY }}`; no API key value is committed.
- The workflow uses `pull_request` for same-repository automation and does not use `pull_request_target`.
- Fork PRs do not run automatically. A fork PR can run PR-Agent only when an `OWNER`, `MEMBER`, or `COLLABORATOR` comments `/review`.
- Comment-triggered runs are limited to PR comments created with a body starting with `/review`.
- The PR-Agent action is pinned to the full commit SHA for v0.36.0.
- Permissions are limited to `contents: read`, `issues: write`, and `pull-requests: write`.
- The workflow does not checkout or execute PR code.

## Validation

- Parsed `.github/workflows/pr-agent.yml` with PyYAML.
- Ran `git diff --check` and `git diff --cached --check`.
- Scanned the workflow/staged diff for common secret/token patterns; no real secret values were found.

## Setup

- Repository Actions secret `DEEPSEEK_KEY` must contain the DeepSeek API key.