### PR TITLE
fix(cli): bound ping and RPC requests

### DIFF
--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -75,7 +75,7 @@ service FungiDaemon {
   // Removes a user-managed device.
   rpc RemoveDevice(RemoveDeviceRequest) returns (Empty) {}
 
-  // Continuously pings all active connections to a peer and streams results.
+  // Pings all active connections to a peer and streams each round's results.
   rpc PingPeer(PingPeerRequest) returns (stream PingPeerEvent) {}
 
   // Lists currently established connections with latest ping metadata.
@@ -275,6 +275,8 @@ message RemoveDeviceRequest { string peer_id = 1; }
 message PingPeerRequest {
   string peer_id     = 1;
   uint32 interval_ms = 2;
+  // Number of ping rounds to run. Zero keeps streaming until the client disconnects.
+  uint32 count       = 3;
 }
 
 message PingPeerEvent {

--- a/crates/daemon-grpc/src/generated/fungi_daemon.rs
+++ b/crates/daemon-grpc/src/generated/fungi_daemon.rs
@@ -171,6 +171,9 @@ pub struct PingPeerRequest {
     pub peer_id: ::prost::alloc::string::String,
     #[prost(uint32, tag = "2")]
     pub interval_ms: u32,
+    /// Number of ping rounds to run. Zero keeps streaming until the client disconnects.
+    #[prost(uint32, tag = "3")]
+    pub count: u32,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PingPeerEvent {
@@ -1144,7 +1147,7 @@ pub mod fungi_daemon_client {
                 .insert(GrpcMethod::new("fungi_daemon.FungiDaemon", "RemoveDevice"));
             self.inner.unary(req, path, codec).await
         }
-        /// Continuously pings all active connections to a peer and streams results.
+        /// Pings all active connections to a peer and streams each round's results.
         pub async fn ping_peer(
             &mut self,
             request: impl tonic::IntoRequest<super::PingPeerRequest>,
@@ -1819,7 +1822,7 @@ pub mod fungi_daemon_server {
                 Item = std::result::Result<super::PingPeerEvent, tonic::Status>,
             > + std::marker::Send
             + 'static;
-        /// Continuously pings all active connections to a peer and streams results.
+        /// Pings all active connections to a peer and streams each round's results.
         async fn ping_peer(
             &self,
             request: tonic::Request<super::PingPeerRequest>,

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -58,6 +58,10 @@ fn ping_event(
     }
 }
 
+fn ping_count_reached(count: u32, tick_seq: u64) -> bool {
+    count > 0 && tick_seq >= u64::from(count)
+}
+
 fn proto_runtime_kind(kind: i32) -> Result<Option<fungi_daemon::RuntimeKind>, Status> {
     match ServiceRuntimeKind::try_from(kind) {
         Ok(ServiceRuntimeKind::Unspecified) => Ok(None),
@@ -490,6 +494,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
         } else {
             req.interval_ms
         };
+        let count = req.count;
 
         let daemon = self.inner.clone();
         let (tx, rx) = mpsc::channel::<Result<PingPeerEvent, Status>>(128);
@@ -609,6 +614,10 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                                 .await?;
                         }
                     }
+                }
+
+                if ping_count_reached(count, tick_seq) {
+                    break;
                 }
             }
 
@@ -1403,6 +1412,18 @@ fn i64_to_system_time(secs: i64) -> Result<SystemTime, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn finite_ping_stops_at_requested_round() {
+        assert!(!ping_count_reached(4, 3));
+        assert!(ping_count_reached(4, 4));
+        assert!(ping_count_reached(4, 5));
+    }
+
+    #[test]
+    fn zero_ping_count_keeps_streaming() {
+        assert!(!ping_count_reached(0, u64::MAX));
+    }
 
     #[test]
     #[cfg(windows)]

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -62,6 +62,23 @@ fn ping_count_reached(count: u32, tick_seq: u64) -> bool {
     count > 0 && tick_seq >= u64::from(count)
 }
 
+async fn send_idle_ping_event(
+    tx: &mpsc::Sender<Result<PingPeerEvent, Status>>,
+    peer_id: &str,
+    tick_seq: u64,
+    ts_unix_ms: i64,
+    count: u32,
+) -> Result<bool, PingEventSendError> {
+    tx.send(Ok(ping_event(
+        peer_id,
+        tick_seq,
+        ts_unix_ms,
+        ping_peer_event::Event::Idle(PingPeerIdle {}),
+    )))
+    .await?;
+    Ok(ping_count_reached(count, tick_seq))
+}
+
 fn proto_runtime_kind(kind: i32) -> Result<Option<fungi_daemon::RuntimeKind>, Status> {
     match ServiceRuntimeKind::try_from(kind) {
         Ok(ServiceRuntimeKind::Unspecified) => Ok(None),
@@ -548,13 +565,9 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                 let ts_unix_ms = now_unix_ms();
 
                 let Some(peer_connections) = daemon.get_peer_connections(peer_id) else {
-                    tx.send(Ok(ping_event(
-                        &peer_id_str,
-                        tick_seq,
-                        ts_unix_ms,
-                        ping_peer_event::Event::Idle(PingPeerIdle {}),
-                    )))
-                    .await?;
+                    if send_idle_ping_event(&tx, &peer_id_str, tick_seq, ts_unix_ms, count).await? {
+                        break;
+                    }
                     continue;
                 };
 
@@ -1418,6 +1431,20 @@ mod tests {
         assert!(!ping_count_reached(4, 3));
         assert!(ping_count_reached(4, 4));
         assert!(ping_count_reached(4, 5));
+    }
+
+    #[tokio::test]
+    async fn finite_idle_ping_stops_after_requested_round() {
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(
+            send_idle_ping_event(&tx, "device", 4, 123, 4)
+                .await
+                .unwrap()
+        );
+        let event = rx.recv().await.unwrap().unwrap();
+        assert_eq!(event.tick_seq, 4);
+        assert!(matches!(event.event, Some(ping_peer_event::Event::Idle(_))));
     }
 
     #[test]

--- a/fungi/src/commands/fungi_control/client.rs
+++ b/fungi/src/commands/fungi_control/client.rs
@@ -7,6 +7,11 @@ use crate::commands::CommonArgs;
 
 use super::shared::fatal;
 
+pub(super) const DEFAULT_RPC_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(30);
+pub(super) const LONG_RPC_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(300);
+
 pub(super) fn read_rpc_endpoint(fungi_dir: &std::path::Path) -> anyhow::Result<String> {
     fungi_config::read_daemon_endpoint(fungi_dir)
 }
@@ -21,8 +26,25 @@ pub(super) fn rpc_address_from_endpoint(endpoint: &str) -> anyhow::Result<String
     Ok(address.to_string())
 }
 
+fn rpc_endpoint(
+    rpc_addr: String,
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> anyhow::Result<tonic::transport::Endpoint> {
+    Ok(tonic::transport::Endpoint::from_shared(rpc_addr)?
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout))
+}
+
 pub async fn get_rpc_client(
     args: &CommonArgs,
+) -> Option<FungiDaemonClient<tonic::transport::Channel>> {
+    get_rpc_client_with_timeout(args, DEFAULT_RPC_REQUEST_TIMEOUT).await
+}
+
+pub(super) async fn get_rpc_client_with_timeout(
+    args: &CommonArgs,
+    request_timeout: std::time::Duration,
 ) -> Option<FungiDaemonClient<tonic::transport::Channel>> {
     let fungi_config = match FungiConfig::try_read_from_dir(&args.fungi_dir()) {
         Ok(config) => config,
@@ -35,27 +57,32 @@ pub async fn get_rpc_client(
     };
 
     let connect_timeout = std::time::Duration::from_secs(3);
-    match tokio::time::timeout(connect_timeout, FungiDaemonClient::connect(rpc_addr)).await {
-        Ok(Ok(mut client)) => match client.config_file_path(Request::new(Empty {})).await {
-            Ok(resp) => {
-                let remote_config_path =
-                    std::path::PathBuf::from(resp.into_inner().config_file_path);
-                if config_paths_match(&remote_config_path, &expected_config_path) {
-                    Some(client)
-                } else {
-                    log::warn!(
-                        "Connected daemon config path mismatch: expected {}, got {}",
-                        expected_config_path.display(),
-                        remote_config_path.display()
-                    );
+    let endpoint = rpc_endpoint(rpc_addr, connect_timeout, request_timeout)
+        .unwrap_or_else(|error| fatal(format!("Invalid Fungi daemon endpoint: {error}")));
+    match tokio::time::timeout(connect_timeout, endpoint.connect()).await {
+        Ok(Ok(channel)) => {
+            let mut client = FungiDaemonClient::new(channel);
+            match client.config_file_path(Request::new(Empty {})).await {
+                Ok(resp) => {
+                    let remote_config_path =
+                        std::path::PathBuf::from(resp.into_inner().config_file_path);
+                    if config_paths_match(&remote_config_path, &expected_config_path) {
+                        Some(client)
+                    } else {
+                        log::warn!(
+                            "Connected daemon config path mismatch: expected {}, got {}",
+                            expected_config_path.display(),
+                            remote_config_path.display()
+                        );
+                        None
+                    }
+                }
+                Err(error) => {
+                    log::error!("Failed to query daemon config path: {}", error);
                     None
                 }
             }
-            Err(error) => {
-                log::error!("Failed to query daemon config path: {}", error);
-                None
-            }
-        },
+        }
         Ok(Err(e)) => {
             log::error!("Error connecting to daemon: {}", e);
             None
@@ -83,7 +110,70 @@ fn config_paths_match(left: &std::path::Path, right: &std::path::Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{config_paths_match, read_rpc_endpoint, rpc_address_from_endpoint};
+    use std::{convert::Infallible, future::Future, pin::Pin, time::Duration};
+
+    use fungi_daemon_grpc::fungi_daemon_grpc::fungi_daemon_client::FungiDaemonClient;
+    use tonic::{Request, body::Body, codegen::Service, server::NamedService};
+
+    use super::{config_paths_match, read_rpc_endpoint, rpc_address_from_endpoint, rpc_endpoint};
+
+    #[derive(Clone)]
+    struct HangingRpcService;
+
+    impl NamedService for HangingRpcService {
+        const NAME: &'static str = "fungi_daemon.FungiDaemon";
+    }
+
+    impl Service<tonic::codegen::http::Request<Body>> for HangingRpcService {
+        type Response = tonic::codegen::http::Response<Body>;
+        type Error = Infallible;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: tonic::codegen::http::Request<Body>) -> Self::Future {
+            Box::pin(std::future::pending())
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_endpoint_times_out_a_stalled_request() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(HangingRpcService)
+                .serve_with_incoming(
+                    tonic::codegen::tokio_stream::wrappers::TcpListenerStream::new(listener),
+                ),
+        );
+
+        let channel = rpc_endpoint(
+            format!("http://{address}"),
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+        )
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+        let mut client = FungiDaemonClient::new(channel);
+        let started = tokio::time::Instant::now();
+        let error = client
+            .version(Request::new(fungi_daemon_grpc::fungi_daemon_grpc::Empty {}))
+            .await
+            .unwrap_err();
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(error.message().contains("Timeout expired"));
+        server.abort();
+    }
 
     #[test]
     fn config_path_match_accepts_relative_and_absolute_paths() {

--- a/fungi/src/commands/fungi_control/ping.rs
+++ b/fungi/src/commands/fungi_control/ping.rs
@@ -13,7 +13,17 @@ use super::{
     },
 };
 
-pub async fn execute_ping(args: CommonArgs, peer: PeerInput, interval_ms: u32, verbose: bool) {
+fn ping_count_exceeded(count: u32, tick_seq: u64) -> bool {
+    count > 0 && tick_seq > u64::from(count)
+}
+
+pub async fn execute_ping(
+    args: CommonArgs,
+    peer: PeerInput,
+    interval_ms: u32,
+    count: u32,
+    verbose: bool,
+) {
     let mut client = match get_rpc_client(&args).await {
         Some(c) => c,
         None => fatal("Cannot connect to Fungi daemon. Is it running?"),
@@ -28,6 +38,7 @@ pub async fn execute_ping(args: CommonArgs, peer: PeerInput, interval_ms: u32, v
     let req = PingPeerRequest {
         peer_id: resolved.peer_id.clone(),
         interval_ms,
+        count,
     };
 
     let response = match client.ping_peer(Request::new(req)).await {
@@ -36,15 +47,22 @@ pub async fn execute_ping(args: CommonArgs, peer: PeerInput, interval_ms: u32, v
     };
 
     let mut stream = response.into_inner();
-    println!(
-        "Ping stream peer={} interval={}ms (Ctrl+C to stop)",
-        if verbose {
-            resolved.peer_id.clone()
-        } else {
-            shorten_peer_id(&resolved.peer_id)
-        },
-        interval_ms
-    );
+    let peer_label = if verbose {
+        resolved.peer_id.clone()
+    } else {
+        shorten_peer_id(&resolved.peer_id)
+    };
+    if count == 0 {
+        println!(
+            "Ping stream peer={} interval={}ms (Ctrl+C to stop)",
+            peer_label, interval_ms
+        );
+    } else {
+        println!(
+            "Ping peer={} count={} interval={}ms",
+            peer_label, count, interval_ms
+        );
+    }
 
     if !verbose {
         println!(
@@ -53,7 +71,17 @@ pub async fn execute_ping(args: CommonArgs, peer: PeerInput, interval_ms: u32, v
         );
     }
 
-    while let Ok(Some(event)) = stream.message().await {
+    loop {
+        let event = match stream.message().await {
+            Ok(Some(event)) => event,
+            Ok(None) => break,
+            Err(error) => fatal_grpc(error),
+        };
+        // Older daemons ignore the count field and keep streaming. Waiting for
+        // the next tick preserves every result from the requested final round.
+        if ping_count_exceeded(count, event.tick_seq) {
+            break;
+        }
         match event.event {
             Some(ping_peer_event::Event::Connecting(_)) => {
                 if verbose {
@@ -166,5 +194,25 @@ pub async fn execute_ping(args: CommonArgs, peer: PeerInput, interval_ms: u32, v
                 }
             }
         }
+    }
+
+    if count > 0 {
+        println!("Ping completed: {count} rounds");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ping_count_exceeded;
+
+    #[test]
+    fn finite_client_accepts_every_requested_round() {
+        assert!(!ping_count_exceeded(4, 4));
+        assert!(ping_count_exceeded(4, 5));
+    }
+
+    #[test]
+    fn watch_mode_never_stops_for_a_tick_count() {
+        assert!(!ping_count_exceeded(0, u64::MAX));
     }
 }

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -27,7 +27,10 @@ use serde::Serialize;
 use crate::commands::CommonArgs;
 
 use super::{
-    client::get_rpc_client,
+    client::{
+        DEFAULT_RPC_REQUEST_TIMEOUT, LONG_RPC_REQUEST_TIMEOUT, get_rpc_client,
+        get_rpc_client_with_timeout,
+    },
     shared::{
         DeviceInput, OptionalDeviceTargetArg, fatal, fatal_grpc, print_target_device,
         resolve_optional_device,
@@ -177,7 +180,8 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
         });
     validate_service_command_before_connect(&command);
 
-    let mut client = match get_rpc_client(&args).await {
+    let request_timeout = service_request_timeout(&command);
+    let mut client = match get_rpc_client_with_timeout(&args, request_timeout).await {
         Some(c) => c,
         None => fatal("Cannot connect to Fungi daemon. Is it running?"),
     };
@@ -561,6 +565,13 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
                 Err(error) => fatal_grpc(error),
             }
         }
+    }
+}
+
+fn service_request_timeout(command: &ServiceCommands) -> std::time::Duration {
+    match command {
+        ServiceCommands::Apply { .. } | ServiceCommands::Pull { .. } => LONG_RPC_REQUEST_TIMEOUT,
+        _ => DEFAULT_RPC_REQUEST_TIMEOUT,
     }
 }
 
@@ -2882,6 +2893,36 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn service_apply_and_pull_use_long_rpc_timeout() {
+        let apply = ServiceCommands::Apply {
+            target: None,
+            manifest: None,
+            recipe: None,
+            create: false,
+            refresh: false,
+            dry_run: false,
+            start: false,
+            yes: false,
+        };
+        let pull = ServiceCommands::Pull {
+            manifest: "service.fungi.md".to_string(),
+        };
+
+        assert_eq!(service_request_timeout(&apply), LONG_RPC_REQUEST_TIMEOUT);
+        assert_eq!(service_request_timeout(&pull), LONG_RPC_REQUEST_TIMEOUT);
+    }
+
+    #[test]
+    fn ordinary_service_commands_use_default_rpc_timeout() {
+        let list = ServiceCommands::List {
+            verbose: false,
+            refresh: false,
+        };
+
+        assert_eq!(service_request_timeout(&list), DEFAULT_RPC_REQUEST_TIMEOUT);
+    }
 
     #[test]
     fn recipe_list_shows_catalog_release_once() {

--- a/fungi/src/commands/mod.rs
+++ b/fungi/src/commands/mod.rs
@@ -4,10 +4,21 @@ pub mod fungi_init;
 pub mod fungi_migrate;
 pub mod fungi_relay;
 
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use fungi_config::{FungiDir, default_fungi_dir_name};
+
+pub const DEFAULT_PING_COUNT: u32 = 4;
+
+pub fn resolve_ping_count(count: Option<NonZeroU32>, watch: bool) -> u32 {
+    if watch {
+        0
+    } else {
+        count.map_or(DEFAULT_PING_COUNT, NonZeroU32::get)
+    }
+}
 
 /// A platform built for seamless multi-device integration
 #[derive(Parser)]
@@ -84,13 +95,19 @@ pub enum Commands {
     /// Connection observability and diagnostics
     #[command(subcommand, visible_alias = "conn")]
     Connection(fungi_control::ConnectionCommands),
-    /// Continuously ping all active connections to a device
+    /// Ping all active connections to a device
     Ping {
         /// Device name to ping
         peer: fungi_control::PeerInput,
         /// Ping interval in milliseconds
         #[arg(long, default_value_t = 2000)]
         interval_ms: u32,
+        /// Number of ping rounds to run (default: 4)
+        #[arg(long, conflicts_with = "watch")]
+        count: Option<NonZeroU32>,
+        /// Continue pinging until interrupted
+        #[arg(long, conflicts_with = "count", default_value_t = false)]
+        watch: bool,
         /// Show detailed output
         #[arg(short, long, default_value_t = false)]
         verbose: bool,

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -37,8 +37,16 @@ fn main() -> Result<()> {
         Commands::Ping {
             peer,
             interval_ms,
+            count,
+            watch,
             verbose,
-        } => block_on(execute_ping(fungi_args.common, peer, interval_ms, verbose)),
+        } => block_on(execute_ping(
+            fungi_args.common,
+            peer,
+            interval_ms,
+            resolve_ping_count(count, watch),
+            verbose,
+        )),
         Commands::Dynamic(tokens) => block_on(execute_dynamic_service(fungi_args.common, tokens)),
     }
 

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -1,10 +1,11 @@
 use clap::{CommandFactory, Parser};
 use fungi::commands::{
-    Commands, FungiArgs,
+    Commands, DEFAULT_PING_COUNT, FungiArgs,
     fungi_control::{
         DeviceAddressCommands, DeviceCommands, DeviceInput, ServiceArgs, ServiceCommands,
         ServiceRecipeCommands,
     },
+    resolve_ping_count,
 };
 
 #[test]
@@ -68,6 +69,53 @@ fn parses_migrate_command() {
     let Commands::Migrate(_) = args.command else {
         panic!("expected migrate command");
     };
+}
+
+#[test]
+fn ping_defaults_to_finite_mode() {
+    let args = FungiArgs::try_parse_from(["fungi", "ping", "nas"]).unwrap();
+
+    let Commands::Ping { count, watch, .. } = args.command else {
+        panic!("expected ping command");
+    };
+
+    assert!(count.is_none());
+    assert!(!watch);
+    assert_eq!(resolve_ping_count(count, watch), DEFAULT_PING_COUNT);
+}
+
+#[test]
+fn parses_ping_count() {
+    let args = FungiArgs::try_parse_from(["fungi", "ping", "nas", "--count", "2"]).unwrap();
+
+    let Commands::Ping { count, watch, .. } = args.command else {
+        panic!("expected ping command");
+    };
+
+    assert_eq!(count.map(|count| count.get()), Some(2));
+    assert!(!watch);
+    assert_eq!(resolve_ping_count(count, watch), 2);
+}
+
+#[test]
+fn parses_continuous_ping_watch_mode() {
+    let args = FungiArgs::try_parse_from(["fungi", "ping", "nas", "--watch"]).unwrap();
+
+    let Commands::Ping { count, watch, .. } = args.command else {
+        panic!("expected ping command");
+    };
+
+    assert!(count.is_none());
+    assert!(watch);
+    assert_eq!(resolve_ping_count(count, watch), 0);
+}
+
+#[test]
+fn rejects_invalid_ping_count_combinations() {
+    assert!(FungiArgs::try_parse_from(["fungi", "ping", "nas", "--count", "0"]).is_err());
+    assert!(
+        FungiArgs::try_parse_from(["fungi", "ping", "nas", "--count", "2", "--watch"]).is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make `fungi ping DEVICE` finish after four rounds by default
- add explicit `--count` and `--watch` modes with old-daemon compatibility
- apply client-side timeouts to all CLI-to-daemon RPC requests

## Changes

- extend `PingPeerRequest` with a backward-compatible count field; zero retains continuous streaming
- stop finite ping streams in the daemon and add a client fallback for daemons that ignore the new field
- surface ping stream failures instead of silently treating them as completion
- configure tonic endpoints with a 30-second request timeout by default
- use a 300-second request timeout for service apply and the legacy pull path
- add CLI parsing, ping boundary, timeout classification, and stalled-RPC regression tests

## Verification

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --all`
- manually inspected `fungi ping --help`
- verified with a deliberately stalled tonic service that the client request times out
- verified from tonic 0.14 transport behavior that receiving a server-streaming response is not cut off by the endpoint request timeout

## AI assistance

- Codex (GPT-5.6)
