### PR TITLE
[codex] Reject access to stopped local services

### DIFF
--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -520,6 +520,7 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
                     )
                 }
                 let instance = inspect_local_service(&mut client, target.name).await;
+                require_local_service_running(&instance);
                 select_local_port(&instance, entry.as_deref())
                     .map(|port| format!("127.0.0.1:{}", port.host_port))
             };
@@ -1204,6 +1205,7 @@ async fn open_local_dynamic_service(args: CommonArgs, service: String, entry: Op
     };
 
     if let Some(instance) = find_local_service(&mut client, &service).await {
+        require_local_service_running(&instance);
         let Some(url) = build_local_web_url(&instance, entry.as_deref()) else {
             fatal("No web entry is available for this service")
         };
@@ -1600,6 +1602,8 @@ fn build_local_web_url(instance: &ServiceInstance, entry: Option<&str>) -> Optio
 }
 
 fn open_or_print_local_service(instance: &ServiceInstance, entry: Option<&str>) {
+    require_local_service_running(instance);
+
     if let Some(url) = build_local_web_url(instance, entry) {
         open_url(&url);
         println!("Opened {url}");
@@ -1610,6 +1614,15 @@ fn open_or_print_local_service(instance: &ServiceInstance, entry: Option<&str>) 
         fatal("No connectable entry is available for this service")
     };
     println!("127.0.0.1:{}", port.host_port);
+}
+
+fn require_local_service_running(instance: &ServiceInstance) {
+    if !instance.status.is_running() {
+        fatal(format!(
+            "Local service {} exists but is not running (phase: {}). Start it with:\n  fungi service start {}",
+            instance.name, instance.status.phase, instance.name
+        ));
+    }
 }
 
 fn select_access_endpoint<'a>(

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -207,6 +207,70 @@ fn cli_requires_local_scope_for_existing_dynamic_service() {
 }
 
 #[test]
+fn cli_rejects_open_and_connect_for_stopped_local_service() {
+    let home = TempDir::new().unwrap();
+    let rpc = reserve_port();
+    let swarm = reserve_port();
+    let target = reserve_port();
+
+    init_fungi_dir(home.path(), rpc, swarm);
+    let _daemon = start_daemon(home.path());
+    let _peer = wait_peer_id(home.path());
+
+    let manifest = write_existing_tcp_service_manifest(home.path(), "stopped-web", target, "web");
+    let manifest_path = manifest.to_string_lossy();
+    run_cli(
+        home.path(),
+        [
+            "service",
+            "apply",
+            "stopped-web",
+            "--yes",
+            manifest_path.as_ref(),
+        ],
+    );
+
+    let assert_rejected = |output: CliOutput| {
+        assert!(
+            !output.status.success(),
+            "{:?} unexpectedly succeeded",
+            output.args
+        );
+        assert_eq!(output.stdout, "");
+        assert!(
+            output
+                .stderr
+                .contains("Local service stopped-web exists but is not running (phase: stopped)"),
+            "command {:?}\nstderr:\n{}",
+            output.args,
+            output.stderr
+        );
+        assert!(
+            output.stderr.contains("fungi service start stopped-web"),
+            "command {:?}\nstderr:\n{}",
+            output.args,
+            output.stderr
+        );
+    };
+
+    assert_rejected(run_cli_result_with_retry(
+        home.path(),
+        ["service", "open", "stopped-web"],
+        "",
+    ));
+    assert_rejected(run_cli_result_with_retry(
+        home.path(),
+        ["service", "connect", "stopped-web"],
+        "",
+    ));
+    assert_rejected(run_cli_result_with_retry(
+        home.path(),
+        ["stopped-web@local"],
+        "",
+    ));
+}
+
+#[test]
 fn cli_rejects_reserved_local_device_name() {
     let home = TempDir::new().unwrap();
 


### PR DESCRIPTION
## Summary

- reject `fungi service open` for stopped local services
- reject local `fungi service connect` from printing an unusable configured address
- apply the same lifecycle check to explicit local service shortcuts such as `fungi service@local`
- tell users which `fungi service start` command to run

## Root cause

Local service inspection retains configured port information while a service is stopped. The CLI used the presence of those ports as sufficient evidence that the service could be opened or connected, so it could launch an empty browser page or print an address with no active listener.

The daemon should continue reporting configured ports for inspection and display. This change instead gates access commands on `ServiceInstance.status.is_running()` before using those ports.

## Validation

- `cargo test -p fungi`
- `cargo fmt --all -- --check`
- `git diff --check`

The CLI smoke suite now covers stopped local `service open`, `service connect`, and `service@local` access attempts.
