### PR TITLE
Fix PR-Agent DeepSeek V4 Pro token limit

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -39,6 +39,7 @@ jobs:
           DEEPSEEK.KEY: ${{ secrets.DEEPSEEK_KEY }}
           config.model: deepseek/deepseek-v4-pro
           config.fallback_models: '["deepseek/deepseek-v4-pro"]'
+          config.custom_model_max_tokens: "1000000"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "false"


### PR DESCRIPTION
## Summary

- Configure PR-Agent with an explicit custom token limit for `deepseek/deepseek-v4-pro`.

## Why

- Manual `/review` runs currently reach PR-Agent but stop after `Preparing review...`.
- The workflow logs show PR-Agent v0.36.0 does not have `deepseek/deepseek-v4-pro` in its `MAX_TOKENS` table.
- Setting `config.custom_model_max_tokens` lets PR-Agent accept the model while its existing `config.max_model_tokens` cap still limits actual prompt size.

## Validation

- Parsed `.github/workflows/pr-agent.yml` with PyYAML.
- Ran `git diff --check` and `git diff --cached --check`.
- Scanned the workflow diff for common secret/token patterns; no real secret values were found.
