### PR TITLE
Allow trusted manual PR-Agent commands

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -16,7 +16,7 @@ jobs:
       ${{
         github.event.sender.type != 'Bot' &&
         github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/review') &&
+        startsWith(github.event.comment.body, '/') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Allow trusted repository members to trigger any PR-Agent slash command manually from PR comments.
- Keep PR-Agent disabled for automatic `pull_request` events.

## Why

- `/review` alone only produces the PR reviewer guide, which is often too high-level.
- Commands like `/improve` are the PR-Agent path for concrete code suggestions.
- Keeping all commands manual avoids the unstable automatic `pull_request` chain and prevents unwanted automatic PR description rewrites.

## Usage

- Use one command per comment for predictable behavior.
- Examples: `/review`, `/improve`, `/improve --pr_code_suggestions.commitable_code_suggestions=true`, `/ask "What are the risky parts of this PR?"`.
- `/describe` is available manually, but it may update the PR description unless overridden with PR-Agent options.

## Security

- Still does not use `pull_request_target`.
- Still does not checkout or execute PR code.
- Only `OWNER`, `MEMBER`, or `COLLABORATOR` PR comments that start with `/` can trigger PR-Agent.
- Secrets remain referenced only through GitHub Actions secrets.

## Validation

- Parsed `.github/workflows/pr-agent.yml` with PyYAML.
- Ran `git diff --check` and `git diff --cached --check`.
- Scanned the workflow diff for common secret/token patterns; no real secret values were found.
