### PR TITLE
fix(android): use WebPKI for daemon HTTPS

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -83,3 +83,4 @@ jobs:
           script: |
             adb devices
             ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ANDROID_NDK="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" cargo ndk -P 24 -t x86_64 test -p fungi-config --lib -- --nocapture
+            ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ANDROID_NDK="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" cargo ndk -P 24 -t x86_64 test -p fungi-daemon --lib http_client::tests:: -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.6",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1635,6 +1636,7 @@ dependencies = [
  "toml",
  "typed-path",
  "ulid",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ percent-encoding = "2.3"
 prost = "0.14"
 rand = "0.8"
 reqwest = { version = "0.13", default-features = false }
+rustls = { version = "0.23", default-features = false }
 rustix = { version = "1.1.4", features = ["fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -64,6 +65,7 @@ typed-path = "0.12"
 ulid = "1"
 void = "1"
 wasmtime-cli = "46.0.1"
+webpki-roots = "1"
 libp2p = { version = "0.56", features = [
     "macros",
     "noise",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -42,5 +42,9 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 ulid = { workspace = true }
 
+[target.'cfg(target_os = "android")'.dependencies]
+rustls = { workspace = true, features = ["aws_lc_rs", "std", "tls12"] }
+webpki-roots = { workspace = true }
+
 [dev-dependencies]
 toml = { workspace = true }

--- a/crates/daemon/src/http_client.rs
+++ b/crates/daemon/src/http_client.rs
@@ -1,0 +1,64 @@
+use anyhow::{Context, Result};
+use once_cell::sync::OnceCell;
+use reqwest::Client;
+
+static HTTP_CLIENT: OnceCell<Client> = OnceCell::new();
+
+pub(crate) fn http_client() -> Result<&'static Client> {
+    HTTP_CLIENT.get_or_try_init(build_http_client)
+}
+
+fn build_http_client() -> Result<Client> {
+    let builder = Client::builder();
+
+    // The daemon runs as a standalone native process on Android, so it has no JVM or Android
+    // Context with which to initialize reqwest 0.13's default rustls-platform-verifier. Use an
+    // explicit WebPKI configuration there. Other platforms retain reqwest's platform verifier.
+    #[cfg(target_os = "android")]
+    let builder = builder.tls_backend_preconfigured(android_tls_config()?);
+
+    builder.build().context("failed to build HTTP client")
+}
+
+#[cfg(target_os = "android")]
+fn android_tls_config() -> Result<rustls::ClientConfig> {
+    use std::sync::Arc;
+
+    let roots = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+    Ok(
+        rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_safe_default_protocol_versions()
+            .context("failed to configure Android TLS protocol versions")?
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reuses_shared_http_client() {
+        let first = http_client().unwrap();
+        let second = http_client().unwrap();
+        assert!(std::ptr::eq(first, second));
+    }
+
+    #[cfg(target_os = "android")]
+    #[tokio::test]
+    async fn android_client_verifies_public_https_without_jvm() {
+        let response = http_client()
+            .unwrap()
+            .get("https://github.com")
+            .send()
+            .await
+            .unwrap();
+
+        assert!(response.status().is_success());
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,6 +1,7 @@
 mod api;
 mod controls;
 mod daemon;
+mod http_client;
 mod node_capabilities;
 mod recipes;
 pub mod runtime;

--- a/crates/daemon/src/recipes.rs
+++ b/crates/daemon/src/recipes.rs
@@ -4,7 +4,9 @@ use anyhow::{Context as _, Result, bail};
 use fungi_config::recipe_cache::{RecipeCache, validate_asset_name};
 use serde::Deserialize;
 
-use crate::{peek_service_manifest_name, service_manifest_with_instance_name};
+use crate::{
+    http_client::http_client, peek_service_manifest_name, service_manifest_with_instance_name,
+};
 
 const OFFICIAL_RECIPE_SOURCE_LABEL: &str = "enbop/fungi-service-recipes";
 const OFFICIAL_RECIPE_LATEST_RELEASE_URL: &str =
@@ -237,14 +239,18 @@ async fn load_official_recipe_index(
 }
 
 async fn refresh_latest_official_recipe_index(cache: &RecipeCache) -> Result<String> {
-    let latest_release_response = reqwest::get(OFFICIAL_RECIPE_LATEST_RELEASE_URL)
+    let latest_release_response = http_client()?
+        .get(OFFICIAL_RECIPE_LATEST_RELEASE_URL)
+        .send()
         .await
         .context("failed to resolve latest official recipe release")?
         .error_for_status()
         .context("latest official recipe release request failed")?;
     let release_version = release_version_from_release_page_url(latest_release_response.url())?;
 
-    let response = reqwest::get(release_asset_url(&release_version, "index.json")?)
+    let response = http_client()?
+        .get(release_asset_url(&release_version, "index.json")?)
+        .send()
         .await
         .context("failed to fetch official recipe index")?
         .error_for_status()
@@ -273,7 +279,9 @@ async fn ensure_cached_asset(
         return Ok(path);
     }
 
-    let response = reqwest::get(release_asset_url(release_version, asset_name)?)
+    let response = http_client()?
+        .get(release_asset_url(release_version, asset_name)?)
+        .send()
         .await
         .with_context(|| format!("failed to fetch recipe asset `{asset_name}`"))?
         .error_for_status()

--- a/crates/daemon/src/runtime/helpers.rs
+++ b/crates/daemon/src/runtime/helpers.rs
@@ -8,6 +8,8 @@ use fungi_config::paths::FungiPaths;
 use fungi_docker_agent::{ContainerSpec, DockerAgentError, PortProtocol};
 use tokio::process::Command;
 
+use crate::http_client::http_client;
+
 use super::{
     manifest::service_expose_endpoint_bindings, model::*, providers::WasmtimeServiceState,
 };
@@ -173,7 +175,9 @@ async fn stage_wasmtime_component(
             })?;
         }
         ServiceSource::WasmtimeUrl { url } => {
-            let response = reqwest::get(url)
+            let response = http_client()?
+                .get(url)
+                .send()
                 .await
                 .with_context(|| format!("Failed to download WASI component from {url}"))?
                 .error_for_status()


### PR DESCRIPTION
## Summary

- Prevent the standalone Android daemon from aborting when recipe or Wasmtime component downloads perform HTTPS certificate verification.
- Keep Reqwest 0.13 platform-default certificate verification unchanged on non-Android targets.

## Changes

- Add a shared daemon HTTP client used by all four existing external download call sites.
- Configure only Android with an explicit Rustls client using WebPKI roots and the AWS-LC crypto provider.
- Continue using Reqwest's default platform verifier on non-Android targets.
- Add an Android emulator regression test that performs a public HTTPS request without JVM initialization.

## Verification

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --all`
- `cargo clippy -p fungi-daemon --all-targets -- -D warnings`
- `cargo ndk -P 24 -t arm64-v8a check -p fungi-daemon`
- `cargo ndk -P 24 -t x86_64 check -p fungi-daemon`
- `cargo ndk -P 24 -t x86_64 test -p fungi-daemon --lib http_client::tests:: --no-run`
- `git diff --check`
- Android emulator CI runs `http_client::tests::android_client_verifies_public_https_without_jvm`.

## AI assistance

- Codex
