### PR TITLE
[codex] Handle SIGTERM during daemon shutdown

### DIFF
--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -76,8 +76,9 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     };
 
     tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            log::info!("Received Ctrl+C, shutting down Fungi daemon...");
+        signal = termination_signal() => {
+            let signal = signal.context("Failed to wait for daemon termination signal")?;
+            log::info!("Received {signal}, shutting down Fungi daemon...");
         },
         res = server_fut => {
             if let Err(error) = res {
@@ -98,6 +99,26 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     }
 
     Ok(())
+}
+
+#[cfg(unix)]
+async fn termination_signal() -> std::io::Result<&'static str> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut terminate = signal(SignalKind::terminate())?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result?;
+            Ok("Ctrl+C")
+        },
+        _ = terminate.recv() => Ok("SIGTERM"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn termination_signal() -> std::io::Result<&'static str> {
+    tokio::signal::ctrl_c().await?;
+    Ok("Ctrl+C")
 }
 
 fn print_grpc_startup_error(rpc_listen_address: &str, error: &anyhow::Error) {


### PR DESCRIPTION
## Summary

- handle `SIGTERM` as a graceful daemon shutdown signal on Unix
- preserve existing `Ctrl+C` behavior across platforms
- propagate signal-handler errors through the daemon error path

## Root cause

The daemon only handled `SIGINT` from Ctrl+C. Background process managers normally stop daemons with `SIGTERM`, which terminated Fungi without running Rust destructors. Managed Wasmtime child processes therefore survived as orphans.

On the next daemon start, persisted services with a desired running state were launched again. The replacement process failed because the orphan still owned the service port, so Fungi reported `exited(1)` even though the old process continued serving traffic.

## Impact

Unix daemon shutdown through `SIGTERM` now follows the normal teardown path. Dropping the runtime provider activates the existing `kill_on_drop` behavior for managed Wasmtime children, allowing persisted services to restart cleanly with accurate state.

## Validation

- `cargo fmt --check`
- `cargo test -p fungi`
- `cargo check --workspace`
- reproduced the stale `exited(1)` state with a fresh Wasmtime service on a two-node setup
- verified `SIGTERM` removes managed Wasmtime child processes
- verified daemon restart restores the service as `running`
- verified remote stop/start restores the saved local listener and returns HTTP 200
