### PR TITLE
feat(service): add bounded remote service logs

### DIFF
--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -143,6 +143,10 @@ service FungiDaemon {
   rpc RemoteStartService(RemoteServiceNameRequest)
   returns (RemoteServiceControlResponse) {}
 
+    // Gets bounded logs for a service on a remote peer.
+  rpc RemoteGetServiceLogs(RemoteGetServiceLogsRequest)
+  returns (ServiceLogsResponse) {}
+
     // Stops a service on a remote peer by service name.
   rpc RemoteStopService(RemoteServiceNameRequest)
   returns (RemoteServiceControlResponse) {}
@@ -515,6 +519,12 @@ message RemotePullServiceRequest {
 message RemoteServiceNameRequest {
   string peer_id = 1;
   string name    = 2;
+}
+
+message RemoteGetServiceLogsRequest {
+  string peer_id = 1;
+  string name    = 2;
+  uint32 tail    = 3;
 }
 
 message RemotePeerRequest { string peer_id = 1; }

--- a/crates/daemon-grpc/src/generated/fungi_daemon.rs
+++ b/crates/daemon-grpc/src/generated/fungi_daemon.rs
@@ -554,6 +554,15 @@ pub struct RemoteServiceNameRequest {
     pub name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoteGetServiceLogsRequest {
+    #[prost(string, tag = "1")]
+    pub peer_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub tail: u32,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemotePeerRequest {
     #[prost(string, tag = "1")]
     pub peer_id: ::prost::alloc::string::String,
@@ -1505,6 +1514,26 @@ pub mod fungi_daemon_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        /// Gets bounded logs for a service on a remote peer.
+        pub async fn remote_get_service_logs(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RemoteGetServiceLogsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ServiceLogsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/fungi_daemon.FungiDaemon/RemoteGetServiceLogs",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "fungi_daemon.FungiDaemon",
+                "RemoteGetServiceLogs",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         /// Stops a service on a remote peer by service name.
         pub async fn remote_stop_service(
             &mut self,
@@ -1900,6 +1929,11 @@ pub mod fungi_daemon_server {
             &self,
             request: tonic::Request<super::RemoteServiceNameRequest>,
         ) -> std::result::Result<tonic::Response<super::RemoteServiceControlResponse>, tonic::Status>;
+        /// Gets bounded logs for a service on a remote peer.
+        async fn remote_get_service_logs(
+            &self,
+            request: tonic::Request<super::RemoteGetServiceLogsRequest>,
+        ) -> std::result::Result<tonic::Response<super::ServiceLogsResponse>, tonic::Status>;
         /// Stops a service on a remote peer by service name.
         async fn remote_stop_service(
             &self,
@@ -3621,6 +3655,48 @@ pub mod fungi_daemon_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RemoteStartServiceSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/fungi_daemon.FungiDaemon/RemoteGetServiceLogs" => {
+                    #[allow(non_camel_case_types)]
+                    struct RemoteGetServiceLogsSvc<T: FungiDaemon>(pub Arc<T>);
+                    impl<T: FungiDaemon>
+                        tonic::server::UnaryService<super::RemoteGetServiceLogsRequest>
+                        for RemoteGetServiceLogsSvc<T>
+                    {
+                        type Response = super::ServiceLogsResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RemoteGetServiceLogsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FungiDaemon>::remote_get_service_logs(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = RemoteGetServiceLogsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -1114,6 +1114,26 @@ impl FungiDaemon for FungiDaemonRpcImpl {
         }))
     }
 
+    async fn remote_get_service_logs(
+        &self,
+        request: Request<RemoteGetServiceLogsRequest>,
+    ) -> Result<Response<ServiceLogsResponse>, Status> {
+        let req = request.into_inner();
+        let peer_id = PeerId::from_str(&req.peer_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid peer_id: {e}")))?;
+        let tail = (req.tail != 0).then_some(req.tail as usize);
+        let logs = self
+            .inner
+            .remote_get_service_logs(peer_id, req.name, tail)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get remote service logs: {e}")))?;
+
+        Ok(Response::new(ServiceLogsResponse {
+            raw: logs.raw,
+            text: logs.text,
+        }))
+    }
+
     async fn remote_stop_service(
         &self,
         request: Request<RemoteServiceNameRequest>,

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -586,6 +586,28 @@ impl FungiDaemon {
         ))
     }
 
+    pub async fn remote_get_service_logs(
+        &self,
+        peer_id: PeerId,
+        name: String,
+        tail: Option<usize>,
+    ) -> Result<ServiceLogs> {
+        let tail = tail
+            .unwrap_or(crate::DEFAULT_REMOTE_SERVICE_LOG_TAIL)
+            .clamp(1, crate::MAX_REMOTE_SERVICE_LOG_TAIL);
+        let response = self
+            .service_control_protocol_control()
+            .get_peer_service_logs(peer_id, name, tail)
+            .await?;
+        let text = response
+            .logs_text
+            .ok_or_else(|| anyhow::anyhow!("remote service log response did not include logs"))?;
+        Ok(ServiceLogs {
+            raw: Vec::new(),
+            text,
+        })
+    }
+
     pub async fn remote_stop_service(
         &self,
         peer_id: PeerId,

--- a/crates/daemon/src/controls/mod.rs
+++ b/crates/daemon/src/controls/mod.rs
@@ -7,6 +7,8 @@ mod tcp_tunneling;
 
 pub use docker::{DockerControl, detect_socket_path};
 pub use node_capabilities::NodeCapabilitiesControl;
-pub use service_control::ServiceControlProtocolControl;
+pub use service_control::{
+    DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL, ServiceControlProtocolControl,
+};
 pub use service_discovery::ServiceDiscoveryControl;
 pub use tcp_tunneling::TcpTunnelingControl;

--- a/crates/daemon/src/controls/service_control.rs
+++ b/crates/daemon/src/controls/service_control.rs
@@ -19,6 +19,10 @@ use crate::{
 };
 
 const MAX_CONTROL_FRAME_LEN: usize = 2 * 1024 * 1024;
+pub const DEFAULT_REMOTE_SERVICE_LOG_TAIL: usize = 200;
+pub const MAX_REMOTE_SERVICE_LOG_TAIL: usize = 2_000;
+const MAX_REMOTE_SERVICE_LOG_BYTES: usize = 512 * 1024;
+const REMOTE_LOG_TRUNCATION_NOTICE: &str = "[fungi] remote log output truncated\n";
 
 #[derive(Clone)]
 pub struct ServiceControlProtocolControl {
@@ -89,6 +93,23 @@ impl ServiceControlProtocolControl {
         self.send_request(
             peer_id,
             ServiceControlRequest::ListServices { request_id: None },
+        )
+        .await
+    }
+
+    pub async fn get_peer_service_logs(
+        &self,
+        peer_id: PeerId,
+        service: String,
+        tail: usize,
+    ) -> Result<ServiceControlResponse> {
+        self.send_request(
+            peer_id,
+            ServiceControlRequest::GetServiceLogs {
+                request_id: None,
+                service,
+                tail: tail.clamp(1, MAX_REMOTE_SERVICE_LOG_TAIL),
+            },
         )
         .await
     }
@@ -257,6 +278,28 @@ impl ServiceControlProtocolControl {
                     Err(error) => Err(error),
                 }
             }
+            ServiceControlRequest::GetServiceLogs { service, tail, .. } => {
+                let tail = tail.clamp(1, MAX_REMOTE_SERVICE_LOG_TAIL);
+                match self
+                    .runtime_control
+                    .logs_by_name(
+                        &service,
+                        &crate::ServiceLogsOptions {
+                            tail: Some(tail.to_string()),
+                        },
+                    )
+                    .await
+                {
+                    Ok(logs) => {
+                        return ServiceControlResponse::success_logs(
+                            request_id,
+                            service,
+                            limit_remote_log_text(logs.text),
+                        );
+                    }
+                    Err(error) => Err(error),
+                }
+            }
             ServiceControlRequest::StartService { service, .. } => {
                 match self.runtime_control.start_by_name(&service).await {
                     Ok(()) => match self
@@ -358,6 +401,19 @@ impl ServiceControlProtocolControl {
     }
 }
 
+fn limit_remote_log_text(text: String) -> String {
+    if text.len() <= MAX_REMOTE_SERVICE_LOG_BYTES {
+        return text;
+    }
+
+    let retained_bytes = MAX_REMOTE_SERVICE_LOG_BYTES - REMOTE_LOG_TRUNCATION_NOTICE.len();
+    let mut start = text.len() - retained_bytes;
+    while !text.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("{REMOTE_LOG_TRUNCATION_NOTICE}{}", &text[start..])
+}
+
 async fn write_frame<S, T>(stream: &mut S, value: &T) -> Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -409,4 +465,25 @@ where
         .map_err(|e| anyhow::anyhow!("Failed to read frame payload: {e}"))?;
     serde_json::from_slice(&payload)
         .map_err(|e| anyhow::anyhow!("Failed to decode service-control frame: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_log_text_is_limited_from_the_front_at_a_character_boundary() {
+        let text = format!("discarded\n{}", "界".repeat(MAX_REMOTE_SERVICE_LOG_BYTES));
+
+        let limited = limit_remote_log_text(text);
+
+        assert!(limited.starts_with(REMOTE_LOG_TRUNCATION_NOTICE));
+        assert!(limited.ends_with('界'));
+        assert!(limited.len() <= MAX_REMOTE_SERVICE_LOG_BYTES);
+    }
+
+    #[test]
+    fn short_remote_log_text_is_unchanged() {
+        assert_eq!(limit_remote_log_text("hello\n".to_string()), "hello\n");
+    }
 }

--- a/crates/daemon/src/controls/service_control.rs
+++ b/crates/daemon/src/controls/service_control.rs
@@ -282,20 +282,14 @@ impl ServiceControlProtocolControl {
                 let tail = tail.clamp(1, MAX_REMOTE_SERVICE_LOG_TAIL);
                 match self
                     .runtime_control
-                    .logs_by_name(
-                        &service,
-                        &crate::ServiceLogsOptions {
-                            tail: Some(tail.to_string()),
-                        },
-                    )
+                    .logs_text_by_name_bounded(&service, tail, MAX_REMOTE_SERVICE_LOG_BYTES)
                     .await
                 {
                     Ok(logs) => {
-                        return ServiceControlResponse::success_logs(
-                            request_id,
-                            service,
-                            limit_remote_log_text(logs.text),
-                        );
+                        match bounded_service_log_response(request_id.clone(), service, logs) {
+                            Ok(response) => return response,
+                            Err(error) => Err(error),
+                        }
                     }
                     Err(error) => Err(error),
                 }
@@ -401,17 +395,80 @@ impl ServiceControlProtocolControl {
     }
 }
 
-fn limit_remote_log_text(text: String) -> String {
-    if text.len() <= MAX_REMOTE_SERVICE_LOG_BYTES {
-        return text;
+fn bounded_service_log_response(
+    request_id: Option<String>,
+    service_name: String,
+    logs: crate::runtime::BoundedLogText,
+) -> Result<ServiceControlResponse> {
+    let (content, truncated) = limit_remote_log_content(logs.text, logs.truncated);
+    let response = ServiceControlResponse::success_logs(
+        request_id.clone(),
+        service_name.clone(),
+        render_remote_log_text(&content, truncated),
+    );
+    if serialized_frame_len(&response)? <= MAX_CONTROL_FRAME_LEN {
+        return Ok(response);
     }
 
-    let retained_bytes = MAX_REMOTE_SERVICE_LOG_BYTES - REMOTE_LOG_TRUNCATION_NOTICE.len();
-    let mut start = text.len() - retained_bytes;
-    while !text.is_char_boundary(start) {
-        start += 1;
+    let mut boundaries = content
+        .char_indices()
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    boundaries.push(content.len());
+    let mut low = 0;
+    let mut high = boundaries.len() - 1;
+    while low < high {
+        let middle = low + (high - low) / 2;
+        let candidate = ServiceControlResponse::success_logs(
+            request_id.clone(),
+            service_name.clone(),
+            render_remote_log_text(&content[boundaries[middle]..], true),
+        );
+        if serialized_frame_len(&candidate)? <= MAX_CONTROL_FRAME_LEN {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
     }
-    format!("{REMOTE_LOG_TRUNCATION_NOTICE}{}", &text[start..])
+
+    let response = ServiceControlResponse::success_logs(
+        request_id,
+        service_name,
+        render_remote_log_text(&content[boundaries[low]..], true),
+    );
+    if serialized_frame_len(&response)? > MAX_CONTROL_FRAME_LEN {
+        anyhow::bail!("Service-control log response cannot fit within the frame limit");
+    }
+    Ok(response)
+}
+
+fn limit_remote_log_content(mut text: String, mut truncated: bool) -> (String, bool) {
+    let initial_budget =
+        MAX_REMOTE_SERVICE_LOG_BYTES - usize::from(truncated) * REMOTE_LOG_TRUNCATION_NOTICE.len();
+    if text.len() > initial_budget {
+        truncated = true;
+        let content_budget = MAX_REMOTE_SERVICE_LOG_BYTES - REMOTE_LOG_TRUNCATION_NOTICE.len();
+        let mut start = text.len() - content_budget;
+        while !text.is_char_boundary(start) {
+            start += 1;
+        }
+        text = text[start..].to_string();
+    }
+    (text, truncated)
+}
+
+fn render_remote_log_text(content: &str, truncated: bool) -> String {
+    if truncated {
+        format!("{REMOTE_LOG_TRUNCATION_NOTICE}{content}")
+    } else {
+        content.to_string()
+    }
+}
+
+fn serialized_frame_len(value: &impl Serialize) -> Result<usize> {
+    serde_json::to_vec(value)
+        .map(|payload| payload.len())
+        .map_err(|e| anyhow::anyhow!("Failed to serialize service-control frame: {e}"))
 }
 
 async fn write_frame<S, T>(stream: &mut S, value: &T) -> Result<()>
@@ -421,6 +478,13 @@ where
 {
     let payload = serde_json::to_vec(value)
         .map_err(|e| anyhow::anyhow!("Failed to serialize service-control frame: {e}"))?;
+    if payload.len() > MAX_CONTROL_FRAME_LEN {
+        anyhow::bail!(
+            "Service-control frame too large: {} bytes (max {})",
+            payload.len(),
+            MAX_CONTROL_FRAME_LEN
+        );
+    }
     let payload_len = u32::try_from(payload.len())
         .map_err(|_| anyhow::anyhow!("Service-control frame is too large"))?;
 
@@ -473,9 +537,13 @@ mod tests {
 
     #[test]
     fn remote_log_text_is_limited_from_the_front_at_a_character_boundary() {
-        let text = format!("discarded\n{}", "界".repeat(MAX_REMOTE_SERVICE_LOG_BYTES));
+        let logs = crate::runtime::BoundedLogText {
+            text: format!("discarded\n{}", "界".repeat(MAX_REMOTE_SERVICE_LOG_BYTES)),
+            truncated: false,
+        };
 
-        let limited = limit_remote_log_text(text);
+        let response = bounded_service_log_response(None, "demo".to_string(), logs).unwrap();
+        let limited = response.logs_text.unwrap();
 
         assert!(limited.starts_with(REMOTE_LOG_TRUNCATION_NOTICE));
         assert!(limited.ends_with('界'));
@@ -484,6 +552,49 @@ mod tests {
 
     #[test]
     fn short_remote_log_text_is_unchanged() {
-        assert_eq!(limit_remote_log_text("hello\n".to_string()), "hello\n");
+        let response = bounded_service_log_response(
+            None,
+            "demo".to_string(),
+            crate::runtime::BoundedLogText {
+                text: "hello\n".to_string(),
+                truncated: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(response.logs_text.as_deref(), Some("hello\n"));
+    }
+
+    #[test]
+    fn control_heavy_remote_logs_fit_the_serialized_frame_limit() {
+        let response = bounded_service_log_response(
+            Some("request".to_string()),
+            "demo".to_string(),
+            crate::runtime::BoundedLogText {
+                text: "\0".repeat(MAX_REMOTE_SERVICE_LOG_BYTES),
+                truncated: false,
+            },
+        )
+        .unwrap();
+        let payload = serde_json::to_vec(&response).unwrap();
+
+        assert!(payload.len() <= MAX_CONTROL_FRAME_LEN);
+        assert!(
+            response
+                .logs_text
+                .as_deref()
+                .unwrap()
+                .starts_with(REMOTE_LOG_TRUNCATION_NOTICE)
+        );
+    }
+
+    #[tokio::test]
+    async fn write_frame_rejects_oversized_outgoing_payloads() {
+        let mut stream = futures::io::Cursor::new(Vec::new());
+        let oversized = "\0".repeat(MAX_CONTROL_FRAME_LEN);
+
+        let error = write_frame(&mut stream, &oversized).await.unwrap_err();
+
+        assert!(error.to_string().contains("frame too large"));
+        assert!(stream.into_inner().is_empty());
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -16,6 +16,7 @@ pub mod test_support;
 
 pub use api::{ServiceAccess, ServiceAccessEndpoint};
 use clap::Parser;
+pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;
 pub use node_capabilities::{
     LocalRuntimeAvailability, LocalRuntimeStatus, NodeCapabilities, NodeRuntimeCapabilities,

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -386,6 +386,35 @@ impl RuntimeControl {
         self.logs(runtime, name, options).await
     }
 
+    pub(crate) async fn logs_text_by_name_bounded(
+        &self,
+        name: &str,
+        tail: usize,
+        max_bytes: usize,
+    ) -> Result<BoundedLogText> {
+        let runtime = self.resolve_runtime(name)?;
+        self.ensure_runtime_enabled(runtime)?;
+        self.ensure_runtime_service(runtime, name).await?;
+        match runtime {
+            RuntimeKind::Docker => {
+                let logs = self
+                    .docker_provider()?
+                    .logs(
+                        &self.docker_runtime_handle_or_name(name),
+                        &ServiceLogsOptions {
+                            tail: Some(tail.to_string()),
+                        },
+                    )
+                    .await?;
+                Ok(super::providers::limit_text_bytes_from_end(
+                    logs.text, max_bytes,
+                ))
+            }
+            RuntimeKind::Wasmtime => self.wasmtime.logs_text_bounded(name, tail, max_bytes),
+            RuntimeKind::External => bail!("external TCP services do not have runtime logs"),
+        }
+    }
+
     pub async fn list_published_device_services(&self) -> Result<Vec<DeviceService>> {
         let manifests = self
             .service_manifests

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -284,3 +284,9 @@ pub struct ServiceLogs {
     pub raw: Vec<u8>,
     pub text: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedLogText {
+    pub(crate) text: String,
+    pub(crate) truncated: bool,
+}

--- a/crates/daemon/src/runtime/providers.rs
+++ b/crates/daemon/src/runtime/providers.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs::{self, OpenOptions},
-    io::Read,
+    io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     process::Stdio,
     sync::Arc,
@@ -150,6 +150,39 @@ fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
 }
 
 impl WasmtimeRuntimeProvider {
+    pub(crate) fn logs_text_bounded(
+        &self,
+        handle: &str,
+        tail: usize,
+        max_bytes: usize,
+    ) -> Result<BoundedLogText> {
+        let log_file_path = {
+            let services = self.services.lock();
+            services
+                .get(handle)
+                .ok_or_else(|| anyhow::anyhow!("wasmtime service not found: {handle}"))?
+                .log_file_path
+                .clone()
+        };
+
+        let mut file = match fs::File::open(&log_file_path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BoundedLogText {
+                    text: String::new(),
+                    truncated: false,
+                });
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to read log file: {}", log_file_path.display())
+                });
+            }
+        };
+        read_tail_text_bounded(&mut file, tail, max_bytes)
+            .with_context(|| format!("Failed to read log file: {}", log_file_path.display()))
+    }
+
     pub fn new(
         runtime_root: PathBuf,
         launcher_path: PathBuf,
@@ -256,6 +289,159 @@ impl WasmtimeRuntimeProvider {
     fn service_artifacts_dir(&self, local_service_id: &str) -> PathBuf {
         FungiPaths::from_fungi_home(&self.fungi_home).service_artifacts_dir(local_service_id)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Seek, SeekFrom};
+
+    use super::*;
+
+    struct CountingReader {
+        inner: Cursor<Vec<u8>>,
+        bytes_read: usize,
+    }
+
+    impl CountingReader {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                inner: Cursor::new(bytes),
+                bytes_read: 0,
+            }
+        }
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let read = self.inner.read(buffer)?;
+            self.bytes_read += read;
+            Ok(read)
+        }
+    }
+
+    impl Seek for CountingReader {
+        fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(position)
+        }
+    }
+
+    #[test]
+    fn bounded_tail_reads_only_the_file_suffix() {
+        let mut bytes = vec![b'x'; 2 * 1024 * 1024];
+        bytes.extend_from_slice(b"\nkeep one\nkeep two\n");
+        let mut reader = CountingReader::new(bytes);
+
+        let logs = read_tail_text_bounded(&mut reader, 2, 64).unwrap();
+
+        assert_eq!(logs.text, "keep one\nkeep two\n");
+        assert!(!logs.truncated);
+        assert_eq!(reader.bytes_read, 65);
+    }
+
+    #[test]
+    fn bounded_tail_limits_a_single_oversized_line() {
+        let mut reader = CountingReader::new(vec![b'x'; 1024]);
+
+        let logs = read_tail_text_bounded(&mut reader, 1, 32).unwrap();
+
+        assert_eq!(logs.text, "x".repeat(32));
+        assert!(logs.truncated);
+        assert_eq!(reader.bytes_read, 33);
+    }
+
+    #[test]
+    fn bounded_tail_preserves_utf8_and_trailing_newline_semantics() {
+        let mut bytes = vec![b'x'; 1024];
+        bytes.extend_from_slice("\n前一行\n最后一行\n".as_bytes());
+        let mut reader = CountingReader::new(bytes);
+
+        let logs = read_tail_text_bounded(&mut reader, 1, 64).unwrap();
+
+        assert_eq!(logs.text, "最后一行\n");
+        assert!(!logs.truncated);
+        assert!(logs.text.is_char_boundary(logs.text.len()));
+    }
+
+    #[test]
+    fn bounded_tail_handles_invalid_utf8_without_exceeding_budget() {
+        let mut bytes = vec![b'x'; 128];
+        bytes.extend_from_slice(b"\n\xfftail\n");
+        let mut reader = CountingReader::new(bytes);
+
+        let logs = read_tail_text_bounded(&mut reader, 1, 16).unwrap();
+
+        assert_eq!(logs.text, "�tail\n");
+        assert!(logs.text.len() <= 16);
+        assert!(!logs.truncated);
+    }
+}
+
+pub(crate) fn limit_text_bytes_from_end(text: String, max_bytes: usize) -> BoundedLogText {
+    if text.len() <= max_bytes {
+        return BoundedLogText {
+            text,
+            truncated: false,
+        };
+    }
+
+    if max_bytes == 0 {
+        return BoundedLogText {
+            text: String::new(),
+            truncated: !text.is_empty(),
+        };
+    }
+
+    let mut start = text.len() - max_bytes;
+    while !text.is_char_boundary(start) {
+        start += 1;
+    }
+    BoundedLogText {
+        text: text[start..].to_string(),
+        truncated: true,
+    }
+}
+
+fn read_tail_text_bounded<R: Read + Seek>(
+    reader: &mut R,
+    tail: usize,
+    max_bytes: usize,
+) -> Result<BoundedLogText> {
+    let file_len = reader.seek(SeekFrom::End(0))?;
+    if file_len == 0 || tail == 0 || max_bytes == 0 {
+        return Ok(BoundedLogText {
+            text: String::new(),
+            truncated: file_len > 0,
+        });
+    }
+
+    let read_budget = max_bytes.saturating_add(1);
+    let read_len = usize::try_from(file_len.min(read_budget as u64))?;
+    let read_start = file_len - read_len as u64;
+    reader.seek(SeekFrom::Start(read_start))?;
+
+    let mut raw = vec![0_u8; read_len];
+    reader.read_exact(&mut raw)?;
+
+    let scan_end = raw.len() - usize::from(raw.ends_with(b"\n"));
+    let mut remaining_lines = tail;
+    let mut selected_start = raw.len().saturating_sub(max_bytes);
+    for index in (0..scan_end).rev() {
+        if raw[index] != b'\n' {
+            continue;
+        }
+        remaining_lines -= 1;
+        if remaining_lines == 0 {
+            selected_start = index + 1;
+            break;
+        }
+    }
+
+    let source_exceeded_budget = file_len > max_bytes as u64;
+    let incomplete_requested_lines = source_exceeded_budget && remaining_lines > 0;
+    let text = String::from_utf8_lossy(&raw[selected_start..]).into_owned();
+    let mut bounded = limit_text_bytes_from_end(text, max_bytes);
+    bounded.truncated |= incomplete_requested_lines;
+    Ok(bounded)
 }
 
 fn with_default_mount_roots(fungi_home: &Path, mut paths: Vec<PathBuf>) -> Vec<PathBuf> {

--- a/crates/daemon/src/service_control.rs
+++ b/crates/daemon/src/service_control.rs
@@ -10,6 +10,11 @@ pub enum ServiceControlRequest {
     ListServices {
         request_id: Option<String>,
     },
+    GetServiceLogs {
+        request_id: Option<String>,
+        service: String,
+        tail: usize,
+    },
     StartService {
         request_id: Option<String>,
         service: String,
@@ -29,6 +34,7 @@ impl ServiceControlRequest {
         match self {
             Self::PullService { request_id, .. }
             | Self::ListServices { request_id, .. }
+            | Self::GetServiceLogs { request_id, .. }
             | Self::StartService { request_id, .. }
             | Self::StopService { request_id, .. }
             | Self::RemoveService { request_id, .. } => request_id.as_deref(),
@@ -39,7 +45,8 @@ impl ServiceControlRequest {
         match self {
             Self::PullService { .. } => None,
             Self::ListServices { .. } => None,
-            Self::StartService { service, .. }
+            Self::GetServiceLogs { service, .. }
+            | Self::StartService { service, .. }
             | Self::StopService { service, .. }
             | Self::RemoveService { service, .. } => Some(service.clone()),
         }
@@ -56,6 +63,8 @@ pub struct ServiceControlResponse {
     pub service: Option<ServiceControlServiceRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub services_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logs_text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ServiceControlError>,
 }
@@ -68,6 +77,7 @@ impl ServiceControlResponse {
             forgotten_locally: false,
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
+            logs_text: None,
             error: None,
         }
     }
@@ -79,6 +89,7 @@ impl ServiceControlResponse {
             forgotten_locally: true,
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
+            logs_text: None,
             error: None,
         }
     }
@@ -90,6 +101,19 @@ impl ServiceControlResponse {
             forgotten_locally: false,
             service: None,
             services_json: Some(services_json),
+            logs_text: None,
+            error: None,
+        }
+    }
+
+    pub fn success_logs(request_id: Option<String>, service_name: String, text: String) -> Self {
+        Self {
+            request_id,
+            ok: true,
+            forgotten_locally: false,
+            service: Some(ServiceControlServiceRef { name: service_name }),
+            services_json: None,
+            logs_text: Some(text),
             error: None,
         }
     }
@@ -101,6 +125,7 @@ impl ServiceControlResponse {
             forgotten_locally: false,
             service: None,
             services_json: None,
+            logs_text: None,
             error: Some(ServiceControlError {
                 code: code.to_string(),
                 message,

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -39,6 +39,7 @@
 
 use std::{
     net::TcpListener,
+    path::Path,
     time::{Duration, Instant},
 };
 
@@ -223,6 +224,11 @@ impl TestDaemon {
     /// Borrow the inner daemon for calling any daemon API directly.
     pub fn daemon(&self) -> &FungiDaemon {
         &self.inner
+    }
+
+    /// Return the isolated Fungi home used by this daemon.
+    pub fn fungi_dir(&self) -> &Path {
+        self._dir.path()
     }
 
     /// Borrow the underlying [`fungi_swarm::SwarmControl`].

--- a/crates/daemon/tests/remote_service_logs_tests.rs
+++ b/crates/daemon/tests/remote_service_logs_tests.rs
@@ -1,0 +1,86 @@
+use std::{fs, time::Duration};
+
+use anyhow::Result;
+use fungi_daemon::test_support::spawn_connected_pair;
+use libp2p::swarm::dial_opts::DialOpts;
+
+#[tokio::test]
+async fn trusted_device_reads_bounded_remote_service_logs() -> Result<()> {
+    let (client, server) = spawn_connected_pair().await?;
+    let server_peer_id = server.peer_id();
+    let server_addr = server.tcp_multiaddr();
+    client
+        .swarm_control()
+        .invoke_swarm(move |swarm| {
+            swarm.dial(
+                DialOpts::peer_id(server_peer_id)
+                    .addresses(vec![server_addr])
+                    .build(),
+            )
+        })
+        .await??;
+    client
+        .wait_connected(server.peer_id(), Duration::from_secs(5))
+        .await?;
+
+    let component = server.fungi_dir().join("demo.wasm");
+    fs::write(&component, b"test component bytes")?;
+    let manifest = format!(
+        r#"fungi: service/v1
+id: remote-log-demo
+run:
+  provider: wasmtime
+  source:
+    file: {}
+publish:
+  main:
+    tcp:
+      port: 18080
+"#,
+        component.display()
+    );
+    server
+        .daemon()
+        .pull_service_from_manifest_yaml(manifest, Some(server.fungi_dir().to_path_buf()))
+        .await?;
+
+    let runtime_log = server
+        .fungi_dir()
+        .join("runtime/wasmtime/remote-log-demo/runtime.log");
+    let text = (0..2_500)
+        .map(|line| format!("remote log line {line:03}\n"))
+        .collect::<String>();
+    fs::write(runtime_log, text)?;
+
+    let default_logs = client
+        .daemon()
+        .remote_get_service_logs(server.peer_id(), "remote-log-demo".to_string(), None)
+        .await?;
+    assert_eq!(default_logs.text.lines().count(), 200);
+    assert!(!default_logs.text.contains("remote log line 2299"));
+    assert!(default_logs.text.contains("remote log line 2300"));
+    assert!(default_logs.text.contains("remote log line 2499"));
+
+    let tail_logs = client
+        .daemon()
+        .remote_get_service_logs(server.peer_id(), "remote-log-demo".to_string(), Some(3))
+        .await?;
+    assert_eq!(
+        tail_logs.text,
+        "remote log line 2497\nremote log line 2498\nremote log line 2499\n"
+    );
+
+    let capped_logs = client
+        .daemon()
+        .remote_get_service_logs(
+            server.peer_id(),
+            "remote-log-demo".to_string(),
+            Some(usize::MAX),
+        )
+        .await?;
+    assert_eq!(capped_logs.text.lines().count(), 2_000);
+    assert!(capped_logs.text.contains("remote log line 500"));
+    assert!(capped_logs.text.contains("remote log line 2499"));
+
+    Ok(())
+}

--- a/crates/daemon/tests/remote_service_logs_tests.rs
+++ b/crates/daemon/tests/remote_service_logs_tests.rs
@@ -50,7 +50,7 @@ publish:
     let text = (0..2_500)
         .map(|line| format!("remote log line {line:03}\n"))
         .collect::<String>();
-    fs::write(runtime_log, text)?;
+    fs::write(&runtime_log, text)?;
 
     let default_logs = client
         .daemon()
@@ -81,6 +81,19 @@ publish:
     assert_eq!(capped_logs.text.lines().count(), 2_000);
     assert!(capped_logs.text.contains("remote log line 500"));
     assert!(capped_logs.text.contains("remote log line 2499"));
+
+    fs::write(&runtime_log, "\0".repeat(512 * 1024))?;
+    let escaped_logs = client
+        .daemon()
+        .remote_get_service_logs(server.peer_id(), "remote-log-demo".to_string(), Some(1))
+        .await?;
+    assert!(
+        escaped_logs
+            .text
+            .starts_with("[fungi] remote log output truncated\n")
+    );
+    assert!(escaped_logs.text.ends_with('\0'));
+    assert!(escaped_logs.text.len() < 512 * 1024);
 
     Ok(())
 }

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -5,7 +5,8 @@ use std::process::Command;
 use clap::{Args, Subcommand};
 use fungi_config::{FungiDir, devices::LOCAL_DEVICE_NAME, paths::FungiPaths};
 use fungi_daemon::{
-    DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
+    DEFAULT_REMOTE_SERVICE_LOG_TAIL, DeviceService, DeviceServiceSnapshot,
+    MAX_REMOTE_SERVICE_LOG_TAIL, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
     ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus, parse_service_manifest_yaml,
     service_manifest_with_instance_name,
 };
@@ -16,8 +17,9 @@ use fungi_daemon_grpc::{
         DeviceServiceSnapshotRequest, Empty, GetRecipeRequest, GetServiceLogsRequest,
         ListRecipesRequest, ListRecipesResponse, ListServiceAccessesRequest, ListServicesResponse,
         PullServiceRequest, RecipeDetail, RecipeRuntimeKind, RecipeSummary,
-        RemotePullServiceRequest, RemoteServiceControlResponse, RemoteServiceNameRequest,
-        ResolveRecipeRequest, ServiceInstanceResponse, ServiceNameRequest,
+        RemoteGetServiceLogsRequest, RemotePullServiceRequest, RemoteServiceControlResponse,
+        RemoteServiceNameRequest, ResolveRecipeRequest, ServiceInstanceResponse,
+        ServiceNameRequest,
     },
 };
 use serde::Serialize;
@@ -123,11 +125,12 @@ pub enum ServiceCommands {
         #[arg(short, long, default_value_t = false)]
         verbose: bool,
     },
-    /// Get local service logs by name
+    /// Get service logs by name
     Logs {
         name: String,
+        /// Return only the last N lines (remote default: 200; remote maximum: 2000)
         #[arg(long)]
-        tail: Option<String>,
+        tail: Option<usize>,
     },
     /// Remove a service
     Remove {
@@ -336,20 +339,30 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
             }
         }
         ServiceCommands::Logs { name, tail } => {
-            if device.is_some() {
-                fatal("Remote service logs are not implemented yet")
-            }
-            let req = GetServiceLogsRequest {
-                runtime: 0,
-                name,
-                tail: tail.unwrap_or_default(),
-            };
-            match client.get_service_logs(Request::new(req)).await {
-                Ok(resp) => {
-                    let logs = resp.into_inner();
-                    print!("{}", logs.text);
+            let target = parse_service_reference(name);
+            reject_service_entry(&target, "logs");
+            let device = resolve_service_device_target(&args, device, target.device);
+            if let Some(device) = device {
+                let tail = resolve_remote_log_tail(tail).unwrap_or_else(|error| fatal(error));
+                let req = RemoteGetServiceLogsRequest {
+                    peer_id: device.peer_id,
+                    name: target.name,
+                    tail: tail as u32,
+                };
+                match client.remote_get_service_logs(Request::new(req)).await {
+                    Ok(resp) => print!("{}", resp.into_inner().text),
+                    Err(error) => fatal_remote_device_grpc(error),
                 }
-                Err(e) => fatal_grpc(e),
+            } else {
+                let req = GetServiceLogsRequest {
+                    runtime: 0,
+                    name: target.name,
+                    tail: tail.map(|tail| tail.to_string()).unwrap_or_default(),
+                };
+                match client.get_service_logs(Request::new(req)).await {
+                    Ok(resp) => print!("{}", resp.into_inner().text),
+                    Err(error) => fatal_grpc(error),
+                }
             }
         }
         ServiceCommands::Stop { name } => {
@@ -549,6 +562,16 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
             }
         }
     }
+}
+
+fn resolve_remote_log_tail(tail: Option<usize>) -> Result<usize, String> {
+    let tail = tail.unwrap_or(DEFAULT_REMOTE_SERVICE_LOG_TAIL);
+    if !(1..=MAX_REMOTE_SERVICE_LOG_TAIL).contains(&tail) {
+        return Err(format!(
+            "Remote log tail must be between 1 and {MAX_REMOTE_SERVICE_LOG_TAIL} lines"
+        ));
+    }
+    Ok(tail)
 }
 
 fn validate_service_command_before_connect(command: &ServiceCommands) {
@@ -2847,6 +2870,30 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn remote_log_tail_defaults_and_accepts_bounds() {
+        assert_eq!(
+            resolve_remote_log_tail(None),
+            Ok(DEFAULT_REMOTE_SERVICE_LOG_TAIL)
+        );
+        assert_eq!(resolve_remote_log_tail(Some(1)), Ok(1));
+        assert_eq!(
+            resolve_remote_log_tail(Some(MAX_REMOTE_SERVICE_LOG_TAIL)),
+            Ok(MAX_REMOTE_SERVICE_LOG_TAIL)
+        );
+    }
+
+    #[test]
+    fn remote_log_tail_rejects_zero_and_values_over_limit() {
+        let expected =
+            format!("Remote log tail must be between 1 and {MAX_REMOTE_SERVICE_LOG_TAIL} lines");
+        assert_eq!(resolve_remote_log_tail(Some(0)), Err(expected.clone()));
+        assert_eq!(
+            resolve_remote_log_tail(Some(MAX_REMOTE_SERVICE_LOG_TAIL + 1)),
+            Err(expected)
+        );
+    }
 
     #[test]
     fn select_access_endpoint_prefers_requested_entry() {

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -559,6 +559,104 @@ fn cli_can_create_and_access_remote_tcp_service() {
     );
 }
 
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Windows GitHub Actions intermittently cancels short-lived local gRPC CLI connections in two-daemon smoke tests"
+)]
+fn cli_reads_remote_service_logs_with_default_and_explicit_tail() {
+    let a = TempDir::new().unwrap();
+    let b = TempDir::new().unwrap();
+    let a_rpc = reserve_port();
+    let b_rpc = reserve_port();
+    let a_swarm = reserve_port();
+    let b_swarm = reserve_port();
+
+    init_fungi_dir(a.path(), a_rpc, a_swarm);
+    init_fungi_dir(b.path(), b_rpc, b_swarm);
+
+    let _daemon_a = start_daemon(a.path());
+    let _daemon_b = start_daemon(b.path());
+
+    let a_peer = wait_peer_id(a.path());
+    let b_peer = wait_peer_id(b.path());
+    let b_addr = format!("/ip4/127.0.0.1/tcp/{b_swarm}/p2p/{b_peer}");
+
+    run_cli(
+        a.path(),
+        [
+            "device",
+            "add",
+            "b",
+            b_peer.as_str(),
+            "--addr",
+            b_addr.as_str(),
+        ],
+    );
+    run_cli(b.path(), ["device", "add", "a", a_peer.as_str()]);
+    run_cli_with_input(b.path(), ["device", "trust", "a"], "y\n");
+
+    let component = b.path().join("remote-log-demo.wasm");
+    std::fs::write(&component, b"test component bytes").unwrap();
+    let manifest = write_wasmtime_service_manifest(a.path(), &component, "remote-log-demo");
+    let manifest_path = manifest.to_string_lossy();
+    run_cli(
+        a.path(),
+        [
+            "service",
+            "apply",
+            "remote-log-demo@b",
+            "--yes",
+            manifest_path.as_ref(),
+        ],
+    );
+
+    let log_path = b
+        .path()
+        .join("runtime/wasmtime/remote-log-demo/runtime.log");
+    let text = (0..210)
+        .map(|line| format!("cli remote log {line:03}\n"))
+        .collect::<String>();
+    std::fs::write(log_path, text).unwrap();
+
+    let output = run_cli(a.path(), ["service", "logs", "remote-log-demo@b"]);
+    assert_eq!(output.stderr, "");
+    assert_eq!(output.stdout.lines().count(), 200);
+    assert!(!output.stdout.contains("cli remote log 009"));
+    assert!(output.stdout.starts_with("cli remote log 010\n"));
+    assert!(output.stdout.ends_with("cli remote log 209\n"));
+
+    let output = run_cli(
+        a.path(),
+        [
+            "service",
+            "--device",
+            "b",
+            "logs",
+            "remote-log-demo",
+            "--tail",
+            "2",
+        ],
+    );
+    assert_eq!(output.stdout, "cli remote log 208\ncli remote log 209\n");
+    assert_eq!(output.stderr, "");
+
+    let output = run_cli_result(
+        a.path(),
+        ["service", "logs", "remote-log-demo@b", "--tail", "2001"],
+        "",
+    );
+    assert!(!output.status.success());
+    assert_eq!(output.stdout, "");
+    assert!(
+        output
+            .stderr
+            .contains("Remote log tail must be between 1 and 2000 lines"),
+        "{}",
+        output.stderr
+    );
+}
+
 fn init_fungi_dir(path: &std::path::Path, rpc_port: u16, swarm_port: u16) {
     run_cli(path, ["init"]);
     assert!(
@@ -630,6 +728,37 @@ publish:
 ---
 
 # dry-run-wasi
+"#,
+            component.display()
+        ),
+    )
+    .unwrap();
+    path
+}
+
+fn write_wasmtime_service_manifest(
+    dir: &std::path::Path,
+    component: &std::path::Path,
+    name: &str,
+) -> std::path::PathBuf {
+    let path = dir.join(format!("{name}.fungi.md"));
+    std::fs::write(
+        &path,
+        format!(
+            r#"---
+fungi: service/v1
+id: {name}
+run:
+  provider: wasmtime
+  source:
+    file: {}
+publish:
+  main:
+    tcp:
+      port: 8080
+---
+
+# {name}
 "#,
             component.display()
         ),


### PR DESCRIPTION
## Summary

- Enable trusted devices to retrieve service logs remotely through the existing service-control channel.
- Keep remote log output bounded and suitable for CLI piping and AI agent feedback loops.

## Changes

- Add `RemoteGetServiceLogs` support across the gRPC and P2P service-control layers.
- Support both remote target forms:
  - `fungi service logs <name>@<device> [--tail N]`
  - `fungi service --device <device> logs <name> [--tail N]`
- Default remote log requests to the latest 200 lines.
- Accept remote `--tail` values from 1 through 2000, with validation in the CLI and defensive clamping in the daemon.
- Limit remote log responses to 512 KiB, retaining the newest content and adding a truncation notice when necessary.
- Keep local log behavior unchanged when `--tail` is omitted.
- Emit only log text on stdout so output remains pipe-friendly.
- Add unit, P2P integration, and dual-daemon CLI smoke coverage.

## Verification

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --all`
- Verified default 200-line remote output.
- Verified explicit `--tail` through both remote target syntaxes.
- Verified the 2000-line maximum and 512 KiB response limit.
- Verified trusted-device CLI → gRPC → P2P → remote runtime log retrieval.

## AI assistance

- Codex (GPT-5.6)
