### PR TITLE
Require manual PR-Agent reviews

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,8 +1,6 @@
 name: PR-Agent
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
@@ -17,18 +15,9 @@ jobs:
     if: >-
       ${{
         github.event.sender.type != 'Bot' &&
-        (
-          (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == github.repository
-          ) ||
-          (
-            github.event_name == 'issue_comment' &&
-            github.event.issue.pull_request != null &&
-            startsWith(github.event.comment.body, '/review') &&
-            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-          )
-        )
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       }}
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +29,3 @@ jobs:
           config.model: deepseek/deepseek-v4-pro
           config.fallback_models: '["deepseek/deepseek-v4-pro"]'
           config.custom_model_max_tokens: "1000000"
-          github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "true"
-          github_action_config.auto_improve: "false"
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'


### PR DESCRIPTION
## Summary

- Change the PR-Agent workflow to run only from trusted `/review` PR comments.
- Remove the automatic `pull_request` trigger and auto-action env settings.

## Why

- The `pull_request` auto path can fail after `auto_describe` when it proceeds into `auto_review`.
- Recent logs on #45 showed PR-Agent entered the automatic chain, successfully reached DeepSeek, then failed in provider URL parsing.
- The manual `/review` `issue_comment` path has been verified to work with DeepSeek V4 Pro and the custom token limit.

## Security

- The workflow still does not use `pull_request_target`.
- The workflow still does not checkout or execute PR code.
- Only PR comments from `OWNER`, `MEMBER`, or `COLLABORATOR` starting with `/review` trigger PR-Agent.
- The DeepSeek key remains referenced only through `${{ secrets.DEEPSEEK_KEY }}`.

## Validation

- Parsed `.github/workflows/pr-agent.yml` with PyYAML.
- Ran `git diff --check` and `git diff --cached --check`.
- Scanned the workflow diff for common secret/token patterns; no real secret values were found.
