### PR TITLE
fix(daemon): restore remote service state asynchronously

### DIFF
--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -153,7 +153,7 @@ impl PingPeerError {
 }
 
 pub async fn start_grpc_server(
-    daemon: fungi_daemon::FungiDaemon,
+    daemon: Arc<fungi_daemon::FungiDaemon>,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
     tonic::transport::Server::builder()
@@ -172,10 +172,8 @@ pub struct FungiDaemonRpcImpl {
 }
 
 impl FungiDaemonRpcImpl {
-    pub fn new(inner: fungi_daemon::FungiDaemon) -> Self {
-        Self {
-            inner: Arc::new(inner),
-        }
+    pub fn new(inner: Arc<fungi_daemon::FungiDaemon>) -> Self {
+        Self { inner }
     }
 }
 

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -1283,6 +1283,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
 
         self.inner
             .detach_service_access(peer_id, req.service_name)
+            .await
             .map_err(|e| Status::internal(format!("Failed to detach service access: {e}")))?;
 
         Ok(Response::new(Empty {}))

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -48,3 +48,4 @@ webpki-roots = { workspace = true }
 
 [dev-dependencies]
 toml = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -667,7 +667,8 @@ impl FungiDaemon {
             .unwrap_or_default()
             .to_string();
         if !service_key.is_empty() {
-            self.detach_service_access_by_match(peer_id, &service_key)
+            self.detach_service_access(peer_id, service_key.clone())
+                .await
                 .with_context(|| {
                     format!(
                         "remote service stopped, but failed to disconnect local access listeners for {service_key}"

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -1,11 +1,13 @@
 use std::{
     collections::BTreeMap,
+    future::Future,
     path::{Path, PathBuf},
     time::SystemTime,
 };
 
 use anyhow::{Context as _, Result};
 use fungi_config::runtime::Runtime as RuntimeConfig;
+use futures::{StreamExt, stream};
 use libp2p::PeerId;
 
 use crate::runtime::{
@@ -14,9 +16,10 @@ use crate::runtime::{
 };
 use crate::service_state::DesiredServiceState;
 use crate::{
-    FungiDaemon, LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities,
-    ResolvedServiceRecipe, ServiceControlResponse, ServiceRecipeDetail, ServiceRecipeRuntime,
-    ServiceRecipeSummary, build_local_node_capabilities, build_local_runtime_status,
+    DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY, DEVICE_SERVICE_REFRESH_TIMEOUT, FungiDaemon,
+    LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities, ResolvedServiceRecipe,
+    ServiceControlResponse, ServiceRecipeDetail, ServiceRecipeRuntime, ServiceRecipeSummary,
+    build_local_node_capabilities, build_local_runtime_status,
 };
 
 pub struct DeviceServiceSnapshotLookup {
@@ -39,6 +42,32 @@ impl DeviceServiceSnapshotSource {
             Self::Empty => "empty",
         }
     }
+}
+
+async fn refresh_device_service_snapshots_with<F, Fut>(
+    device_ids: impl IntoIterator<Item = PeerId>,
+    refresh: F,
+) -> Vec<(PeerId, Result<DeviceServiceSnapshot>)>
+where
+    F: Fn(PeerId) -> Fut,
+    Fut: Future<Output = Result<DeviceServiceSnapshot>>,
+{
+    let refresh = &refresh;
+    stream::iter(device_ids)
+        .map(|device_id| async move {
+            let result = tokio::time::timeout(DEVICE_SERVICE_REFRESH_TIMEOUT, refresh(device_id))
+                .await
+                .unwrap_or_else(|_| {
+                    Err(anyhow::anyhow!(
+                        "timed out refreshing device service snapshot after {} seconds",
+                        DEVICE_SERVICE_REFRESH_TIMEOUT.as_secs()
+                    ))
+                });
+            (device_id, result)
+        })
+        .buffer_unordered(DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY)
+        .collect()
+        .await
 }
 
 impl FungiDaemon {
@@ -350,6 +379,16 @@ impl FungiDaemon {
         Ok(snapshot)
     }
 
+    pub async fn refresh_device_service_snapshots(
+        &self,
+        device_ids: impl IntoIterator<Item = PeerId>,
+    ) -> Vec<(PeerId, Result<DeviceServiceSnapshot>)> {
+        refresh_device_service_snapshots_with(device_ids, |device_id| {
+            self.refresh_device_service_snapshot(device_id)
+        })
+        .await
+    }
+
     pub fn save_device_service_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
         let snapshot_json = serde_json::to_string(snapshot)?;
         let fungi_dir = self.config_fungi_dir()?;
@@ -372,7 +411,11 @@ impl FungiDaemon {
         refresh: bool,
     ) -> Result<DeviceServiceSnapshotLookup> {
         if refresh {
-            match self.refresh_device_service_snapshot(device_id).await {
+            let mut results = self.refresh_device_service_snapshots([device_id]).await;
+            let (_, result) = results
+                .pop()
+                .expect("one device refresh should produce one result");
+            match result {
                 Ok(snapshot) => {
                     return Ok(DeviceServiceSnapshotLookup {
                         snapshot,
@@ -728,6 +771,8 @@ fn runtime_status_warning(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use crate::test_support::TestDaemon;
     use crate::{
         DeviceServiceEndpoint, ServiceExposeUsage, ServiceExposeUsageKind, ServicePhase,
@@ -735,6 +780,50 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn batch_snapshot_refresh_limits_concurrency() {
+        let in_flight = AtomicUsize::new(0);
+        let max_in_flight = AtomicUsize::new(0);
+        let in_flight = &in_flight;
+        let max_in_flight = &max_in_flight;
+        let peer_ids = (0..DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY + 1)
+            .map(|_| PeerId::random())
+            .collect::<Vec<_>>();
+
+        let results = refresh_device_service_snapshots_with(peer_ids, move |peer_id| async move {
+            let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            max_in_flight.fetch_max(current, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(DeviceServiceSnapshot {
+                peer_id: peer_id.to_string(),
+                services: Vec::new(),
+                updated_at: SystemTime::now(),
+            })
+        })
+        .await;
+
+        assert_eq!(results.len(), DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY + 1);
+        assert_eq!(
+            max_in_flight.load(Ordering::SeqCst),
+            DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_snapshot_refresh_applies_shared_timeout() {
+        let results = refresh_device_service_snapshots_with([PeerId::random()], |_| {
+            std::future::pending::<Result<DeviceServiceSnapshot>>()
+        })
+        .await;
+
+        let error = results.into_iter().next().unwrap().1.unwrap_err();
+        assert!(error.to_string().contains(&format!(
+            "after {} seconds",
+            DEVICE_SERVICE_REFRESH_TIMEOUT.as_secs()
+        )));
+    }
 
     #[test]
     fn merges_managed_status_with_published_connectable_endpoint() {

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -84,6 +84,35 @@ impl FungiDaemon {
         }
     }
 
+    async fn restore_current_service_access_forwarding_record(
+        &self,
+        candidate: &LocalServicePreference,
+        endpoint: &DeviceServiceEndpoint,
+    ) -> Result<()> {
+        let local_preferences_lock = self.local_preferences_lock();
+        let _local_preferences_guard = local_preferences_lock.lock().await;
+        let local_preferences = self.local_preferences()?;
+        let Some(current_record) = local_preferences
+            .find_record(
+                &candidate.remote_peer_id,
+                &candidate.remote_service_name,
+                &candidate.remote_service_port_name,
+            )
+            .cloned()
+        else {
+            log::debug!(
+                "Skipping stale service access restore for {}@{} entry {}",
+                candidate.remote_service_name,
+                candidate.remote_peer_id,
+                candidate.remote_service_port_name
+            );
+            return Ok(());
+        };
+
+        self.restore_service_access_forwarding_record(&current_record, endpoint)
+            .await
+    }
+
     async fn restore_service_access_forwarding_rule(&self, rule: ForwardingRule) {
         if let Err(error) = self.add_service_access_forwarding_rule_internal(rule).await {
             log::warn!(
@@ -388,7 +417,7 @@ impl FungiDaemon {
             };
 
             if let Err(error) = self
-                .restore_service_access_forwarding_record(record, endpoint)
+                .restore_current_service_access_forwarding_record(record, endpoint)
                 .await
             {
                 log::warn!(
@@ -658,6 +687,97 @@ mod tests {
             .filter(|access| access.service_name == service_name)
             .count();
         assert!(saved_count <= 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_does_not_recreate_forgotten_listener() -> Result<()> {
+        let service_name = "forgotten-restore";
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                None,
+            )
+            .await?;
+        let stale_records = client.daemon().local_preference_records().await?;
+
+        client
+            .daemon()
+            .forget_service_access(peer_id, service_name.to_string())
+            .await?;
+        client
+            .daemon()
+            .restore_service_access_records_from_cached_snapshots(&stale_records)
+            .await;
+
+        assert!(
+            client
+                .daemon()
+                .get_service_access_forwarding_rules()
+                .is_empty()
+        );
+        assert!(
+            client
+                .daemon()
+                .list_service_accesses(Some(peer_id))
+                .await?
+                .is_empty()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_preserves_reattached_listener() -> Result<()> {
+        let service_name = "reattached-restore";
+        let first_local_port = free_tcp_port()?;
+        let mut second_local_port = free_tcp_port()?;
+        while second_local_port == first_local_port {
+            second_local_port = free_tcp_port()?;
+        }
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(first_local_port),
+            )
+            .await?;
+        let stale_records = client.daemon().local_preference_records().await?;
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(second_local_port),
+            )
+            .await?;
+        client
+            .daemon()
+            .restore_service_access_records_from_cached_snapshots(&stale_records)
+            .await;
+
+        let active_ports = client
+            .daemon()
+            .get_service_access_forwarding_rules()
+            .into_iter()
+            .filter(|(_, rule)| rule.remote_service_name.as_deref() == Some(service_name))
+            .map(|(_, rule)| rule.local_port)
+            .collect::<Vec<_>>();
+        assert_eq!(active_ports, vec![second_local_port]);
         Ok(())
     }
 

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::TcpListener as StdTcpListener,
-    time::Duration,
 };
 
 use anyhow::{Result, bail};
@@ -303,32 +302,28 @@ impl FungiDaemon {
             }
         }
 
-        for peer_id in peer_ids {
-            match tokio::time::timeout(
-                Duration::from_secs(5),
-                self.refresh_device_service_snapshot(peer_id),
-            )
-            .await
-            {
-                Ok(Ok(_)) => {}
-                Ok(Err(error)) => {
-                    log::warn!(
-                        "Failed to refresh device service snapshot during startup restore for {}: {}",
-                        peer_id,
-                        error
-                    );
-                }
-                Err(_) => {
-                    log::warn!(
-                        "Timed out refreshing device service snapshot during startup restore for {}",
-                        peer_id
-                    );
-                }
+        for (peer_id, result) in self.refresh_device_service_snapshots(peer_ids).await {
+            if let Err(error) = result {
+                log::warn!(
+                    "Failed to refresh device service snapshot during startup restore for {}: {}",
+                    peer_id,
+                    error
+                );
             }
         }
 
-        self.restore_service_access_records_from_cached_snapshots(&records)
-            .await;
+        match self.local_preference_records().await {
+            Ok(current_records) => {
+                self.restore_service_access_records_from_cached_snapshots(&current_records)
+                    .await;
+            }
+            Err(error) => {
+                log::warn!(
+                    "Failed to reload local service access preferences after startup refresh: {}",
+                    error
+                );
+            }
+        }
     }
 
     async fn local_preference_records(&self) -> Result<Vec<LocalServicePreference>> {

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -91,6 +91,16 @@ impl FungiDaemon {
     ) -> Result<()> {
         let local_preferences_lock = self.local_preferences_lock();
         let _local_preferences_guard = local_preferences_lock.lock().await;
+        if self
+            .service_access_is_detached(&candidate.remote_peer_id, &candidate.remote_service_name)
+        {
+            log::debug!(
+                "Skipping detached service access restore for {}@{}",
+                candidate.remote_service_name,
+                candidate.remote_peer_id
+            );
+            return Ok(());
+        }
         let local_preferences = self.local_preferences()?;
         let Some(current_record) = local_preferences
             .find_record(
@@ -292,6 +302,7 @@ impl FungiDaemon {
         }
 
         enabled_endpoints.sort_by(|left, right| left.name.cmp(&right.name));
+        self.clear_service_access_detached(&peer_id_string, &service.name);
         Ok(ServiceAccess {
             peer_id: peer_id_string,
             service_name: service.name,
@@ -433,8 +444,12 @@ impl FungiDaemon {
         }
     }
 
-    pub fn detach_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.detach_service_access_by_match(peer_id, &service_name)
+    pub async fn detach_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
+        let local_preferences_lock = self.local_preferences_lock();
+        let _local_preferences_guard = local_preferences_lock.lock().await;
+        self.detach_service_access_by_match_internal(peer_id, &service_name)?;
+        self.mark_service_access_detached(&peer_id.to_string(), &service_name);
+        Ok(())
     }
 
     pub async fn restore_saved_service_access(
@@ -465,7 +480,11 @@ impl FungiDaemon {
         Ok(())
     }
 
-    pub fn detach_service_access_by_match(&self, peer_id: PeerId, matcher: &str) -> Result<()> {
+    fn detach_service_access_by_match_internal(
+        &self,
+        peer_id: PeerId,
+        matcher: &str,
+    ) -> Result<()> {
         let peer_id_string = peer_id.to_string();
         let rules_to_remove = self
             .get_service_access_forwarding_rules()
@@ -488,10 +507,11 @@ impl FungiDaemon {
         let local_preferences_lock = self.local_preferences_lock();
         let _local_preferences_guard = local_preferences_lock.lock().await;
 
-        self.detach_service_access_by_match(peer_id, &service_name)?;
+        self.detach_service_access_by_match_internal(peer_id, &service_name)?;
         let peer_id_string = peer_id.to_string();
         self.local_preferences()?
             .remove_service_records(&peer_id_string, &service_name)?;
+        self.clear_service_access_detached(&peer_id_string, &service_name);
         Ok(())
     }
 
@@ -513,6 +533,7 @@ impl FungiDaemon {
 
         self.local_preferences()?
             .remove_device_records(&peer_id_string)?;
+        self.clear_device_service_access_detached(&peer_id_string);
         Ok(())
     }
 
@@ -778,6 +799,65 @@ mod tests {
             .map(|(_, rule)| rule.local_port)
             .collect::<Vec<_>>();
         assert_eq!(active_ports, vec![second_local_port]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_preserves_explicit_detach_until_reattach() -> Result<()> {
+        let service_name = "detached-restore";
+        let local_port = free_tcp_port()?;
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(local_port),
+            )
+            .await?;
+        let stale_records = client.daemon().local_preference_records().await?;
+
+        client
+            .daemon()
+            .detach_service_access(peer_id, service_name.to_string())
+            .await?;
+        client
+            .daemon()
+            .restore_service_access_records_from_cached_snapshots(&stale_records)
+            .await;
+
+        assert!(
+            client
+                .daemon()
+                .get_service_access_forwarding_rules()
+                .is_empty()
+        );
+        assert_eq!(
+            client
+                .daemon()
+                .list_service_accesses(Some(peer_id))
+                .await?
+                .len(),
+            1
+        );
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                None,
+            )
+            .await?;
+        assert_eq!(
+            client.daemon().get_service_access_forwarding_rules().len(),
+            1
+        );
         Ok(())
     }
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -253,7 +253,6 @@ impl FungiDaemon {
         };
 
         daemon.restore_service_endpoint_listeners().await?;
-        daemon.restore_saved_service_access_from_snapshots().await;
 
         Ok(daemon)
     }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -45,6 +45,7 @@ pub struct FungiDaemon {
     trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
     direct_address_cache: Arc<Mutex<DirectAddressCache>>,
     local_preferences_lock: Arc<AsyncMutex<()>>,
+    detached_service_accesses: Mutex<BTreeSet<(String, String)>>,
     args: DaemonArgs,
 
     swarm_control: SwarmControl,
@@ -74,6 +75,30 @@ impl FungiDaemon {
 
     pub(crate) fn local_preferences_lock(&self) -> Arc<AsyncMutex<()>> {
         self.local_preferences_lock.clone()
+    }
+
+    pub(crate) fn service_access_is_detached(&self, peer_id: &str, service_name: &str) -> bool {
+        self.detached_service_accesses
+            .lock()
+            .contains(&(peer_id.to_string(), service_name.to_string()))
+    }
+
+    pub(crate) fn mark_service_access_detached(&self, peer_id: &str, service_name: &str) {
+        self.detached_service_accesses
+            .lock()
+            .insert((peer_id.to_string(), service_name.to_string()));
+    }
+
+    pub(crate) fn clear_service_access_detached(&self, peer_id: &str, service_name: &str) {
+        self.detached_service_accesses
+            .lock()
+            .remove(&(peer_id.to_string(), service_name.to_string()));
+    }
+
+    pub(crate) fn clear_device_service_access_detached(&self, peer_id: &str) {
+        self.detached_service_accesses
+            .lock()
+            .retain(|(detached_peer_id, _)| detached_peer_id != peer_id);
     }
 
     pub fn swarm_control(&self) -> &SwarmControl {
@@ -240,6 +265,7 @@ impl FungiDaemon {
             trusted_devices_config,
             direct_address_cache,
             local_preferences_lock,
+            detached_service_accesses: Mutex::new(BTreeSet::new()),
             args,
             swarm_control,
             mdns_control,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -39,6 +39,9 @@ pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,
 };
 
+pub const DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY: usize = 16;
+pub const DEVICE_SERVICE_REFRESH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 #[derive(Debug, Clone, Default, Parser)]
 pub struct DaemonArgs {
     #[clap(

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -5,10 +5,10 @@ use std::process::Command;
 use clap::{Args, Subcommand};
 use fungi_config::{FungiDir, devices::LOCAL_DEVICE_NAME, paths::FungiPaths};
 use fungi_daemon::{
-    DEFAULT_REMOTE_SERVICE_LOG_TAIL, DeviceService, DeviceServiceSnapshot,
-    MAX_REMOTE_SERVICE_LOG_TAIL, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
-    ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus, parse_service_manifest_yaml,
-    service_manifest_with_instance_name,
+    DEFAULT_REMOTE_SERVICE_LOG_TAIL, DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY, DeviceService,
+    DeviceServiceSnapshot, MAX_REMOTE_SERVICE_LOG_TAIL, RuntimeKind, ServiceAccess,
+    ServiceExposeUsageKind, ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus,
+    parse_service_manifest_yaml, service_manifest_with_instance_name,
 };
 use fungi_daemon_grpc::{
     Request,
@@ -22,6 +22,7 @@ use fungi_daemon_grpc::{
         ServiceNameRequest,
     },
 };
+use futures::{StreamExt, stream};
 use serde::Serialize;
 
 use crate::commands::CommonArgs;
@@ -1325,24 +1326,24 @@ async fn print_service_overview(client: &mut RpcClient, verbose: bool, refresh: 
     );
 
     let devices = list_saved_devices(client).await;
-    if refresh {
-        for device in devices {
-            let saved_accesses = list_accesses(client, &device.peer_id).await;
-            let snapshot = fetch_device_service_snapshot(client, &device.peer_id, true).await;
-            add_remote_service_overview_rows(
-                &mut rows,
-                &device,
-                &saved_accesses,
-                snapshot,
-                verbose,
-            );
-        }
-    } else {
-        for device in devices {
-            let accesses = list_accesses(client, &device.peer_id).await;
-            let snapshot = fetch_device_service_snapshot(client, &device.peer_id, false).await;
-            add_remote_service_overview_rows(&mut rows, &device, &accesses, snapshot, verbose);
-        }
+    let remote_devices = stream::iter(devices)
+        .map(|device| {
+            let mut access_client = client.clone();
+            let mut snapshot_client = client.clone();
+            async move {
+                let (saved_accesses, snapshot) = tokio::join!(
+                    list_accesses(&mut access_client, &device.peer_id),
+                    fetch_device_service_snapshot(&mut snapshot_client, &device.peer_id, refresh,),
+                );
+                (device, saved_accesses, snapshot)
+            }
+        })
+        .buffer_unordered(DEVICE_SERVICE_REFRESH_MAX_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+    for (device, saved_accesses, snapshot) in remote_devices {
+        add_remote_service_overview_rows(&mut rows, &device, &saved_accesses, snapshot, verbose);
     }
 
     rows.sort_by(|left, right| left.reference.cmp(&right.reference));

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 use fungi_config::FungiDir;
 use fungi_daemon::FungiDaemon;
 use fungi_daemon_grpc::start_grpc_server;
+use std::sync::Arc;
 
 use super::fungi_relay::RelayArgs;
 
@@ -49,7 +50,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     log::info!("Starting Fungi daemon...");
 
     let daemon = match FungiDaemon::start(fungi_dir.clone(), args.clone()).await {
-        Ok(daemon) => daemon,
+        Ok(daemon) => Arc::new(daemon),
         Err(error) => {
             print_startup_error("Failed to start Fungi daemon", &error);
             return Err(error);
@@ -79,7 +80,15 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     let _published_endpoint =
         fungi_config::PublishedDaemonEndpoint::publish(&fungi_dir, rpc_socket_addr)?;
     log::info!("Daemon RPC endpoint: http://{rpc_socket_addr}");
-    let server_fut = start_grpc_server(daemon, rpc_listener);
+    let server_fut = start_grpc_server(daemon.clone(), rpc_listener);
+    let service_access_restore_task = tokio::spawn({
+        let daemon = daemon.clone();
+        async move {
+            log::info!("Restoring saved service access in the background...");
+            daemon.restore_saved_service_access_from_snapshots().await;
+            log::info!("Finished restoring saved service access");
+        }
+    });
 
     let stdin_monitor = if args.exit_on_stdin_close {
         Some(tokio::spawn(stdin_monitor()))
@@ -87,16 +96,23 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
         None
     };
 
-    tokio::select! {
+    let run_result = tokio::select! {
         signal = termination_signal() => {
-            let signal = signal.context("Failed to wait for daemon termination signal")?;
-            log::info!("Received {signal}, shutting down Fungi daemon...");
+            match signal {
+                Ok(signal) => {
+                    log::info!("Received {signal}, shutting down Fungi daemon...");
+                    Ok(())
+                }
+                Err(error) => Err(error).context("Failed to wait for daemon termination signal"),
+            }
         },
         res = server_fut => {
             if let Err(error) = res {
                 print_grpc_startup_error(&rpc_listen_address, &error);
                 log::error!("Error occurred while serving: {}", error);
-                return Err(error);
+                Err(error)
+            } else {
+                Ok(())
             }
         },
         _ = async {
@@ -107,10 +123,12 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
             }
         } => {
             log::info!("Shutting down Fungi daemon...");
+            Ok(())
         },
-    }
+    };
 
-    Ok(())
+    service_access_restore_task.abort();
+    run_result
 }
 
 async fn bind_rpc_listener(listen_address: &str) -> Result<tokio::net::TcpListener> {

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -6,7 +6,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use fungi_config::FungiConfig;
+use fungi_config::{
+    FungiConfig,
+    devices::{DeviceInfo, DevicesConfig},
+    local_preferences::{LocalPortSource, LocalPreferenceCache, LocalServicePreference},
+};
 use tempfile::TempDir;
 
 struct DaemonChild {
@@ -77,6 +81,57 @@ fn daemon_publishes_dynamic_endpoint_and_enforces_one_instance_per_fungi_dir() {
     let recovered_endpoint = fungi_config::read_daemon_endpoint(home.path()).unwrap();
     assert!(recovered_endpoint.starts_with("http://127.0.0.1:"));
     recovered.stop_gracefully();
+}
+
+#[test]
+fn daemon_publishes_endpoint_before_saved_service_access_refresh_finishes() {
+    let home = TempDir::new().unwrap();
+    let swarm = reserve_port();
+    init_fungi_dir(home.path(), 0, swarm);
+
+    let blackhole = TcpListener::bind("127.0.0.1:0").unwrap();
+    let blackhole_port = blackhole.local_addr().unwrap().port();
+    thread::spawn(move || {
+        if let Ok((_stream, _)) = blackhole.accept() {
+            thread::sleep(Duration::from_secs(20));
+        }
+    });
+
+    let peer_id = libp2p::PeerId::random();
+    let mut device = DeviceInfo::new_unknown(peer_id);
+    device.name = Some("slow-device".to_string());
+    device.multiaddrs = vec![format!("/ip4/127.0.0.1/tcp/{blackhole_port}/p2p/{peer_id}")];
+    DevicesConfig::apply_from_dir(home.path())
+        .unwrap()
+        .add_or_update_device(device)
+        .unwrap();
+    LocalPreferenceCache::apply_from_dir(home.path())
+        .unwrap()
+        .upsert_record(LocalServicePreference {
+            remote_peer_id: peer_id.to_string(),
+            remote_service_name: "slow-service".to_string(),
+            remote_service_port_name: "main".to_string(),
+            local_host: "127.0.0.1".to_string(),
+            local_port: reserve_port(),
+            local_port_source: LocalPortSource::Auto,
+        })
+        .unwrap();
+
+    let daemon = start_daemon(home.path());
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(3);
+    while !fungi_config::daemon_endpoint_path(home.path()).exists() {
+        assert!(
+            Instant::now() < deadline,
+            "daemon endpoint publication waited for background service access refresh"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let output = run_cli(home.path(), ["info", "version"]);
+    assert!(!output.stdout.trim().is_empty());
+    assert!(started.elapsed() < Duration::from_secs(3));
+    daemon.stop_gracefully();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- publish the daemon RPC endpoint before restoring saved remote service access
- restore remote service snapshots in a background task with up to 16 devices refreshed concurrently
- raise the shared per-device refresh timeout from 5 seconds to 15 seconds
- make `fungi service list --refresh` issue concurrent refresh requests while reusing the daemon's shared refresh path
- re-read current access preferences before applying restored snapshots so startup does not resurrect removed entries

## Why

Daemon startup previously awaited saved service restoration before binding and publishing the local RPC endpoint. Offline or not-yet-reachable devices could therefore delay app readiness by one timeout per device. The restoration is best-effort remote state recovery and should not be part of the local daemon readiness path.

## Implementation notes

- concurrency and timeout are shared constants in `fungi-daemon`
- the batch refresh helper uses unordered buffering capped at 16
- the existing per-device gRPC API remains unchanged; no protocol regeneration is required
- the background restoration task is aborted when daemon shutdown wins the server select

## Verification

- `cargo fmt --check`
- `cargo test --workspace`
- regression test verifies the endpoint and version RPC become ready while a saved peer refresh is still hanging
- unit tests verify the concurrency ceiling and shared timeout