### PR TITLE
fix(config): support daemon locking on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "log",
  "mdns-sd",
  "multiaddr",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ percent-encoding = "2.3"
 prost = "0.14"
 rand = "0.8"
 reqwest = { version = "0.13", default-features = false }
+rustix = { version = "1.1.4", features = ["fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,3 +18,6 @@ mdns-sd = { workspace = true }
 fungi-config-migrate = { workspace = true }
 ulid = { workspace = true }
 tempfile = { workspace = true }
+
+[target.'cfg(target_os = "android")'.dependencies]
+rustix = { workspace = true }

--- a/crates/config/src/daemon_lock.rs
+++ b/crates/config/src/daemon_lock.rs
@@ -10,6 +10,22 @@ pub fn daemon_lock_path(fungi_dir: &Path) -> PathBuf {
     fungi_dir.join(DAEMON_LOCK_FILE)
 }
 
+#[cfg(target_os = "android")]
+fn try_lock(file: &File) -> std::result::Result<(), TryLockError> {
+    use rustix::fs::{FlockOperation, flock};
+
+    match flock(file, FlockOperation::NonBlockingLockExclusive) {
+        Ok(()) => Ok(()),
+        Err(error) if error == rustix::io::Errno::WOULDBLOCK => Err(TryLockError::WouldBlock),
+        Err(error) => Err(TryLockError::Error(error.into())),
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn try_lock(file: &File) -> std::result::Result<(), TryLockError> {
+    file.try_lock()
+}
+
 pub struct DaemonInstanceLock {
     _file: File,
 }
@@ -31,7 +47,7 @@ impl DaemonInstanceLock {
             .open(&path)
             .with_context(|| format!("Failed to open daemon lock file: {}", path.display()))?;
 
-        match file.try_lock() {
+        match try_lock(&file) {
             Ok(()) => Ok(Self { _file: file }),
             Err(TryLockError::WouldBlock) => anyhow::bail!(
                 "Fungi daemon is already running for {}",


### PR DESCRIPTION
## Summary

- Fix Android daemon startup by using a supported advisory file lock.

## Changes

- Use `rustix::fs::flock` for non-blocking exclusive locking on Android.
- Keep `std::fs::File::try_lock` on other platforms.
- Preserve duplicate-daemon detection and stale lock-file recovery.

## Verification

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --all`
- Android arm64 release build
- Android arm64 lock tests on a physical device
- Android 16 start, stop/restart, and duplicate-daemon checks

## AI assistance

- Codex
