### PR TITLE
[codex] Finalize v0.7.0 config migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - Unreleased
+
+### Changed
+
+- The Fungi directory is migrated to schema v3 before commands run. Existing managed service data is moved into per-service `appdata/services/<local_service_id>/` directories, while service manifests and state use the new `services/<local_service_id>/` layout.
+- Migration creates a full snapshot under `bk/` before changing the live Fungi directory. Back up the Fungi directory separately before upgrading if the existing service data or legacy forwarding configuration is important.
+
+### Removed
+
+- Legacy `tcp_tunneling` and `file_transfer` configuration sections are removed during migration and are not retained as runtime compatibility paths. Legacy service access records are migrated to `local_preferences`, but other legacy forwarding rules must be recreated after upgrading.
+- Obsolete remote service cache directories are removed after being included in the migration backup.
+
 ## [0.6.1] - 2026-04-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "fungi"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-config"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "fungi-config-migrate",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-config-migrate"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-daemon"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-daemon-grpc"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "fungi-config",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-docker-agent"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-lab"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-stream"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-swarm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-result",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-tests"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "env_logger 0.11.8",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/config-migrate/src/apply.rs
+++ b/crates/config-migrate/src/apply.rs
@@ -9,8 +9,10 @@ use crate::{
     detection::detect_source_version,
     model::{
         APPLY_ROLLBACK_DIR_NAME, BACKUP_ROOT_DIR, CURRENT_FUNGI_DIR_VERSION, DEVICES_FILE,
-        DetectedVersion, LEGACY_ADDRESS_BOOK_FILE, LEGACY_SERVICE_STATE_FILE, MigrationPlan,
-        STAGING_DIR_PREFIX,
+        DetectedVersion, LEGACY_ADDRESS_BOOK_FILE, LEGACY_LOCAL_ACCESS_FILE,
+        LEGACY_MANAGED_SERVICES_CACHE_DIR, LEGACY_REMOTE_SERVICES_CACHE_DIR,
+        LEGACY_SERVICE_STATE_FILE, LOCAL_PREFERENCES_FILE, MigrationPlan, STAGING_DIR_PREFIX,
+        TRUSTED_DEVICES_FILE,
     },
 };
 
@@ -42,44 +44,76 @@ impl MigrationTransaction {
             )
         })?;
 
-        let backup_dir = backup_root.join(format!(
+        let backup_dir_name = format!(
             "{timestamp}-from-{}-to-v{target_version}",
             source_version.backup_label()
-        ));
-        let staging_dir =
-            fungi_dir.join(format!("{STAGING_DIR_PREFIX}{timestamp}-v{target_version}"));
-
-        if backup_dir.exists() {
-            bail!(
-                "Refusing to overwrite existing migration backup directory: {}",
-                backup_dir.display()
-            );
-        }
-        if staging_dir.exists() {
-            bail!(
-                "Refusing to overwrite existing migration staging directory: {}",
-                staging_dir.display()
-            );
-        }
-
-        fs::create_dir_all(&backup_dir).with_context(|| {
-            format!(
-                "Failed to create migration backup directory: {}",
-                backup_dir.display()
-            )
-        })?;
-        fs::create_dir_all(&staging_dir).with_context(|| {
-            format!(
-                "Failed to create migration staging directory: {}",
-                staging_dir.display()
-            )
-        })?;
+        );
+        let staging_dir_name = format!("{STAGING_DIR_PREFIX}{timestamp}-v{target_version}");
+        let (backup_dir, staging_dir) = allocate_transaction_dirs(
+            &backup_root,
+            fungi_dir,
+            &backup_dir_name,
+            &staging_dir_name,
+        )?;
 
         Ok(Self {
             backup_dir,
             staging_dir,
         })
     }
+}
+
+fn allocate_transaction_dirs(
+    backup_root: &Path,
+    fungi_dir: &Path,
+    backup_dir_name: &str,
+    staging_dir_name: &str,
+) -> Result<(PathBuf, PathBuf)> {
+    for attempt in 0..1000 {
+        let suffix = if attempt == 0 {
+            String::new()
+        } else {
+            format!("-{attempt}")
+        };
+        let backup_dir = backup_root.join(format!("{backup_dir_name}{suffix}"));
+        let staging_dir = fungi_dir.join(format!("{staging_dir_name}{suffix}"));
+        if backup_dir.exists() || staging_dir.exists() {
+            continue;
+        }
+
+        match fs::create_dir(&backup_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to create migration backup directory: {}",
+                        backup_dir.display()
+                    )
+                });
+            }
+        }
+        match fs::create_dir(&staging_dir) {
+            Ok(()) => return Ok((backup_dir, staging_dir)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let _ = fs::remove_dir_all(&backup_dir);
+            }
+            Err(error) => {
+                let _ = fs::remove_dir_all(&backup_dir);
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to create migration staging directory: {}",
+                        staging_dir.display()
+                    )
+                });
+            }
+        }
+    }
+
+    bail!(
+        "Failed to allocate a unique migration backup directory under {}",
+        backup_root.display()
+    )
 }
 
 pub(crate) fn copy_selected_paths(
@@ -105,6 +139,25 @@ pub(crate) fn copy_selected_paths(
     Ok(())
 }
 
+pub(crate) fn copy_backup_snapshot(source_root: &Path, target_root: &Path) -> Result<()> {
+    for entry in fs::read_dir(source_root).with_context(|| {
+        format!(
+            "Failed to read source directory during migration backup: {}",
+            source_root.display()
+        )
+    })? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let display_name = file_name.to_string_lossy();
+        if display_name == BACKUP_ROOT_DIR || display_name.starts_with(STAGING_DIR_PREFIX) {
+            continue;
+        }
+
+        copy_path_recursively(&entry.path(), &target_root.join(file_name))?;
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_migrated_dir(staging_root: &Path, plan: &MigrationPlan) -> Result<()> {
     if plan.update_config {
         match detect_source_version(staging_root)? {
@@ -126,6 +179,28 @@ pub(crate) fn validate_migrated_dir(staging_root: &Path, plan: &MigrationPlan) -
         if !staging_root.join(DEVICES_FILE).exists() {
             bail!("Migration validation failed; devices.toml was not created in staging");
         }
+    }
+
+    if plan.migrate_incoming_allowed_peers && !staging_root.join(TRUSTED_DEVICES_FILE).exists() {
+        bail!("Migration validation failed; trusted_devices.toml was not created in staging");
+    }
+
+    if plan.migrate_legacy_local_access {
+        if staging_root.join(LEGACY_LOCAL_ACCESS_FILE).exists() {
+            bail!("Migration validation failed; legacy local_access.json still exists in staging");
+        }
+        if !staging_root.join(LOCAL_PREFERENCES_FILE).exists() {
+            bail!("Migration validation failed; local_preferences.json was not created in staging");
+        }
+    }
+
+    if plan.remove_legacy_service_caches
+        && (staging_root.join(LEGACY_REMOTE_SERVICES_CACHE_DIR).exists()
+            || staging_root
+                .join(LEGACY_MANAGED_SERVICES_CACHE_DIR)
+                .exists())
+    {
+        bail!("Migration validation failed; obsolete remote service caches still exist in staging");
     }
 
     if plan.migrate_legacy_managed_services && staging_root.join(LEGACY_SERVICE_STATE_FILE).exists()

--- a/crates/config-migrate/src/config_files.rs
+++ b/crates/config-migrate/src/config_files.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, fs, path::Path};
 
 use crate::model::{
     CONFIG_FILE, CURRENT_FUNGI_DIR_VERSION, DEVICES_FILE, LEGACY_ADDRESS_BOOK_FILE,
-    SERVICES_ROOT_DIR, normalize_fs_path,
+    SERVICES_ROOT_DIR, TRUSTED_DEVICES_FILE, normalize_fs_path,
 };
 
 pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Path) -> Result<()> {
@@ -25,6 +25,11 @@ pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Pa
         toml::Value::Integer(CURRENT_FUNGI_DIR_VERSION.into()),
     );
     table.remove("incoming_allowed_peers");
+    table.remove("tcp_tunneling");
+    table.remove("file_transfer");
+    if let Some(network_table) = table.get_mut("network").and_then(toml::Value::as_table_mut) {
+        network_table.remove("incoming_allowed_peers");
+    }
 
     if let Some(runtime_table) = table.get_mut("runtime").and_then(toml::Value::as_table_mut) {
         runtime_table.remove("allowed_ports");
@@ -41,6 +46,62 @@ pub(crate) fn migrate_config_toml_to_current(staging_root: &Path, fungi_dir: &Pa
         )
     })?;
 
+    Ok(())
+}
+
+pub(crate) fn migrate_legacy_incoming_allowed_peers(staging_root: &Path) -> Result<()> {
+    let config_path = staging_root.join(CONFIG_FILE);
+    let content = fs::read_to_string(&config_path).with_context(|| {
+        format!(
+            "Failed to read config.toml from staging directory: {}",
+            config_path.display()
+        )
+    })?;
+    let value: toml::Value =
+        toml::from_str(&content).context("Failed to parse config.toml in staging")?;
+    let Some(table) = value.as_table() else {
+        anyhow::bail!("config.toml root must be a TOML table");
+    };
+
+    let mut incoming_peers = legacy_incoming_allowed_peers(table)?;
+    incoming_peers.sort();
+    incoming_peers.dedup();
+
+    let trusted_devices_path = staging_root.join(TRUSTED_DEVICES_FILE);
+    let mut trusted_devices_value = if trusted_devices_path.exists() {
+        let existing = fs::read_to_string(&trusted_devices_path).with_context(|| {
+            format!(
+                "Failed to read existing trusted_devices.toml from staging directory: {}",
+                trusted_devices_path.display()
+            )
+        })?;
+        toml::from_str(&existing)
+            .context("Failed to parse existing trusted_devices.toml in staging")?
+    } else {
+        toml::Value::Table(toml::map::Map::new())
+    };
+
+    let trusted_devices = ensure_toml_array_field(&mut trusted_devices_value, "trusted_devices")?;
+    let mut existing = trusted_devices
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+    for peer_id in incoming_peers {
+        if existing.insert(peer_id.clone()) {
+            trusted_devices.push(toml::Value::String(peer_id));
+        }
+    }
+    trusted_devices.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+
+    let encoded = toml::to_string_pretty(&trusted_devices_value)
+        .context("Failed to encode migrated trusted_devices.toml from staging")?;
+    fs::write(&trusted_devices_path, encoded).with_context(|| {
+        format!(
+            "Failed to write migrated trusted_devices.toml into staging directory: {}",
+            trusted_devices_path.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -128,13 +189,54 @@ fn remove_legacy_services_allowlist(runtime_table: &mut toml::Table, fungi_dir: 
     };
 
     paths.retain(|value| {
-        !value
+        value
             .as_str()
-            .is_some_and(|raw| normalize_fs_path(Path::new(raw)) == legacy_services_path)
+            .is_none_or(|raw| normalize_fs_path(Path::new(raw)) != legacy_services_path)
     });
     if paths.is_empty() {
         runtime_table.remove("allowed_host_paths");
     }
+}
+
+fn legacy_incoming_allowed_peers(table: &toml::Table) -> Result<Vec<String>> {
+    let mut peers = Vec::new();
+    append_toml_string_array(
+        &mut peers,
+        table.get("incoming_allowed_peers"),
+        "incoming_allowed_peers",
+    )?;
+    append_toml_string_array(
+        &mut peers,
+        table
+            .get("network")
+            .and_then(toml::Value::as_table)
+            .and_then(|network| network.get("incoming_allowed_peers")),
+        "network.incoming_allowed_peers",
+    )?;
+    Ok(peers)
+}
+
+fn append_toml_string_array(
+    output: &mut Vec<String>,
+    value: Option<&toml::Value>,
+    field_name: &str,
+) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(values) = value.as_array() else {
+        anyhow::bail!("{field_name} must be an array of peer IDs");
+    };
+    for item in values {
+        let Some(peer_id) = item.as_str() else {
+            anyhow::bail!("{field_name} must contain only peer ID strings");
+        };
+        let peer_id = peer_id.trim();
+        if !peer_id.is_empty() {
+            output.push(peer_id.to_string());
+        }
+    }
+    Ok(())
 }
 
 fn ensure_toml_array_field<'a>(

--- a/crates/config-migrate/src/detection.rs
+++ b/crates/config-migrate/src/detection.rs
@@ -6,8 +6,11 @@ use std::{
 };
 
 use crate::model::{
-    CONFIG_FILE, DATA_ROOT_DIR, DEVICES_FILE, DetectedVersion, LEGACY_ADDRESS_BOOK_FILE,
-    LEGACY_SERVICE_STATE_FILE, MigrationPlan, SERVICES_ROOT_DIR, normalize_fs_path,
+    APPDATA_SERVICES_ROOT_DIR, ARTIFACTS_SERVICES_ROOT_DIR, CONFIG_FILE, DEVICES_FILE,
+    DetectedVersion, LEGACY_ADDRESS_BOOK_FILE, LEGACY_LOCAL_ACCESS_FILE,
+    LEGACY_MANAGED_SERVICES_CACHE_DIR, LEGACY_REMOTE_SERVICES_CACHE_DIR, LEGACY_SERVICE_STATE_FILE,
+    LOCAL_PREFERENCES_FILE, MigrationPlan, PREVIOUS_FUNGI_DIR_VERSION, SERVICES_ROOT_DIR,
+    TRUSTED_DEVICES_FILE, normalize_fs_path,
 };
 
 pub fn detect_source_version(fungi_dir: &Path) -> Result<DetectedVersion> {
@@ -52,6 +55,13 @@ pub(crate) fn build_migration_plan(
 ) -> Result<MigrationPlan> {
     let legacy_address_book_exists = fungi_dir.join(LEGACY_ADDRESS_BOOK_FILE).exists();
     let legacy_service_state_exists = fungi_dir.join(LEGACY_SERVICE_STATE_FILE).exists();
+    let legacy_local_access_exists = fungi_dir.join(LEGACY_LOCAL_ACCESS_FILE).exists();
+    let legacy_remote_services_cache_exists =
+        fungi_dir.join(LEGACY_REMOTE_SERVICES_CACHE_DIR).exists();
+    let legacy_managed_services_cache_exists =
+        fungi_dir.join(LEGACY_MANAGED_SERVICES_CACHE_DIR).exists();
+    let remove_legacy_service_caches =
+        legacy_remote_services_cache_exists || legacy_managed_services_cache_exists;
 
     if matches!(source_version, DetectedVersion::MissingConfig)
         && (legacy_address_book_exists || legacy_service_state_exists)
@@ -67,9 +77,25 @@ pub(crate) fn build_migration_plan(
     }
 
     let mut touched_paths = BTreeSet::new();
-    let update_config = config_requires_current_normalization(fungi_dir, source_version)?;
+    let migrate_incoming_allowed_peers =
+        config_has_legacy_incoming_allowed_peers(fungi_dir, source_version)?;
+    let update_config = config_requires_current_normalization(fungi_dir, source_version)?
+        || migrate_incoming_allowed_peers;
     if update_config {
         touched_paths.insert(PathBuf::from(CONFIG_FILE));
+    }
+    if migrate_incoming_allowed_peers {
+        touched_paths.insert(PathBuf::from(TRUSTED_DEVICES_FILE));
+    }
+    if legacy_local_access_exists {
+        touched_paths.insert(PathBuf::from(LEGACY_LOCAL_ACCESS_FILE));
+        touched_paths.insert(PathBuf::from(LOCAL_PREFERENCES_FILE));
+    }
+    if legacy_remote_services_cache_exists {
+        touched_paths.insert(PathBuf::from(LEGACY_REMOTE_SERVICES_CACHE_DIR));
+    }
+    if legacy_managed_services_cache_exists {
+        touched_paths.insert(PathBuf::from(LEGACY_MANAGED_SERVICES_CACHE_DIR));
     }
 
     if legacy_address_book_exists {
@@ -80,15 +106,35 @@ pub(crate) fn build_migration_plan(
     if legacy_service_state_exists {
         touched_paths.insert(PathBuf::from(LEGACY_SERVICE_STATE_FILE));
         touched_paths.insert(PathBuf::from(SERVICES_ROOT_DIR));
-        touched_paths.insert(PathBuf::from(DATA_ROOT_DIR));
+        touched_paths.insert(PathBuf::from(APPDATA_SERVICES_ROOT_DIR));
+        touched_paths.insert(PathBuf::from(ARTIFACTS_SERVICES_ROOT_DIR));
     }
 
     Ok(MigrationPlan {
         update_config,
+        migrate_incoming_allowed_peers,
+        migrate_legacy_local_access: legacy_local_access_exists,
+        remove_legacy_service_caches,
         migrate_address_book: legacy_address_book_exists,
         migrate_legacy_managed_services: legacy_service_state_exists,
         touched_paths: touched_paths.into_iter().collect(),
     })
+}
+
+fn config_has_legacy_incoming_allowed_peers(
+    fungi_dir: &Path,
+    source_version: &DetectedVersion,
+) -> Result<bool> {
+    if matches!(source_version, DetectedVersion::MissingConfig) {
+        return Ok(false);
+    }
+
+    let table = read_config_table(fungi_dir, "detecting legacy incoming peer allowlist")?;
+    Ok(table.contains_key("incoming_allowed_peers")
+        || table
+            .get("network")
+            .and_then(toml::Value::as_table)
+            .is_some_and(|network_table| network_table.contains_key("incoming_allowed_peers")))
 }
 
 fn config_requires_current_normalization(
@@ -99,20 +145,20 @@ fn config_requires_current_normalization(
         return Ok(false);
     }
 
-    let config_path = fungi_dir.join(CONFIG_FILE);
-    let content = fs::read_to_string(&config_path).with_context(|| {
-        format!(
-            "Failed to read Fungi config file while building migration plan: {}",
-            config_path.display()
-        )
-    })?;
-    let value: toml::Value = toml::from_str(&content)
-        .context("Failed to parse config.toml while building migration plan")?;
-    let Some(table) = value.as_table() else {
-        bail!("config.toml root must be a TOML table while building migration plan");
-    };
+    if matches!(
+        source_version,
+        DetectedVersion::Version(PREVIOUS_FUNGI_DIR_VERSION)
+    ) {
+        return Ok(true);
+    }
+
+    let table = read_config_table(fungi_dir, "building migration plan")?;
 
     if !table.contains_key("version") {
+        return Ok(true);
+    }
+
+    if table.contains_key("tcp_tunneling") || table.contains_key("file_transfer") {
         return Ok(true);
     }
 
@@ -139,6 +185,22 @@ fn config_requires_current_normalization(
         });
 
     Ok(has_legacy_services_allowlist)
+}
+
+fn read_config_table(fungi_dir: &Path, action: &str) -> Result<toml::Table> {
+    let config_path = fungi_dir.join(CONFIG_FILE);
+    let content = fs::read_to_string(&config_path).with_context(|| {
+        format!(
+            "Failed to read Fungi config file while {action}: {}",
+            config_path.display()
+        )
+    })?;
+    let value: toml::Value = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse config.toml while {action}"))?;
+    let Some(table) = value.as_table() else {
+        bail!("config.toml root must be a TOML table while {action}");
+    };
+    Ok(table.clone())
 }
 
 fn ensure_no_mixed_managed_service_layout(fungi_dir: &Path) -> Result<()> {

--- a/crates/config-migrate/src/lib.rs
+++ b/crates/config-migrate/src/lib.rs
@@ -1,6 +1,7 @@
 mod apply;
 mod config_files;
 mod detection;
+mod local_preferences;
 mod model;
 mod services;
 
@@ -10,10 +11,17 @@ mod tests;
 use anyhow::{Result, bail};
 use std::path::Path;
 
-use apply::{MigrationTransaction, apply_staged_paths, copy_selected_paths, validate_migrated_dir};
-use config_files::{migrate_config_toml_to_current, migrate_legacy_address_book};
+use apply::{
+    MigrationTransaction, apply_staged_paths, copy_backup_snapshot, copy_selected_paths,
+    validate_migrated_dir,
+};
+use config_files::{
+    migrate_config_toml_to_current, migrate_legacy_address_book,
+    migrate_legacy_incoming_allowed_peers,
+};
 use detection::build_migration_plan;
 pub use detection::detect_source_version;
+use local_preferences::migrate_legacy_local_access;
 pub use model::{CURRENT_FUNGI_DIR_VERSION, DetectedVersion, MigrationReport};
 use services::migrate_legacy_services_state;
 
@@ -34,7 +42,9 @@ pub fn migrate_if_needed(fungi_dir: &Path) -> Result<MigrationReport> {
         {
             Ok(MigrationReport::no_changes(source_version))
         }
-        DetectedVersion::LegacyNoVersion | DetectedVersion::Version(CURRENT_FUNGI_DIR_VERSION) => {
+        DetectedVersion::LegacyNoVersion
+        | DetectedVersion::Version(model::PREVIOUS_FUNGI_DIR_VERSION)
+        | DetectedVersion::Version(CURRENT_FUNGI_DIR_VERSION) => {
             migrate_with_plan(fungi_dir, source_version, plan)
         }
         DetectedVersion::Version(version) => bail!(
@@ -55,9 +65,18 @@ fn migrate_with_plan(
 
     let transaction =
         MigrationTransaction::prepare(fungi_dir, &source_version, CURRENT_FUNGI_DIR_VERSION)?;
-    copy_selected_paths(fungi_dir, &transaction.backup_dir, &plan.touched_paths)?;
+    copy_backup_snapshot(fungi_dir, &transaction.backup_dir)?;
     copy_selected_paths(fungi_dir, &transaction.staging_dir, &plan.touched_paths)?;
 
+    if plan.migrate_incoming_allowed_peers {
+        migrate_legacy_incoming_allowed_peers(&transaction.staging_dir)?;
+    }
+    if plan.migrate_legacy_local_access {
+        migrate_legacy_local_access(&transaction.staging_dir)?;
+    }
+    if plan.remove_legacy_service_caches {
+        remove_legacy_service_caches(&transaction.staging_dir)?;
+    }
     if plan.update_config {
         migrate_config_toml_to_current(&transaction.staging_dir, fungi_dir)?;
     }
@@ -80,4 +99,17 @@ fn migrate_with_plan(
         migrated_paths: plan.touched_paths,
         changed: true,
     })
+}
+
+fn remove_legacy_service_caches(staging_root: &Path) -> Result<()> {
+    for relative_path in [
+        model::LEGACY_REMOTE_SERVICES_CACHE_DIR,
+        model::LEGACY_MANAGED_SERVICES_CACHE_DIR,
+    ] {
+        let path = staging_root.join(relative_path);
+        if path.exists() {
+            std::fs::remove_dir_all(&path)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/config-migrate/src/local_preferences.rs
+++ b/crates/config-migrate/src/local_preferences.rs
@@ -1,0 +1,99 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::model::{LEGACY_LOCAL_ACCESS_FILE, LOCAL_PREFERENCES_FILE};
+
+#[derive(Debug, Deserialize)]
+struct LegacyLocalAccess {
+    #[serde(default)]
+    records: Vec<LegacyLocalAccessRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyLocalAccessRecord {
+    remote_peer_id: String,
+    remote_service_name: String,
+    remote_service_port_name: String,
+    local_host: String,
+    local_port: u16,
+    #[serde(default = "default_local_port_source")]
+    local_port_source: String,
+    #[serde(default)]
+    #[serde(rename = "last_remote_protocol")]
+    _last_remote_protocol: Option<String>,
+    #[serde(default)]
+    #[serde(rename = "last_remote_port")]
+    _last_remote_port: Option<u16>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct LocalPreference {
+    remote_peer_id: String,
+    remote_service_name: String,
+    remote_service_port_name: String,
+    local_host: String,
+    local_port: u16,
+    #[serde(default = "default_local_port_source")]
+    local_port_source: String,
+}
+
+fn default_local_port_source() -> String {
+    "auto".to_string()
+}
+
+pub(crate) fn migrate_legacy_local_access(staging_root: &Path) -> Result<()> {
+    let legacy_path = staging_root.join(LEGACY_LOCAL_ACCESS_FILE);
+    let legacy: LegacyLocalAccess =
+        serde_json::from_str(&fs::read_to_string(&legacy_path).with_context(|| {
+            format!(
+                "Failed to read legacy local access file: {}",
+                legacy_path.display()
+            )
+        })?)
+        .context("Failed to parse legacy local access records")?;
+
+    let preferences_path = staging_root.join(LOCAL_PREFERENCES_FILE);
+    let mut preferences = if preferences_path.exists() {
+        serde_json::from_str::<Vec<LocalPreference>>(&fs::read_to_string(&preferences_path)?)
+            .context("Failed to parse existing local preferences during migration")?
+    } else {
+        Vec::new()
+    };
+
+    for record in legacy.records {
+        let preference = LocalPreference {
+            remote_peer_id: record.remote_peer_id,
+            remote_service_name: record.remote_service_name,
+            remote_service_port_name: record.remote_service_port_name,
+            local_host: record.local_host,
+            local_port: record.local_port,
+            local_port_source: record.local_port_source,
+        };
+        let exists = preferences.iter().any(|existing| {
+            existing.remote_peer_id == preference.remote_peer_id
+                && existing.remote_service_name == preference.remote_service_name
+                && existing.remote_service_port_name == preference.remote_service_port_name
+        });
+        if !exists {
+            preferences.push(preference);
+        }
+    }
+    preferences.sort_by(|left, right| {
+        left.remote_peer_id
+            .cmp(&right.remote_peer_id)
+            .then(left.remote_service_name.cmp(&right.remote_service_name))
+            .then(
+                left.remote_service_port_name
+                    .cmp(&right.remote_service_port_name),
+            )
+    });
+
+    if let Some(parent) = preferences_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&preferences_path, serde_json::to_vec_pretty(&preferences)?)?;
+    fs::remove_file(&legacy_path)?;
+    Ok(())
+}

--- a/crates/config-migrate/src/model.rs
+++ b/crates/config-migrate/src/model.rs
@@ -4,7 +4,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub const CURRENT_FUNGI_DIR_VERSION: u32 = 2;
+pub const CURRENT_FUNGI_DIR_VERSION: u32 = 3;
+pub(crate) const PREVIOUS_FUNGI_DIR_VERSION: u32 = 2;
 
 pub(crate) const CONFIG_FILE: &str = "config.toml";
 pub(crate) const BACKUP_ROOT_DIR: &str = "bk";
@@ -12,9 +13,15 @@ pub(crate) const STAGING_DIR_PREFIX: &str = ".fungi-migrate-staging-";
 pub(crate) const APPLY_ROLLBACK_DIR_NAME: &str = ".apply-rollback";
 pub(crate) const LEGACY_ADDRESS_BOOK_FILE: &str = "address_book.toml";
 pub(crate) const DEVICES_FILE: &str = "devices.toml";
+pub(crate) const TRUSTED_DEVICES_FILE: &str = "trusted_devices.toml";
+pub(crate) const LEGACY_LOCAL_ACCESS_FILE: &str = "access/local_access.json";
+pub(crate) const LOCAL_PREFERENCES_FILE: &str = "cache/local_preferences.json";
+pub(crate) const LEGACY_REMOTE_SERVICES_CACHE_DIR: &str = "cache/remote_services";
+pub(crate) const LEGACY_MANAGED_SERVICES_CACHE_DIR: &str = "cache/device_managed_services";
 pub(crate) const LEGACY_SERVICE_STATE_FILE: &str = "services-state.json";
 pub(crate) const SERVICES_ROOT_DIR: &str = "services";
-pub(crate) const DATA_ROOT_DIR: &str = "data";
+pub(crate) const APPDATA_SERVICES_ROOT_DIR: &str = "appdata/services";
+pub(crate) const ARTIFACTS_SERVICES_ROOT_DIR: &str = "artifacts/services";
 pub(crate) const CURRENT_SERVICE_STATE_SCHEMA_VERSION: u32 = 2;
 pub(crate) const LEGACY_SERVICE_STATE_SCHEMA_VERSION: u32 = 1;
 
@@ -71,6 +78,9 @@ impl MigrationReport {
 #[derive(Debug, Default)]
 pub(crate) struct MigrationPlan {
     pub(crate) update_config: bool,
+    pub(crate) migrate_incoming_allowed_peers: bool,
+    pub(crate) migrate_legacy_local_access: bool,
+    pub(crate) remove_legacy_service_caches: bool,
     pub(crate) migrate_address_book: bool,
     pub(crate) migrate_legacy_managed_services: bool,
     pub(crate) touched_paths: Vec<PathBuf>,

--- a/crates/config-migrate/src/services.rs
+++ b/crates/config-migrate/src/services.rs
@@ -9,9 +9,9 @@ use std::{
 use ulid::Ulid;
 
 use crate::model::{
-    CURRENT_SERVICE_STATE_SCHEMA_VERSION, DATA_ROOT_DIR, LEGACY_SERVICE_STATE_FILE,
-    LEGACY_SERVICE_STATE_SCHEMA_VERSION, SERVICES_ROOT_DIR, normalize_non_empty,
-    normalize_optional,
+    APPDATA_SERVICES_ROOT_DIR, ARTIFACTS_SERVICES_ROOT_DIR, CURRENT_SERVICE_STATE_SCHEMA_VERSION,
+    LEGACY_SERVICE_STATE_FILE, LEGACY_SERVICE_STATE_SCHEMA_VERSION, SERVICES_ROOT_DIR,
+    normalize_non_empty, normalize_optional,
 };
 
 pub(crate) fn migrate_legacy_services_state(staging_root: &Path, live_root: &Path) -> Result<()> {
@@ -39,7 +39,8 @@ pub(crate) fn migrate_legacy_services_state(staging_root: &Path, live_root: &Pat
     let legacy_updated_at = normalize_optional(Some(legacy_state.updated_at))
         .unwrap_or_else(|| Utc::now().to_rfc3339());
     let services_root = staging_root.join(SERVICES_ROOT_DIR);
-    let data_root = staging_root.join(DATA_ROOT_DIR);
+    let appdata_root = staging_root.join(APPDATA_SERVICES_ROOT_DIR);
+    let artifacts_root = staging_root.join(ARTIFACTS_SERVICES_ROOT_DIR);
     let mut allocated_local_service_ids = BTreeSet::new();
 
     for (service_name_key, persisted_service) in legacy_state.services {
@@ -56,15 +57,16 @@ pub(crate) fn migrate_legacy_services_state(staging_root: &Path, live_root: &Pat
         let local_service_id = generate_unique_local_service_id(&mut allocated_local_service_ids)?;
         let old_service_data_dir = services_root.join(&service_name);
         let old_live_service_data_dir = live_root.join(SERVICES_ROOT_DIR).join(&service_name);
-        let new_service_data_dir = data_root.join(&local_service_id);
-        let new_live_service_data_dir = live_root.join(DATA_ROOT_DIR).join(&local_service_id);
-        move_or_create_service_data_dir(&old_service_data_dir, &new_service_data_dir)?;
+        let new_service_appdata_dir = appdata_root.join(&local_service_id);
+        let new_service_artifacts_dir = artifacts_root.join(&local_service_id);
+        move_or_create_service_data_dir(&old_service_data_dir, &new_service_appdata_dir)?;
 
         let manifest_document = migrate_legacy_service_manifest(
             persisted_service.manifest,
             &old_live_service_data_dir,
-            &new_live_service_data_dir,
-        );
+            &new_service_appdata_dir,
+            &new_service_artifacts_dir,
+        )?;
         let service_dir = services_root.join(&local_service_id);
         fs::create_dir_all(&service_dir).with_context(|| {
             format!(
@@ -155,53 +157,55 @@ fn move_or_create_service_data_dir(old_path: &Path, new_path: &Path) -> Result<(
 fn migrate_legacy_service_manifest(
     manifest: LegacyServiceManifest,
     old_service_data_dir: &Path,
-    new_service_data_dir: &Path,
-) -> CurrentServiceManifestDocument {
-    let run = match manifest.source {
-        LegacyServiceSource::Docker { image } => CurrentServiceManifestRun {
-            docker: Some(CurrentServiceManifestDockerRun { image }),
-            wasmtime: None,
+    new_service_appdata_dir: &Path,
+    new_service_artifacts_dir: &Path,
+) -> Result<CurrentServiceManifestDocument> {
+    let runtime = manifest._runtime;
+    let source = match manifest.source {
+        LegacyServiceSource::Docker { image } => CurrentServiceSource {
+            image: Some(image),
+            ..CurrentServiceSource::default()
         },
-        LegacyServiceSource::WasmtimeFile { component } => CurrentServiceManifestRun {
-            docker: None,
-            wasmtime: Some(CurrentServiceManifestWasmtimeRun {
-                file: Some(
-                    rewrite_legacy_managed_path(
-                        component,
-                        old_service_data_dir,
-                        new_service_data_dir,
-                    )
-                    .display()
-                    .to_string(),
-                ),
-                url: None,
-            }),
+        LegacyServiceSource::WasmtimeFile { component } => CurrentServiceSource {
+            file: Some(migrate_wasmtime_component(
+                &component,
+                old_service_data_dir,
+                new_service_appdata_dir,
+                new_service_artifacts_dir,
+            )?),
+            ..CurrentServiceSource::default()
         },
-        LegacyServiceSource::WasmtimeUrl { url } => CurrentServiceManifestRun {
-            docker: None,
-            wasmtime: Some(CurrentServiceManifestWasmtimeRun {
-                file: None,
-                url: Some(url),
-            }),
+        LegacyServiceSource::WasmtimeUrl { url } => CurrentServiceSource {
+            url: Some(url),
+            ..CurrentServiceSource::default()
         },
     };
     let expose = manifest.expose;
-    let usage = expose
+    let client_kind = expose
         .as_ref()
         .and_then(|expose| expose.usage.as_ref())
-        .map(|usage| legacy_usage_to_current_entry_usage(usage.kind));
-    let path = expose
+        .map(|usage| legacy_usage_to_current_client_kind(usage.kind));
+    let client_path = expose
         .as_ref()
         .and_then(|expose| expose.usage.as_ref())
         .and_then(|usage| normalize_optional(usage.path.clone()));
-    let icon_url = expose
+    let client_icon_url = expose
         .as_ref()
         .and_then(|expose| normalize_optional(expose.icon_url.clone()));
-    let entries = manifest
+    let client = (client_kind.is_some() || client_path.is_some() || client_icon_url.is_some())
+        .then_some(CurrentServiceClient {
+            kind: client_kind,
+            path: client_path,
+            icon_url: client_icon_url,
+        });
+    let publish = manifest
         .ports
         .into_iter()
         .enumerate()
-        .map(|(index, port)| {
+        .map(|(index, port)| -> Result<_> {
+            if port.protocol != LegacyServicePortProtocol::Tcp {
+                bail!("Legacy UDP service ports cannot be represented by fungi: service/v1");
+            }
             let name = port.name.unwrap_or_else(|| {
                 if index == 0 {
                     "main".to_string()
@@ -209,69 +213,103 @@ fn migrate_legacy_service_manifest(
                     format!("main-{index}")
                 }
             });
-            (
+            let current_port = match runtime {
+                LegacyRuntimeKind::Docker => port.service_port,
+                LegacyRuntimeKind::Wasmtime => {
+                    if port.host_port == 0 {
+                        port.service_port
+                    } else {
+                        port.host_port
+                    }
+                }
+            };
+            Ok((
                 name,
-                CurrentServiceManifestEntry {
-                    target: None,
-                    port: Some(port.service_port),
-                    protocol: (port.protocol != LegacyServicePortProtocol::Tcp)
-                        .then_some(port.protocol),
-                    usage,
-                    path: path.clone(),
-                    icon_url: icon_url.clone(),
+                CurrentServicePublishEntry {
+                    tcp: CurrentServiceTcp { port: current_port },
+                    client: client.clone(),
                 },
-            )
+            ))
         })
-        .collect();
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    if publish.is_empty() {
+        bail!(
+            "Legacy managed service '{}' has no published TCP ports and cannot be represented by fungi: service/v1",
+            manifest.name
+        );
+    }
 
-    CurrentServiceManifestDocument {
-        api_version: "fungi.rs/v1alpha1".to_string(),
-        kind: "Service".to_string(),
-        metadata: CurrentServiceManifestMetadata {
-            name: manifest.name,
-            labels: manifest.labels,
-        },
-        spec: CurrentServiceManifestSpec {
-            run,
-            entries,
-            env: manifest.env,
-            mounts: manifest
-                .mounts
-                .into_iter()
-                .map(|mount| CurrentServiceManifestMount {
-                    host_path: rewrite_legacy_managed_path(
-                        mount.host_path,
-                        old_service_data_dir,
-                        new_service_data_dir,
-                    )
-                    .display()
-                    .to_string(),
-                    runtime_path: mount.runtime_path,
-                })
-                .collect(),
-            command: manifest.command,
-            entrypoint: manifest.entrypoint,
-            working_dir: manifest.working_dir.map(|path| {
-                rewrite_legacy_managed_path(
-                    PathBuf::from(path),
+    let run = CurrentServiceRun {
+        provider: runtime.into(),
+        mode: (runtime == LegacyRuntimeKind::Wasmtime && !publish.is_empty())
+            .then_some(CurrentServiceRunMode::Http),
+        source,
+        args: manifest.command,
+        env: manifest.env,
+        mounts: manifest
+            .mounts
+            .into_iter()
+            .map(|mount| CurrentServiceMount {
+                from: rewrite_legacy_managed_path(
+                    mount.host_path,
                     old_service_data_dir,
-                    new_service_data_dir,
+                    Path::new("$fungi.service.data"),
                 )
                 .display()
-                .to_string()
-            }),
-        },
-    }
+                .to_string(),
+                to: mount.runtime_path,
+            })
+            .collect(),
+    };
+
+    Ok(CurrentServiceManifestDocument {
+        fungi: "service/v1".to_string(),
+        id: manifest.name,
+        run,
+        publish,
+    })
 }
 
-fn legacy_usage_to_current_entry_usage(
-    kind: LegacyServiceExposeUsageKind,
-) -> CurrentServiceManifestEntryUsageKind {
+fn migrate_wasmtime_component(
+    component: &Path,
+    old_service_data_dir: &Path,
+    new_service_appdata_dir: &Path,
+    new_service_artifacts_dir: &Path,
+) -> Result<String> {
+    let Ok(relative_path) = component.strip_prefix(old_service_data_dir) else {
+        return Ok(component.display().to_string());
+    };
+    let staged_component = new_service_appdata_dir.join(relative_path);
+    let artifact_component = new_service_artifacts_dir.join("component.wasm");
+    fs::create_dir_all(new_service_artifacts_dir).with_context(|| {
+        format!(
+            "Failed to create migrated service artifacts directory: {}",
+            new_service_artifacts_dir.display()
+        )
+    })?;
+    fs::copy(&staged_component, &artifact_component).with_context(|| {
+        format!(
+            "Failed to migrate Wasmtime component from {} to {}",
+            staged_component.display(),
+            artifact_component.display()
+        )
+    })?;
+    fs::remove_file(&staged_component).with_context(|| {
+        format!(
+            "Failed to remove migrated Wasmtime component from appdata: {}",
+            staged_component.display()
+        )
+    })?;
+    Ok("$fungi.service.artifacts/component.wasm".to_string())
+}
+
+fn legacy_usage_to_current_client_kind(kind: LegacyServiceExposeUsageKind) -> String {
     match kind {
-        LegacyServiceExposeUsageKind::Web => CurrentServiceManifestEntryUsageKind::Web,
-        LegacyServiceExposeUsageKind::Ssh => CurrentServiceManifestEntryUsageKind::Ssh,
-        LegacyServiceExposeUsageKind::Raw => CurrentServiceManifestEntryUsageKind::Tcp,
+        LegacyServiceExposeUsageKind::Web => "web",
+        LegacyServiceExposeUsageKind::Ssh => "ssh",
+        LegacyServiceExposeUsageKind::Raw => "raw",
     }
+    .to_string()
 }
 
 fn rewrite_legacy_managed_path(path: PathBuf, old_root: &Path, new_root: &Path) -> PathBuf {
@@ -322,13 +360,16 @@ struct LegacyServiceManifest {
     #[serde(default)]
     command: Vec<String>,
     #[serde(default)]
-    entrypoint: Vec<String>,
-    working_dir: Option<String>,
+    #[serde(rename = "entrypoint")]
+    _entrypoint: Vec<String>,
+    #[serde(rename = "working_dir")]
+    _working_dir: Option<String>,
     #[serde(default)]
-    labels: BTreeMap<String, String>,
+    #[serde(rename = "labels")]
+    _labels: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 enum LegacyRuntimeKind {
     Docker,
@@ -392,8 +433,7 @@ struct LegacyServiceMount {
 #[derive(Debug, Clone, Deserialize)]
 struct LegacyServicePort {
     name: Option<String>,
-    #[serde(rename = "host_port")]
-    _host_port: u16,
+    host_port: u16,
     service_port: u16,
     protocol: LegacyServicePortProtocol,
 }
@@ -438,89 +478,83 @@ struct CurrentServiceStateFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CurrentServiceManifestDocument {
-    #[serde(rename = "apiVersion")]
-    api_version: String,
-    kind: String,
-    metadata: CurrentServiceManifestMetadata,
-    spec: CurrentServiceManifestSpec,
+    fungi: String,
+    id: String,
+    run: CurrentServiceRun,
+    publish: BTreeMap<String, CurrentServicePublishEntry>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum CurrentServiceProvider {
+    Docker,
+    Wasmtime,
+}
+
+impl From<LegacyRuntimeKind> for CurrentServiceProvider {
+    fn from(value: LegacyRuntimeKind) -> Self {
+        match value {
+            LegacyRuntimeKind::Docker => Self::Docker,
+            LegacyRuntimeKind::Wasmtime => Self::Wasmtime,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct CurrentServiceManifestMetadata {
-    name: String,
-    #[serde(default)]
-    labels: BTreeMap<String, String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CurrentServiceManifestSpec {
-    run: CurrentServiceManifestRun,
-    entries: BTreeMap<String, CurrentServiceManifestEntry>,
-    #[serde(default)]
+struct CurrentServiceRun {
+    provider: CurrentServiceProvider,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<CurrentServiceRunMode>,
+    source: CurrentServiceSource,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     env: BTreeMap<String, String>,
-    #[serde(default)]
-    mounts: Vec<CurrentServiceManifestMount>,
-    #[serde(default)]
-    command: Vec<String>,
-    #[serde(default)]
-    entrypoint: Vec<String>,
-    #[serde(rename = "workingDir")]
-    working_dir: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    mounts: Vec<CurrentServiceMount>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CurrentServiceManifestRun {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    docker: Option<CurrentServiceManifestDockerRun>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    wasmtime: Option<CurrentServiceManifestWasmtimeRun>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CurrentServiceManifestDockerRun {
-    image: String,
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum CurrentServiceRunMode {
+    Http,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct CurrentServiceManifestWasmtimeRun {
+struct CurrentServiceSource {
     #[serde(skip_serializing_if = "Option::is_none")]
     file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct CurrentServiceManifestEntry {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CurrentServiceMount {
+    from: String,
+    to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CurrentServicePublishEntry {
+    tcp: CurrentServiceTcp,
     #[serde(skip_serializing_if = "Option::is_none")]
-    target: Option<String>,
+    client: Option<CurrentServiceClient>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CurrentServiceTcp {
+    port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CurrentServiceClient {
     #[serde(skip_serializing_if = "Option::is_none")]
-    port: Option<u16>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    protocol: Option<LegacyServicePortProtocol>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    usage: Option<CurrentServiceManifestEntryUsageKind>,
-    #[serde(default)]
+    kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     path: Option<String>,
     #[serde(rename = "iconUrl")]
     #[serde(skip_serializing_if = "Option::is_none")]
     icon_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum CurrentServiceManifestEntryUsageKind {
-    Web,
-    Ssh,
-    Tcp,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CurrentServiceManifestMount {
-    #[serde(rename = "hostPath")]
-    host_path: String,
-    #[serde(rename = "runtimePath")]
-    runtime_path: String,
 }

--- a/crates/config-migrate/src/services.rs
+++ b/crates/config-migrate/src/services.rs
@@ -250,13 +250,7 @@ fn migrate_legacy_service_manifest(
             .mounts
             .into_iter()
             .map(|mount| CurrentServiceMount {
-                from: rewrite_legacy_managed_path(
-                    mount.host_path,
-                    old_service_data_dir,
-                    Path::new("$fungi.service.data"),
-                )
-                .display()
-                .to_string(),
+                from: rewrite_legacy_managed_manifest_path(mount.host_path, old_service_data_dir),
                 to: mount.runtime_path,
             })
             .collect(),
@@ -312,16 +306,21 @@ fn legacy_usage_to_current_client_kind(kind: LegacyServiceExposeUsageKind) -> St
     .to_string()
 }
 
-fn rewrite_legacy_managed_path(path: PathBuf, old_root: &Path, new_root: &Path) -> PathBuf {
+fn rewrite_legacy_managed_manifest_path(path: PathBuf, old_root: &Path) -> String {
     if path == old_root {
-        return new_root.to_path_buf();
+        return "$fungi.service.data".to_string();
     }
 
     if let Ok(suffix) = path.strip_prefix(old_root) {
-        return new_root.join(suffix);
+        let suffix = suffix
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        return format!("$fungi.service.data/{suffix}");
     }
 
-    path
+    path.display().to_string()
 }
 
 fn default_legacy_service_state_schema_version() -> u32 {

--- a/crates/config-migrate/src/tests.rs
+++ b/crates/config-migrate/src/tests.rs
@@ -1,11 +1,12 @@
 use crate::{
     CURRENT_FUNGI_DIR_VERSION, DetectedVersion,
+    apply::MigrationTransaction,
     detection::detect_source_version_from_toml_str,
     migrate_if_needed,
     model::{
-        BACKUP_ROOT_DIR, CONFIG_FILE, CURRENT_SERVICE_STATE_SCHEMA_VERSION, DATA_ROOT_DIR,
-        DEVICES_FILE, LEGACY_ADDRESS_BOOK_FILE, LEGACY_SERVICE_STATE_FILE, SERVICES_ROOT_DIR,
-        STAGING_DIR_PREFIX,
+        BACKUP_ROOT_DIR, CONFIG_FILE, CURRENT_SERVICE_STATE_SCHEMA_VERSION, DEVICES_FILE,
+        LEGACY_ADDRESS_BOOK_FILE, LEGACY_SERVICE_STATE_FILE, SERVICES_ROOT_DIR, STAGING_DIR_PREFIX,
+        TRUSTED_DEVICES_FILE,
     },
 };
 use serde_json::json;
@@ -17,6 +18,23 @@ fn fixture_path(name: &str) -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join(name)
+}
+
+#[test]
+fn migration_transaction_prepare_allocates_fresh_backup_dirs() {
+    let dir = TempDir::new().unwrap();
+
+    let first =
+        MigrationTransaction::prepare(dir.path(), &DetectedVersion::LegacyNoVersion, 7).unwrap();
+    let second =
+        MigrationTransaction::prepare(dir.path(), &DetectedVersion::LegacyNoVersion, 7).unwrap();
+
+    assert_ne!(first.backup_dir, second.backup_dir);
+    assert_ne!(first.staging_dir, second.staging_dir);
+    assert!(first.backup_dir.is_dir());
+    assert!(second.backup_dir.is_dir());
+    assert!(first.staging_dir.is_dir());
+    assert!(second.staging_dir.is_dir());
 }
 
 fn read_fixture(name: &str) -> String {
@@ -35,7 +53,7 @@ fn detects_legacy_no_version_fixture() {
 #[test]
 fn detects_current_version_fixture() {
     let detected =
-        detect_source_version_from_toml_str(&read_fixture("current-v2-config.toml")).unwrap();
+        detect_source_version_from_toml_str(&read_fixture("current-v3-config.toml")).unwrap();
 
     assert_eq!(
         detected,
@@ -44,10 +62,36 @@ fn detects_current_version_fixture() {
 }
 
 #[test]
+fn migrates_version_two_to_final_version_three_schema() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        concat!(
+            "version = 2\n",
+            "\n",
+            "[network]\n",
+            "relay_enabled = true\n",
+        ),
+    )
+    .unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    assert_eq!(report.source_version, DetectedVersion::Version(2));
+    assert_eq!(report.target_version, 3);
+    assert!(
+        fs::read_to_string(dir.path().join(CONFIG_FILE))
+            .unwrap()
+            .contains("version = 3")
+    );
+}
+
+#[test]
 fn current_version_is_a_noop() {
     let dir = TempDir::new().unwrap();
     let config_path = dir.path().join(CONFIG_FILE);
-    fs::write(&config_path, read_fixture("current-v2-config.toml")).unwrap();
+    fs::write(&config_path, read_fixture("current-v3-config.toml")).unwrap();
 
     let report = migrate_if_needed(dir.path()).unwrap();
 
@@ -60,12 +104,12 @@ fn current_version_is_a_noop() {
     );
     assert_eq!(
         fs::read_to_string(config_path).unwrap(),
-        read_fixture("current-v2-config.toml")
+        read_fixture("current-v3-config.toml")
     );
 }
 
 #[test]
-fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files() {
+fn migrates_legacy_config_transactionally_and_keeps_full_backup_snapshot() {
     let dir = TempDir::new().unwrap();
     fs::write(
         dir.path().join(CONFIG_FILE),
@@ -98,7 +142,7 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
     assert_eq!(report.migrated_paths, vec![PathBuf::from(CONFIG_FILE)]);
 
     let migrated_config = fs::read_to_string(dir.path().join(CONFIG_FILE)).unwrap();
-    assert!(migrated_config.contains("version = 2"));
+    assert!(migrated_config.contains("version = 3"));
     assert_eq!(
         fs::read_to_string(dir.path().join("devices.toml")).unwrap(),
         "version = \"0.6.1\"\n[devices]\n"
@@ -125,8 +169,19 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
         fs::read_to_string(backup_dir.join(CONFIG_FILE)).unwrap(),
         original_config
     );
-    assert!(!backup_dir.join("devices.toml").exists());
-    assert!(!backup_dir.join("cache").exists());
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("devices.toml")).unwrap(),
+        "version = \"0.6.1\"\n[devices]\n"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("cache").join("local_preferences.json")).unwrap(),
+        "[]\n"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("cache").join("direct_addresses.json")).unwrap(),
+        "{\n  \"version\": 1,\n  \"addresses\": []\n}\n"
+    );
+    assert!(!backup_dir.join(BACKUP_ROOT_DIR).exists());
 
     assert!(report.staging_dir.is_none());
     let staging_count = fs::read_dir(dir.path())
@@ -145,13 +200,18 @@ fn migrates_legacy_config_transactionally_without_copying_unrelated_side_files()
 #[test]
 fn migration_removes_legacy_incoming_allowed_peers_from_config() {
     let dir = TempDir::new().unwrap();
+    let root_peer = "12D3KooWQW1nMmgC9R2j8uF1pL7dV7cP8xN3d8X7p4hYt3QwD8YV";
+    let network_peer = "12D3KooWJGXfQ3X6E3FJxMeYpPvVhDhxDBBkYDpAJrYaHsxkUTdT";
     fs::write(
         dir.path().join(CONFIG_FILE),
-        concat!(
-            "incoming_allowed_peers = [\"16Uiu2HAmUSNEhHAAhJsWZU16U8kaBqqXwCPbty8q243amnT2FWe8\"]\n",
-            "\n",
-            "[rpc]\n",
-            "listen_address = \"127.0.0.1:6601\"\n",
+        format!(
+            "incoming_allowed_peers = [\"{root_peer}\"]\n\
+             \n\
+             [rpc]\n\
+             listen_address = \"127.0.0.1:6601\"\n\
+             \n\
+             [network]\n\
+             incoming_allowed_peers = [\"{network_peer}\", \"{root_peer}\"]\n",
         ),
     )
     .unwrap();
@@ -160,8 +220,201 @@ fn migration_removes_legacy_incoming_allowed_peers_from_config() {
 
     assert!(report.changed);
     let migrated_config = fs::read_to_string(dir.path().join(CONFIG_FILE)).unwrap();
-    assert!(migrated_config.contains("version = 2"));
+    assert!(migrated_config.contains("version = 3"));
     assert!(!migrated_config.contains("incoming_allowed_peers"));
+
+    let trusted_value: toml::Value =
+        toml::from_str(&fs::read_to_string(dir.path().join(TRUSTED_DEVICES_FILE)).unwrap())
+            .unwrap();
+    let trusted_devices = trusted_value
+        .as_table()
+        .and_then(|table| table.get("trusted_devices"))
+        .and_then(toml::Value::as_array)
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(trusted_devices, vec![network_peer, root_peer]);
+}
+
+#[test]
+fn migration_merges_legacy_incoming_allowed_peers_into_existing_trusted_devices_file() {
+    let dir = TempDir::new().unwrap();
+    let existing_peer = "12D3KooWQW1nMmgC9R2j8uF1pL7dV7cP8xN3d8X7p4hYt3QwD8YV";
+    let new_peer = "12D3KooWJGXfQ3X6E3FJxMeYpPvVhDhxDBBkYDpAJrYaHsxkUTdT";
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        format!(
+            "version = 2\n\
+             \n\
+             [network]\n\
+             incoming_allowed_peers = [\"{existing_peer}\", \"{new_peer}\"]\n",
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(TRUSTED_DEVICES_FILE),
+        format!("trusted_devices = [\"{existing_peer}\"]\n"),
+    )
+    .unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    let trusted_value: toml::Value =
+        toml::from_str(&fs::read_to_string(dir.path().join(TRUSTED_DEVICES_FILE)).unwrap())
+            .unwrap();
+    let trusted_devices = trusted_value
+        .as_table()
+        .and_then(|table| table.get("trusted_devices"))
+        .and_then(toml::Value::as_array)
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(trusted_devices, vec![new_peer, existing_peer]);
+}
+
+#[test]
+fn migration_removes_config_sections_that_no_longer_exist() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        concat!(
+            "[rpc]\n",
+            "listen_address = \"127.0.0.1:6601\"\n",
+            "\n",
+            "[network]\n",
+            "listen_tcp_port = 4101\n",
+            "listen_udp_port = 4102\n",
+            "relay_enabled = false\n",
+            "\n",
+            "[tcp_tunneling.forwarding]\n",
+            "enabled = true\n",
+            "rules = []\n",
+            "\n",
+            "[file_transfer]\n",
+            "client = []\n",
+            "\n",
+            "[runtime]\n",
+            "disable_docker = true\n",
+            "disable_wasmtime = false\n",
+            "allowed_ports = [18080]\n",
+            "\n",
+            "[[runtime.allowed_port_ranges]]\n",
+            "start = 19000\n",
+            "end = 19100\n",
+        ),
+    )
+    .unwrap();
+
+    migrate_if_needed(dir.path()).unwrap();
+
+    let migrated = fs::read_to_string(dir.path().join(CONFIG_FILE)).unwrap();
+    assert!(!migrated.contains("tcp_tunneling"));
+    assert!(!migrated.contains("file_transfer"));
+    assert!(!migrated.contains("allowed_ports"));
+    assert!(!migrated.contains("allowed_port_ranges"));
+    assert!(migrated.contains("listen_address = \"127.0.0.1:6601\""));
+    assert!(migrated.contains("listen_tcp_port = 4101"));
+    assert!(migrated.contains("listen_udp_port = 4102"));
+    assert!(migrated.contains("relay_enabled = false"));
+    assert!(migrated.contains("disable_docker = true"));
+}
+
+#[test]
+fn version_two_with_removed_config_sections_is_normalized() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(CONFIG_FILE),
+        concat!(
+            "version = 2\n",
+            "\n",
+            "[network]\n",
+            "relay_enabled = true\n",
+            "\n",
+            "[tcp_tunneling.forwarding]\n",
+            "enabled = true\n",
+            "rules = []\n",
+        ),
+    )
+    .unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    let migrated = fs::read_to_string(dir.path().join(CONFIG_FILE)).unwrap();
+    assert!(!migrated.contains("tcp_tunneling"));
+    assert!(migrated.contains("version = 3"));
+}
+
+#[test]
+fn migrates_legacy_local_access_records_to_local_preferences() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(CONFIG_FILE), "version = 2\n").unwrap();
+    fs::create_dir_all(dir.path().join("access")).unwrap();
+    fs::write(
+        dir.path().join("access").join("local_access.json"),
+        serde_json::to_vec_pretty(&json!({
+            "records": [{
+                "remote_peer_id": "peer-a",
+                "remote_service_name": "fb",
+                "remote_service_port_name": "http",
+                "local_host": "127.0.0.1",
+                "local_port": 8082,
+                "local_port_source": "user",
+                "last_remote_protocol": "/fungi/service-port/fb/http/0.1.0",
+                "last_remote_port": 8080
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    assert!(!dir.path().join("access").join("local_access.json").exists());
+    let preferences: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(dir.path().join("cache").join("local_preferences.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(preferences.as_array().unwrap().len(), 1);
+    assert_eq!(preferences[0]["remote_peer_id"], "peer-a");
+    assert_eq!(preferences[0]["remote_service_name"], "fb");
+    assert_eq!(preferences[0]["remote_service_port_name"], "http");
+    assert_eq!(preferences[0]["local_host"], "127.0.0.1");
+    assert_eq!(preferences[0]["local_port"], 8082);
+    assert_eq!(preferences[0]["local_port_source"], "user");
+    assert!(preferences[0].get("last_remote_protocol").is_none());
+    assert!(preferences[0].get("last_remote_port").is_none());
+}
+
+#[test]
+fn removes_obsolete_remote_service_caches_after_backing_them_up() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(CONFIG_FILE), "version = 2\n").unwrap();
+    let published = dir.path().join("cache").join("remote_services");
+    let managed = dir.path().join("cache").join("device_managed_services");
+    fs::create_dir_all(&published).unwrap();
+    fs::create_dir_all(&managed).unwrap();
+    fs::write(published.join("peer-a.json"), "published").unwrap();
+    fs::write(managed.join("peer-a.json"), "managed").unwrap();
+
+    let report = migrate_if_needed(dir.path()).unwrap();
+
+    assert!(report.changed);
+    assert!(!published.exists());
+    assert!(!managed.exists());
+    let backup = report.backup_dir.unwrap();
+    assert_eq!(
+        fs::read_to_string(backup.join("cache/remote_services/peer-a.json")).unwrap(),
+        "published"
+    );
+    assert_eq!(
+        fs::read_to_string(backup.join("cache/device_managed_services/peer-a.json")).unwrap(),
+        "managed"
+    );
 }
 
 #[test]
@@ -316,11 +569,21 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
     assert!(local_service_id.starts_with("svc_"));
     assert!(!dir.path().join(SERVICES_ROOT_DIR).join("demo").exists());
 
-    let migrated_data_dir = dir.path().join(DATA_ROOT_DIR).join(&local_service_id);
-    assert!(migrated_data_dir.is_dir());
-    assert!(migrated_data_dir.join("component.wasm").is_file());
+    let migrated_appdata_dir = dir
+        .path()
+        .join("appdata")
+        .join("services")
+        .join(&local_service_id);
+    let migrated_artifacts_dir = dir
+        .path()
+        .join("artifacts")
+        .join("services")
+        .join(&local_service_id);
+    assert!(migrated_appdata_dir.is_dir());
+    assert!(migrated_artifacts_dir.join("component.wasm").is_file());
+    assert!(!migrated_appdata_dir.join("component.wasm").exists());
     assert_eq!(
-        fs::read_to_string(migrated_data_dir.join("cache").join("state.txt")).unwrap(),
+        fs::read_to_string(migrated_appdata_dir.join("cache").join("state.txt")).unwrap(),
         "persist"
     );
 
@@ -333,30 +596,29 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
     assert!(!manifest_yaml.contains("serviceId"));
     assert!(!manifest_yaml.contains("displayName"));
     assert!(!manifest_yaml.contains(&old_service_dir.display().to_string()));
-    assert!(manifest_yaml.contains(&migrated_data_dir.display().to_string()));
+    assert!(!manifest_yaml.contains("workingDir"));
+    assert!(!manifest_yaml.contains("labels"));
 
     let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_yaml).unwrap();
-    assert_eq!(manifest["metadata"]["name"], "demo");
+    assert_eq!(manifest["fungi"], "service/v1");
+    assert_eq!(manifest["id"], "demo");
+    assert_eq!(manifest["run"]["provider"], "wasmtime");
+    assert_eq!(manifest["run"]["mode"], "http");
     assert_eq!(
-        manifest["spec"]["workingDir"],
-        migrated_data_dir.to_string_lossy().as_ref()
+        manifest["run"]["source"]["file"],
+        "$fungi.service.artifacts/component.wasm"
     );
+    assert_eq!(manifest["publish"]["http"]["tcp"]["port"], 18080);
+    assert_eq!(manifest["publish"]["http"]["client"]["kind"], "web");
+    assert_eq!(manifest["publish"]["http"]["client"]["path"], "/");
     assert_eq!(
-        manifest["spec"]["run"]["wasmtime"]["file"],
-        migrated_data_dir
-            .join("component.wasm")
-            .to_string_lossy()
-            .as_ref()
+        manifest["publish"]["http"]["client"]["iconUrl"],
+        "https://example.com/icon.png"
     );
-    assert_eq!(manifest["spec"]["entries"]["http"]["port"], 80);
-    assert_eq!(manifest["spec"]["entries"]["http"]["usage"], "web");
-    assert_eq!(manifest["spec"]["entries"]["http"]["path"], "/");
-    let mounts = manifest["spec"]["mounts"].as_sequence().unwrap();
+    let mounts = manifest["run"]["mounts"].as_sequence().unwrap();
     assert_eq!(mounts.len(), 1);
-    assert_eq!(
-        mounts[0]["hostPath"],
-        migrated_data_dir.join("cache").to_string_lossy().as_ref()
-    );
+    assert_eq!(mounts[0]["from"], "$fungi.service.data/cache");
+    assert_eq!(mounts[0]["to"], "/cache");
 
     let state_value: serde_json::Value = serde_json::from_str(
         &fs::read_to_string(
@@ -385,7 +647,7 @@ fn current_version_with_legacy_artifacts_still_migrates() {
     let dir = TempDir::new().unwrap();
     fs::write(
         dir.path().join(CONFIG_FILE),
-        read_fixture("current-v2-config.toml"),
+        read_fixture("current-v3-config.toml"),
     )
     .unwrap();
     fs::write(dir.path().join(LEGACY_ADDRESS_BOOK_FILE), "peers = []\n").unwrap();

--- a/crates/config-migrate/tests/fixtures/current-v3-config.toml
+++ b/crates/config-migrate/tests/fixtures/current-v3-config.toml
@@ -1,4 +1,4 @@
-version = 2
+version = 3
 
 [rpc]
 listen_address = "127.0.0.1:6601"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -252,7 +252,7 @@ mod tests {
         FungiConfig::init_config_file(config_path.clone()).unwrap();
         assert!(config_path.exists());
         let content = std::fs::read_to_string(&config_path).unwrap();
-        assert!(content.contains("version = 2"));
+        assert!(content.contains("version = 3"));
         assert!(content.contains("[network]"));
         assert!(content.contains("[runtime]"));
         assert!(!content.contains("allowed_ports"));

--- a/crates/daemon/src/service_state.rs
+++ b/crates/daemon/src/service_state.rs
@@ -17,7 +17,6 @@ use crate::runtime::{
 };
 
 const SERVICE_STATE_SCHEMA_VERSION: u32 = 2;
-const LEGACY_SERVICE_STATE_FILE: &str = "services-state.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -66,13 +65,6 @@ impl ServiceStateStore {
             .parent()
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf();
-        let legacy_service_state_path = fungi_home.join(LEGACY_SERVICE_STATE_FILE);
-        if legacy_service_state_path.exists() {
-            bail!(
-                "Unsupported legacy managed service state detected at {}. This release expects managed services under services/<local_service_id>/ and does not read services-state.json.",
-                legacy_service_state_path.display()
-            );
-        }
 
         fs::create_dir_all(&services_root).with_context(|| {
             format!(
@@ -564,27 +556,5 @@ mod tests {
         assert!(!service_dir.exists());
         assert!(appdata_dir.is_dir());
         assert_eq!(fs::read_to_string(&appdata_file).unwrap(), "persist me");
-    }
-
-    #[test]
-    fn load_rejects_legacy_services_state_json() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let services_root = dir.path().join("services");
-        fs::write(
-            dir.path().join(LEGACY_SERVICE_STATE_FILE),
-            "{\n  \"schema_version\": 1,\n  \"services\": {}\n}\n",
-        )
-        .unwrap();
-
-        let error = ServiceStateStore::load(services_root)
-            .err()
-            .expect("legacy services-state.json should be rejected");
-
-        assert!(error.to_string().contains(LEGACY_SERVICE_STATE_FILE));
-        assert!(
-            error
-                .to_string()
-                .contains("Unsupported legacy managed service state detected")
-        );
     }
 }

--- a/crates/lab/src/util.rs
+++ b/crates/lab/src/util.rs
@@ -191,7 +191,7 @@ pub(crate) fn write_node_config(
         .collect::<Vec<_>>()
         .join(", ");
     let config = format!(
-        "version = 2\n\n[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {tcp_port}\nlisten_udp_port = {udp_port}\nrelay_enabled = true\nuse_community_relays = false\ncustom_relay_addresses = [{relay_list}]\n\n[runtime]\ndisable_docker = false\ndisable_wasmtime = false\n"
+        "version = 3\n\n[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {tcp_port}\nlisten_udp_port = {udp_port}\nrelay_enabled = true\nuse_community_relays = false\ncustom_relay_addresses = [{relay_list}]\n\n[runtime]\ndisable_docker = false\ndisable_wasmtime = false\n"
     );
     fs::write(fungi_dir.join("config.toml"), config).with_context(|| {
         format!(

--- a/crates/tests/src/bin/test_service_remote_wasm_cli.rs
+++ b/crates/tests/src/bin/test_service_remote_wasm_cli.rs
@@ -92,7 +92,7 @@ impl TestNode {
         let listen_tcp_port = find_free_port()?;
         let listen_udp_port = find_free_port()?;
         let config_toml = format!(
-            "version = 2\n\n[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {listen_tcp_port}\nlisten_udp_port = {listen_udp_port}\nrelay_enabled = false\nuse_community_relays = false\n\n[runtime]\ndisable_docker = true\ndisable_wasmtime = false\n",
+            "version = 3\n\n[rpc]\nlisten_address = \"127.0.0.1:{rpc_port}\"\n\n[network]\nlisten_tcp_port = {listen_tcp_port}\nlisten_udp_port = {listen_udp_port}\nrelay_enabled = false\nuse_community_relays = false\n\n[runtime]\ndisable_docker = true\ndisable_wasmtime = false\n",
         );
         std::fs::write(fungi_dir.join("config.toml"), config_toml)
             .with_context(|| format!("failed to write config for node {name}"))?;

--- a/fungi/tests/migrate_cli.rs
+++ b/fungi/tests/migrate_cli.rs
@@ -1,14 +1,17 @@
 use std::{
     fs,
+    net::{TcpListener, UdpSocket},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, ChildStdin, Command, Stdio},
     sync::OnceLock,
     thread,
     time::{Duration, Instant},
 };
 
 use fungi_config::{FungiConfig, devices::DevicesConfig};
-use fungi_daemon::{ServiceSource, load_service_manifest_yaml_file};
+use fungi_daemon::{
+    ServicePortAllocation, ServiceRunMode, ServiceSource, load_service_manifest_yaml_file,
+};
 use libp2p::PeerId;
 use serde_json::json;
 use tempfile::TempDir;
@@ -107,10 +110,10 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(migrate_output.stdout.contains("Migrated Fungi"));
 
     let config = FungiConfig::apply_from_dir(home.path()).unwrap();
-    assert_eq!(config.version, 2);
+    assert_eq!(config.version, 3);
     assert!(config.runtime.allowed_host_paths.is_empty());
     let raw_config = fs::read_to_string(home.path().join("config.toml")).unwrap();
-    assert!(raw_config.contains("version = 2"));
+    assert!(raw_config.contains("version = 3"));
     assert!(!raw_config.contains("allowed_port_ranges"));
     assert!(!raw_config.contains("allowed_ports"));
     assert!(!raw_config.contains(&home.path().join("services").display().to_string()));
@@ -138,7 +141,7 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(backup_dir.join("address_book.toml").is_file());
     assert!(backup_dir.join("services-state.json").is_file());
     assert!(backup_dir.join("services").join("demo").is_dir());
-    assert!(!backup_dir.join(".keys").exists());
+    assert!(backup_dir.join(".keys").join("keypair").is_file());
 
     let staging_count = fs::read_dir(home.path())
         .unwrap()
@@ -163,11 +166,20 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(local_service_id.starts_with("svc_"));
     assert!(!home.path().join("services").join("demo").exists());
 
-    let data_dir = home.path().join("data").join(&local_service_id);
-    assert!(data_dir.is_dir());
-    assert!(data_dir.join("component.wasm").is_file());
+    let appdata_dir = home
+        .path()
+        .join("appdata")
+        .join("services")
+        .join(&local_service_id);
+    let artifacts_dir = home
+        .path()
+        .join("artifacts")
+        .join("services")
+        .join(&local_service_id);
+    assert!(appdata_dir.is_dir());
+    assert!(artifacts_dir.join("component.wasm").is_file());
     assert_eq!(
-        fs::read_to_string(data_dir.join("cache").join("state.txt")).unwrap(),
+        fs::read_to_string(appdata_dir.join("cache").join("state.txt")).unwrap(),
         "persist"
     );
 
@@ -180,20 +192,23 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(!manifest_yaml.contains("serviceId"));
     assert!(!manifest_yaml.contains("displayName"));
     assert!(!manifest_yaml.contains(&old_service_dir.display().to_string()));
-    assert!(manifest_yaml.contains(&data_dir.display().to_string()));
+    assert!(manifest_yaml.contains("fungi: service/v1"));
+    assert!(manifest_yaml.contains("$fungi.service.data/cache"));
+    assert!(manifest_yaml.contains("$fungi.service.artifacts/component.wasm"));
 
     let manifest = load_service_manifest_yaml_file(&manifest_path, home.path()).unwrap();
     assert_eq!(manifest.name, "demo");
-    assert_eq!(
-        manifest.working_dir.as_deref(),
-        Some(data_dir.to_string_lossy().as_ref())
-    );
+    assert_eq!(manifest.run_mode, ServiceRunMode::Http);
+    assert_eq!(manifest.working_dir, None);
     assert_eq!(manifest.mounts.len(), 1);
-    assert_eq!(manifest.mounts[0].host_path, data_dir.join("cache"));
+    assert_eq!(manifest.ports[0].host_port, 18080);
+    assert_eq!(manifest.ports[0].service_port, 18080);
+    assert_eq!(
+        manifest.ports[0].host_port_allocation,
+        ServicePortAllocation::Fixed
+    );
     match &manifest.source {
-        ServiceSource::WasmtimeFile { component } => {
-            assert_eq!(component, &data_dir.join("component.wasm"));
-        }
+        ServiceSource::WasmtimeFile { .. } => {}
         other => panic!("unexpected migrated manifest source: {other:?}"),
     }
 
@@ -212,7 +227,187 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert_eq!(state_value["desired_state"], "stopped");
 
     let second_migrate = run_cli(current_fungi_bin(), home.path(), &["migrate"]);
-    assert!(second_migrate.stdout.contains("already at version 2"));
+    assert!(second_migrate.stdout.contains("already at version 3"));
+}
+
+#[test]
+#[ignore = "integration test runs the v0.6.1 release daemon and current daemon; run explicitly with `cargo test -p fungi --test migrate_cli -- --ignored --nocapture`"]
+fn cli_migrate_preserves_v061_daemon_written_state_in_current_layout() {
+    let home = TempDir::new().unwrap();
+    let payload = TempDir::new().unwrap();
+    let legacy = legacy_fungi_bin();
+    let current = current_fungi_bin();
+
+    run_cli(legacy, home.path(), &["init"]);
+    configure_legacy_daemon_ports(home.path());
+
+    let peer_id = PeerId::random().to_string();
+    let service_host_port = reserve_tcp_port();
+    let legacy_service_dir = home.path().join("services").join("cli-demo");
+    fs::create_dir_all(legacy_service_dir.join("mount")).unwrap();
+    fs::write(legacy_service_dir.join("component.wasm"), b"wasm").unwrap();
+    fs::write(
+        legacy_service_dir.join("mount").join("state.txt"),
+        b"persist",
+    )
+    .unwrap();
+    let manifest_path = payload.path().join("cli-demo-service.yaml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"apiVersion: fungi.rs/v1alpha1
+kind: ServiceManifest
+metadata:
+  name: cli-demo
+  labels:
+    release-test: "1"
+spec:
+  runtime: wasmtime
+  source:
+    file: $APP_HOME/component.wasm
+  expose:
+    enabled: true
+    serviceId: cli-demo-service
+    displayName: CLI Demo
+    transport:
+      kind: tcp
+    usage:
+      kind: web
+      path: /ui
+    iconUrl: https://example.com/icon.png
+    catalogId: example/cli-demo
+  ports:
+    - name: http
+      hostPort: {service_host_port}
+      servicePort: 8080
+      protocol: tcp
+  mounts:
+    - hostPath: $APP_HOME/mount
+      runtimePath: /data
+  command:
+    - --demo
+  entrypoint: []
+  workingDir: $APP_HOME/mount
+"#
+        ),
+    )
+    .unwrap();
+
+    {
+        let _daemon = start_daemon(legacy, home.path());
+        run_cli(legacy, home.path(), &["security", "allow-path", "/tmp"]);
+        run_cli(
+            legacy,
+            home.path(),
+            &[
+                "security",
+                "allowed-peers",
+                "add",
+                "--alias",
+                "demo-peer",
+                &peer_id,
+            ],
+        );
+        run_cli(
+            legacy,
+            home.path(),
+            &["service", "pull", manifest_path.to_str().unwrap()],
+        );
+    }
+
+    let legacy_config = fs::read_to_string(home.path().join("config.toml")).unwrap();
+    assert!(legacy_config.contains("incoming_allowed_peers"));
+    assert!(legacy_config.contains("tcp_tunneling"));
+    assert!(legacy_config.contains("file_transfer"));
+    assert!(home.path().join("address_book.toml").exists());
+    assert!(home.path().join("services-state.json").exists());
+
+    let migrate_output = run_cli(current, home.path(), &["migrate"]);
+    assert!(migrate_output.stdout.contains("Migrated Fungi"));
+
+    let migrated_config_raw = fs::read_to_string(home.path().join("config.toml")).unwrap();
+    assert!(migrated_config_raw.contains("version = 3"));
+    assert!(!migrated_config_raw.contains("incoming_allowed_peers"));
+    assert!(!migrated_config_raw.contains("tcp_tunneling"));
+    assert!(!migrated_config_raw.contains("file_transfer"));
+    assert!(!migrated_config_raw.contains("allowed_ports"));
+    assert!(!migrated_config_raw.contains("allowed_port_ranges"));
+    assert!(migrated_config_raw.contains("\"/tmp\""));
+
+    let config = FungiConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(config.version, 3);
+    assert_eq!(
+        config.runtime.allowed_host_paths,
+        vec![PathBuf::from("/tmp")]
+    );
+
+    let trusted =
+        fungi_config::trusted_devices::TrustedDevicesConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(trusted.trusted_devices.len(), 1);
+    assert_eq!(trusted.trusted_devices[0].to_string(), peer_id);
+
+    let devices = DevicesConfig::apply_from_dir(home.path()).unwrap();
+    assert_eq!(devices.devices.len(), 1);
+    assert_eq!(devices.devices[0].peer_id.to_string(), peer_id);
+    assert_eq!(devices.devices[0].name.as_deref(), Some("demo-peer"));
+
+    let service_entries = fs::read_dir(home.path().join("services"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().unwrap().is_dir())
+        .collect::<Vec<_>>();
+    assert_eq!(service_entries.len(), 1);
+    let local_service_id = service_entries[0].file_name().to_string_lossy().to_string();
+    let appdata_dir = home
+        .path()
+        .join("appdata")
+        .join("services")
+        .join(&local_service_id);
+    let artifacts_dir = home
+        .path()
+        .join("artifacts")
+        .join("services")
+        .join(&local_service_id);
+    assert_eq!(
+        fs::read_to_string(appdata_dir.join("mount").join("state.txt")).unwrap(),
+        "persist"
+    );
+    assert!(artifacts_dir.join("component.wasm").is_file());
+    assert!(!appdata_dir.join("component.wasm").exists());
+
+    let migrated_manifest_path = home
+        .path()
+        .join("services")
+        .join(&local_service_id)
+        .join("service.yaml");
+    let migrated_manifest_yaml = fs::read_to_string(&migrated_manifest_path).unwrap();
+    assert!(migrated_manifest_yaml.contains("fungi: service/v1"));
+    assert!(migrated_manifest_yaml.contains(&format!("port: {service_host_port}")));
+    assert!(migrated_manifest_yaml.contains("$fungi.service.data/mount"));
+    assert!(migrated_manifest_yaml.contains("$fungi.service.artifacts/component.wasm"));
+
+    let backup_entries = fs::read_dir(home.path().join("bk"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .collect::<Vec<_>>();
+    assert_eq!(backup_entries.len(), 1);
+    assert!(
+        backup_entries[0]
+            .path()
+            .join(".keys")
+            .join("keypair")
+            .is_file()
+    );
+
+    {
+        let _daemon = start_daemon(current, home.path());
+        let inspect = run_cli(current, home.path(), &["service", "inspect", "cli-demo"]);
+        assert!(inspect.stdout.contains("\"name\": \"cli-demo\""));
+        assert!(inspect.stdout.contains("\"phase\": \"stopped\""));
+    }
+
+    let second_migrate = run_cli(current, home.path(), &["migrate"]);
+    assert!(second_migrate.stdout.contains("already at version 3"));
 }
 
 fn current_fungi_bin() -> &'static Path {
@@ -303,6 +498,85 @@ struct CliOutput {
     stdout: String,
 }
 
+struct RunningDaemon {
+    child: Child,
+    _stdin: ChildStdin,
+}
+
+impl Drop for RunningDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn configure_legacy_daemon_ports(fungi_dir: &Path) {
+    let config_path = fungi_dir.join("config.toml");
+    let rpc_port = reserve_tcp_port();
+    let tcp_port = reserve_tcp_port();
+    let udp_port = reserve_udp_port();
+    let content = fs::read_to_string(&config_path).unwrap();
+    let content = content
+        .replace(
+            "listen_address = \"127.0.0.1:5405\"",
+            &format!("listen_address = \"127.0.0.1:{rpc_port}\""),
+        )
+        .replace(
+            "listen_tcp_port = 0",
+            &format!("listen_tcp_port = {tcp_port}"),
+        )
+        .replace(
+            "listen_udp_port = 0",
+            &format!("listen_udp_port = {udp_port}"),
+        );
+    fs::write(config_path, content).unwrap();
+}
+
+fn reserve_tcp_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn reserve_udp_port() -> u16 {
+    UdpSocket::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn start_daemon(binary: &Path, fungi_dir: &Path) -> RunningDaemon {
+    let mut child = Command::new(binary)
+        .arg("--fungi-dir")
+        .arg(fungi_dir)
+        .arg("daemon")
+        .arg("--exit-on-stdin-close")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.take().unwrap();
+    let daemon = RunningDaemon {
+        child,
+        _stdin: stdin,
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if try_run_cli(binary, fungi_dir, &["info", "version"]).is_some() {
+            return daemon;
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon did not become ready");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 fn run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> CliOutput {
     let mut child = Command::new(binary)
         .arg("--fungi-dir")
@@ -337,4 +611,20 @@ fn run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> CliOutput {
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+fn try_run_cli(binary: &Path, fungi_dir: &Path, args: &[&str]) -> Option<CliOutput> {
+    let output = Command::new(binary)
+        .arg("--fungi-dir")
+        .arg(fungi_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(CliOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+    })
 }


### PR DESCRIPTION
## Summary

- finalize the post-v0.6.1 fungi-dir schema as version 3
- migrate both the unversioned v0.6.1 layout and intermediate version 2 nightly layouts
- rewrite legacy managed services into the current `fungi: service/v1` format and current control/appdata/artifact directory boundaries
- preserve local access intent while removing obsolete remote protocol and port details
- move legacy incoming peer allowlists into `trusted_devices.toml`
- remove obsolete config sections and retired remote service caches after preserving them in a full backup
- strengthen migration transactions and real release-to-current integration coverage

This supersedes #29, whose migration assumptions predate the later intentional config and service-model breaking changes.

## Migration behavior

- unversioned v0.6.1 config -> v3
- intermediate v2 config -> v3
- v3 config -> no-op unless known legacy side files are still present
- `address_book.toml` -> `devices.toml`
- `incoming_allowed_peers` -> `trusted_devices.toml`
- `access/local_access.json` -> `cache/local_preferences.json`
- `services-state.json` and `services/<name>` -> current `services/<local_service_id>`, `appdata/services/<local_service_id>`, and `artifacts/services/<local_service_id>` layout
- `cache/remote_services/` and `cache/device_managed_services/` are removed as obsolete non-authoritative caches
- removed `tcp_tunneling`, `file_transfer`, and runtime port allowlist fields are dropped from live config

Every migration now keeps a complete pre-migration fungi-dir snapshot under `bk/`, excluding backup and staging directories themselves. Transaction directory allocation also avoids overwriting a backup created in the same second.

## Service migration

Legacy managed service state is converted directly into the current `fungi: service/v1` document:

- Wasmtime components move to `$fungi.service.artifacts/component.wasm`
- persisted mount data moves under `$fungi.service.data`
- legacy Wasmtime host ports remain the current published listener ports
- Docker publish entries retain service ports and use the current automatic host-port policy
- removed catalog, labels, working-directory, entrypoint, and remote-port concepts are not carried into the new manifest; the complete originals remain available in the backup

## Validation

- `cargo fmt --check`
- `cargo test -p fungi-config-migrate`
- `cargo test -p fungi-config`
- `cargo test -p fungi`
- `cargo check --workspace`
- `cargo clippy -p fungi-config-migrate --tests -- -D warnings`
- `cargo test -p fungi --test migrate_cli -- --ignored --nocapture`

The ignored integration suite downloads and runs the official v0.6.1 binary, writes configuration and managed service state through the legacy daemon/CLI, migrates it, starts the current daemon, and verifies the migrated service through the current CLI.
