### PR TITLE
refactor(daemon): split lifecycle from domain controls

### DIFF
--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -8,7 +8,6 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -153,13 +152,13 @@ impl PingPeerError {
 }
 
 pub async fn start_grpc_server(
-    daemon: fungi_daemon::FungiDaemon,
+    control: fungi_daemon::FungiControl,
     listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
     tonic::transport::Server::builder()
         .add_service(
             fungi_daemon_grpc::fungi_daemon_server::FungiDaemonServer::new(
-                FungiDaemonRpcImpl::new(daemon),
+                FungiDaemonRpcImpl::new(control),
             ),
         )
         .serve_with_incoming(TcpListenerStream::new(listener))
@@ -168,14 +167,12 @@ pub async fn start_grpc_server(
 }
 
 pub struct FungiDaemonRpcImpl {
-    inner: Arc<fungi_daemon::FungiDaemon>,
+    inner: fungi_daemon::FungiControl,
 }
 
 impl FungiDaemonRpcImpl {
-    pub fn new(inner: fungi_daemon::FungiDaemon) -> Self {
-        Self {
-            inner: Arc::new(inner),
-        }
+    pub fn new(inner: fungi_daemon::FungiControl) -> Self {
+        Self { inner }
     }
 }
 

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -529,7 +529,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             )))
             .await?;
 
-            match daemon.swarm_control().connect(peer_id).await {
+            match daemon.connectivity().swarm_control().connect(peer_id).await {
                 Ok(connections) if !connections.is_empty() => {
                     tx.send(Ok(ping_event(
                         &peer_id_str,
@@ -583,6 +583,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                     let daemon = daemon.clone();
                     ping_set.spawn(async move {
                         let res = daemon
+                            .connectivity()
                             .swarm_control()
                             .ping_connection(connection_id, per_ping_timeout)
                             .await;

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -48,3 +48,4 @@ webpki-roots = { workspace = true }
 
 [dev-dependencies]
 toml = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -37,10 +37,7 @@ impl FungiControl {
     }
 
     pub fn list_trusted_devices(&self) -> Vec<DeviceInfo> {
-        let trusted_device_ids = self
-            .swarm_control()
-            .state()
-            .get_incoming_allowed_peers_list();
+        let trusted_device_ids = self.inbound_access().authorized_peers();
         let devices_config_guard = self.devices_config();
         let devices_config = devices_config_guard.lock();
 

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -29,6 +29,7 @@ impl FungiControl {
 
     pub async fn devices_remove(&self, peer_id: PeerId) -> Result<()> {
         self.devices().remove(peer_id).await?;
+        self.service_access_manager().forget_device(peer_id).await?;
         // Preserve the current CLI behavior while authorization remains a separate daemon-level
         // domain. `Devices::remove` itself intentionally does not imply this policy decision.
         self.untrust_device(peer_id)?;

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
 use fungi_config::devices::DeviceInfo;
-use fungi_swarm::PeerAddressSource;
-use libp2p::Multiaddr;
 use libp2p::PeerId;
 
 use crate::FungiDaemon;
@@ -18,40 +16,22 @@ impl FungiDaemon {
     }
 
     pub fn devices_get_all(&self) -> Vec<DeviceInfo> {
-        self.devices().lock().get_all_devices().clone()
+        self.devices().saved_device_infos()
     }
 
     pub fn devices_add_or_update(&self, device_info: DeviceInfo) -> Result<()> {
-        let current_devices_config = self.devices().lock().clone();
-        let updated_devices_config =
-            current_devices_config.add_or_update_device(device_info.clone())?;
-        *self.devices().lock() = updated_devices_config;
-        self.hydrate_device_info(&device_info);
-        Ok(())
+        self.devices().add_or_update(device_info)
     }
 
     pub fn devices_get_peer(&self, peer_id: PeerId) -> Option<DeviceInfo> {
-        self.devices().lock().get_device_info(&peer_id).cloned()
+        self.devices().get(peer_id).and_then(|device| device.info())
     }
 
     pub async fn devices_remove(&self, peer_id: PeerId) -> Result<()> {
-        let current_devices_config = self.devices().lock().clone();
-        let updated_devices_config = current_devices_config.remove_device(&peer_id)?;
-        *self.devices().lock() = updated_devices_config;
-
+        self.devices().remove(peer_id).await?;
+        // Preserve the current CLI behavior while authorization remains a separate daemon-level
+        // domain. `Devices::remove` itself intentionally does not imply this policy decision.
         self.untrust_device(peer_id)?;
-        self.remove_device_local_service_state(peer_id).await?;
-        Ok(())
-    }
-
-    async fn remove_device_local_service_state(&self, peer_id: PeerId) -> Result<()> {
-        self.forget_device_service_accesses(peer_id).await?;
-
-        let fungi_dir = self.config_fungi_dir()?;
-        let snapshots =
-            fungi_config::service_cache::DeviceServiceSnapshotCache::apply_from_dir(&fungi_dir)?;
-        let peer_id = peer_id.to_string();
-        let _ = snapshots.remove_device_snapshot(&peer_id)?;
         Ok(())
     }
 
@@ -60,7 +40,7 @@ impl FungiDaemon {
             .swarm_control()
             .state()
             .get_incoming_allowed_peers_list();
-        let devices_config_guard = self.devices();
+        let devices_config_guard = self.devices_config();
         let devices_config = devices_config_guard.lock();
 
         trusted_device_ids
@@ -72,27 +52,5 @@ impl FungiDaemon {
                 },
             )
             .collect()
-    }
-
-    fn hydrate_device_info(&self, device_info: &DeviceInfo) {
-        for address in &device_info.multiaddrs {
-            match address.parse::<Multiaddr>() {
-                Ok(multiaddr) => {
-                    self.swarm_control().state().record_peer_address(
-                        device_info.peer_id,
-                        multiaddr,
-                        PeerAddressSource::DeviceConfig,
-                    );
-                }
-                Err(error) => {
-                    log::debug!(
-                        "Ignoring invalid device multiaddr for peer {}: {} ({})",
-                        device_info.peer_id,
-                        address,
-                        error
-                    );
-                }
-            }
-        }
     }
 }

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use fungi_config::devices::DeviceInfo;
 use libp2p::PeerId;
 
-use crate::FungiDaemon;
+use crate::FungiControl;
 
-impl FungiDaemon {
+impl FungiControl {
     pub async fn mdns_get_local_devices(&self) -> Result<Vec<DeviceInfo>> {
         let local_devices = self
             .mdns_control()

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -7,6 +7,7 @@ use crate::FungiControl;
 impl FungiControl {
     pub async fn mdns_get_local_devices(&self) -> Result<Vec<DeviceInfo>> {
         let local_devices = self
+            .connectivity()
             .mdns_control()
             .get_all_devices()
             .values()
@@ -38,17 +39,15 @@ impl FungiControl {
 
     pub fn list_trusted_devices(&self) -> Vec<DeviceInfo> {
         let trusted_device_ids = self.inbound_access().authorized_peers();
-        let devices_config_guard = self.devices_config();
-        let devices_config = devices_config_guard.lock();
 
         trusted_device_ids
             .into_iter()
-            .map(
-                |peer_id| match devices_config.get_device_info(&peer_id).cloned() {
-                    Some(device_info) => device_info,
-                    None => DeviceInfo::new_unknown(peer_id),
-                },
-            )
+            .map(|peer_id| {
+                self.devices()
+                    .get(peer_id)
+                    .and_then(|device| device.info())
+                    .unwrap_or_else(|| DeviceInfo::new_unknown(peer_id))
+            })
             .collect()
     }
 }

--- a/crates/daemon/src/api/devices.rs
+++ b/crates/daemon/src/api/devices.rs
@@ -29,7 +29,7 @@ impl FungiControl {
 
     pub async fn devices_remove(&self, peer_id: PeerId) -> Result<()> {
         self.devices().remove(peer_id).await?;
-        self.service_access_manager().forget_device(peer_id).await?;
+        self.service_access().forget_device(peer_id).await?;
         // Preserve the current CLI behavior while authorization remains a separate daemon-level
         // domain. `Devices::remove` itself intentionally does not imply this policy decision.
         self.untrust_device(peer_id)?;

--- a/crates/daemon/src/api/peer.rs
+++ b/crates/daemon/src/api/peer.rs
@@ -107,30 +107,12 @@ impl FungiControl {
     }
 
     pub fn trust_device(&self, peer_id: PeerId) -> Result<()> {
-        let current_config = self.trusted_devices().lock().clone();
-        let updated_config = current_config.add_trusted_device(&peer_id)?;
-        *self.trusted_devices().lock() = updated_config;
-
-        self.swarm_control()
-            .state()
-            .incoming_allowed_peers()
-            .write()
-            .insert(peer_id);
-        Ok(())
+        self.inbound_access().authorize(peer_id)
     }
 
     pub fn untrust_device(&self, peer_id: PeerId) -> Result<()> {
-        let current_config = self.trusted_devices().lock().clone();
-        let updated_config = current_config.remove_trusted_device(&peer_id)?;
-        *self.trusted_devices().lock() = updated_config;
-
-        self.swarm_control()
-            .state()
-            .incoming_allowed_peers()
-            .write()
-            .remove(&peer_id);
         // TODO disconnect connected incoming peer
-        Ok(())
+        self.inbound_access().revoke(peer_id)
     }
 
     pub fn get_peer_connections(&self, peer_id: PeerId) -> Option<Vec<ConnectionRecord>> {

--- a/crates/daemon/src/api/peer.rs
+++ b/crates/daemon/src/api/peer.rs
@@ -24,6 +24,7 @@ impl FungiControl {
             };
 
         let active_streams_by_protocol = self
+            .connectivity()
             .swarm_control()
             .state()
             .connection_active_stream_protocol_counts(&conn.connection_id())
@@ -76,7 +77,8 @@ impl FungiControl {
     }
 
     fn is_configured_relay_peer(&self, peer_id: PeerId) -> bool {
-        self.swarm_control()
+        self.connectivity()
+            .swarm_control()
             .state()
             .list_relay_endpoint_statuses()
             .into_iter()
@@ -95,7 +97,10 @@ impl FungiControl {
     }
 
     pub fn peer_id(&self) -> String {
-        self.swarm_control().local_peer_id().to_string()
+        self.connectivity()
+            .swarm_control()
+            .local_peer_id()
+            .to_string()
     }
 
     pub fn config_file_path(&self) -> String {
@@ -116,6 +121,7 @@ impl FungiControl {
 
     pub fn get_peer_connections(&self, peer_id: PeerId) -> Option<Vec<ConnectionRecord>> {
         let connections = self
+            .connectivity()
             .swarm_control()
             .state()
             .get_connections_by_peer_id(&peer_id);
@@ -127,7 +133,8 @@ impl FungiControl {
     }
 
     pub fn list_external_address_candidates(&self) -> Vec<ExternalAddressSnapshot> {
-        self.swarm_control()
+        self.connectivity()
+            .swarm_control()
             .state()
             .list_external_address_candidates()
             .into_iter()
@@ -136,7 +143,8 @@ impl FungiControl {
     }
 
     pub fn list_relay_endpoint_statuses(&self) -> Vec<RelayEndpointStatusSnapshot> {
-        self.swarm_control()
+        self.connectivity()
+            .swarm_control()
             .state()
             .list_relay_endpoint_statuses()
             .into_iter()
@@ -145,7 +153,8 @@ impl FungiControl {
     }
 
     pub fn list_peer_addresses(&self) -> Vec<PeerAddressSnapshot> {
-        self.swarm_control()
+        self.connectivity()
+            .swarm_control()
             .state()
             .list_peer_addresses()
             .into_iter()
@@ -154,7 +163,7 @@ impl FungiControl {
     }
 
     pub fn list_connections(&self, peer_id: Option<PeerId>) -> Vec<ConnectionSnapshot> {
-        let state = self.swarm_control().state();
+        let state = self.connectivity().swarm_control().state();
 
         let mut snapshots = Vec::new();
         for pid in state.connected_peer_ids() {
@@ -181,6 +190,7 @@ impl FungiControl {
 
     pub fn list_active_streams(&self) -> Vec<ActiveStreamSnapshot> {
         let mut streams = self
+            .connectivity()
             .swarm_control()
             .state()
             .list_active_streams()
@@ -203,6 +213,7 @@ impl FungiControl {
         protocol: StreamProtocol,
     ) -> Vec<ActiveStreamSnapshot> {
         let mut streams = self
+            .connectivity()
             .swarm_control()
             .state()
             .active_streams_by_protocol(&protocol)

--- a/crates/daemon/src/api/peer.rs
+++ b/crates/daemon/src/api/peer.rs
@@ -84,7 +84,7 @@ impl FungiControl {
     }
 
     pub fn host_name(&self) -> Option<String> {
-        self.config().lock().get_hostname()
+        self.settings().hostname()
     }
 
     #[cfg(target_os = "android")]
@@ -99,8 +99,7 @@ impl FungiControl {
     }
 
     pub fn config_file_path(&self) -> String {
-        self.config()
-            .lock()
+        self.settings()
             .config_file_path()
             .to_string_lossy()
             .to_string()

--- a/crates/daemon/src/api/peer.rs
+++ b/crates/daemon/src/api/peer.rs
@@ -2,14 +2,14 @@ use anyhow::Result;
 use fungi_swarm::{ConnectionDirection, ConnectionRecord};
 use libp2p::{Multiaddr, PeerId, StreamProtocol, multiaddr::Protocol};
 
-use crate::FungiDaemon;
+use crate::FungiControl;
 
 use super::types::{
     ActiveStreamSnapshot, ConnectionSnapshot, ExternalAddressSnapshot, PeerAddressSnapshot,
     ProtocolStreamCountSnapshot, RelayEndpointStatusSnapshot,
 };
 
-impl FungiDaemon {
+impl FungiControl {
     fn build_connection_snapshot(
         &self,
         peer_id: PeerId,

--- a/crates/daemon/src/api/relay.rs
+++ b/crates/daemon/src/api/relay.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use fungi_config::EffectiveRelayAddress;
 use libp2p::Multiaddr;
 
-use crate::FungiDaemon;
+use crate::FungiControl;
 
-impl FungiDaemon {
+impl FungiControl {
     pub fn relay_enabled(&self) -> bool {
         self.config().lock().network.relay_enabled
     }

--- a/crates/daemon/src/api/relay.rs
+++ b/crates/daemon/src/api/relay.rs
@@ -6,49 +6,34 @@ use crate::FungiControl;
 
 impl FungiControl {
     pub fn relay_enabled(&self) -> bool {
-        self.config().lock().network.relay_enabled
+        self.settings().relay_enabled()
     }
 
     pub fn use_community_relays(&self) -> bool {
-        self.config().lock().network.use_community_relays
+        self.settings().use_community_relays()
     }
 
     pub fn custom_relay_addresses(&self) -> Vec<Multiaddr> {
-        self.config().lock().network.custom_relay_addresses.clone()
+        self.settings().custom_relay_addresses()
     }
 
     pub fn effective_relay_addresses(&self) -> Vec<EffectiveRelayAddress> {
-        self.config()
-            .lock()
-            .network
-            .effective_relay_addresses(&fungi_swarm::get_default_relay_addrs())
+        self.settings().effective_relay_addresses()
     }
 
     pub fn set_relay_enabled(&self, enabled: bool) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.set_relay_enabled(enabled)?;
-        *self.config().lock() = updated_config;
-        Ok(())
+        self.settings().set_relay_enabled(enabled)
     }
 
     pub fn set_use_community_relays(&self, enabled: bool) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.set_use_community_relays(enabled)?;
-        *self.config().lock() = updated_config;
-        Ok(())
+        self.settings().set_use_community_relays(enabled)
     }
 
     pub fn add_custom_relay_address(&self, address: Multiaddr) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.add_custom_relay_address(address)?;
-        *self.config().lock() = updated_config;
-        Ok(())
+        self.settings().add_custom_relay_address(address)
     }
 
     pub fn remove_custom_relay_address(&self, address: Multiaddr) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.remove_custom_relay_address(&address)?;
-        *self.config().lock() = updated_config;
-        Ok(())
+        self.settings().remove_custom_relay_address(&address)
     }
 }

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -45,22 +45,20 @@ impl DeviceServiceSnapshotSource {
 
 impl FungiControl {
     pub fn docker_enabled(&self) -> bool {
-        self.config().lock().runtime.docker_enabled()
+        self.settings().runtime().docker_enabled()
     }
 
     pub fn get_runtime_config(&self) -> RuntimeConfig {
-        self.config().lock().get_runtime_config()
+        self.settings().runtime()
     }
 
     pub fn add_runtime_allowed_host_path(&self, path: PathBuf) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.add_runtime_allowed_host_path(path)?;
+        let updated_config = self.settings().add_runtime_allowed_host_path(path)?;
         self.apply_runtime_config_update(updated_config)
     }
 
     pub fn remove_runtime_allowed_host_path(&self, path: &Path) -> Result<()> {
-        let current_config = self.config().lock().clone();
-        let updated_config = current_config.remove_runtime_allowed_host_path(path)?;
+        let updated_config = self.settings().remove_runtime_allowed_host_path(path)?;
         self.apply_runtime_config_update(updated_config)
     }
 
@@ -96,12 +94,9 @@ impl FungiControl {
     }
 
     fn fungi_home_dir(&self) -> PathBuf {
-        self.config()
-            .lock()
-            .config_file_path()
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("."))
-            .to_path_buf()
+        self.settings()
+            .fungi_dir()
+            .unwrap_or_else(|_| std::path::PathBuf::from("."))
     }
 
     fn manifest_resolution_policy(&self) -> ManifestResolutionPolicy {
@@ -109,13 +104,8 @@ impl FungiControl {
     }
 
     fn apply_runtime_config_update(&self, updated_config: fungi_config::FungiConfig) -> Result<()> {
-        if let Some(docker_control) = self.docker_control() {
-            docker_control.update_runtime_config(&updated_config.runtime)?;
-        }
-        self.runtime_control()
-            .update_allowed_host_paths(updated_config.runtime.allowed_host_paths.clone());
-        *self.config().lock() = updated_config;
-        Ok(())
+        self.services()
+            .apply_runtime_config(&updated_config.runtime)
     }
 
     pub async fn pull_service(&self, manifest: ServiceManifest) -> Result<ServiceInstance> {
@@ -356,17 +346,18 @@ impl FungiControl {
     }
 
     pub fn local_node_capabilities(&self) -> NodeCapabilities {
-        let config = self.config().lock().clone();
+        let config = self.settings().snapshot();
         build_local_node_capabilities(&config, self.runtime_control())
     }
 
     pub fn local_runtime_status(&self) -> LocalRuntimeStatus {
-        let config = self.config().lock().clone();
+        let config = self.settings().snapshot();
         build_local_runtime_status(&config, self.runtime_control())
     }
 
     pub async fn get_peer_capability_summary(&self, peer_id: PeerId) -> Result<NodeCapabilities> {
-        self.node_capabilities_control()
+        self.devices()
+            .node_capabilities()
             .discover_peer_capabilities(peer_id)
             .await
     }

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -1,16 +1,18 @@
 use std::{
-    collections::BTreeMap,
     path::{Path, PathBuf},
     time::SystemTime,
 };
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use fungi_config::runtime::Runtime as RuntimeConfig;
 use libp2p::PeerId;
 
 use crate::runtime::{
     DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceInstance, ServiceLogs,
-    ServiceLogsOptions, ServiceManifest, service_expose_endpoint_bindings,
+    ServiceLogsOptions, ServiceManifest,
+};
+use crate::service_endpoints::{
+    sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
 };
 use crate::service_state::DesiredServiceState;
 use crate::{
@@ -67,9 +69,13 @@ impl FungiDaemon {
         name: &str,
         enabled: bool,
     ) -> Result<()> {
-        let manifest = self.runtime_control().get_service_manifest(name);
-        self.sync_service_endpoint_listeners_for_manifest(manifest.as_ref(), enabled)
-            .await
+        sync_service_endpoint_listeners_by_name(
+            self.runtime_control(),
+            self.tcp_tunneling_control(),
+            name,
+            enabled,
+        )
+        .await
     }
 
     async fn sync_service_endpoint_listeners_for_manifest(
@@ -77,39 +83,12 @@ impl FungiDaemon {
         manifest: Option<&ServiceManifest>,
         enabled: bool,
     ) -> Result<()> {
-        let Some(manifest) = manifest else {
-            return Ok(());
-        };
-
-        let endpoints = service_expose_endpoint_bindings(manifest);
-        let listening_rules = self.get_service_endpoint_listening_rules();
-
-        for endpoint in endpoints {
-            let existing_rule_id = listening_rules
-                .iter()
-                .find(|(_, rule)| {
-                    rule.port == endpoint.host_port
-                        && rule.protocol.as_deref() == Some(endpoint.protocol.as_str())
-                })
-                .map(|(rule_id, _)| rule_id.clone());
-
-            if enabled {
-                if existing_rule_id.is_none() {
-                    self.tcp_tunneling_control()
-                        .add_listening_rule(fungi_config::tcp_tunneling::ListeningRule {
-                            host: "127.0.0.1".to_string(),
-                            port: endpoint.host_port,
-                            protocol: Some(endpoint.protocol),
-                        })
-                        .await?;
-                }
-            } else if let Some(rule_id) = existing_rule_id {
-                self.tcp_tunneling_control()
-                    .remove_listening_rule(&rule_id)?;
-            }
-        }
-
-        Ok(())
+        sync_service_endpoint_listeners_for_manifest(
+            self.tcp_tunneling_control(),
+            manifest,
+            enabled,
+        )
+        .await
     }
 
     pub fn supports_runtime(&self, runtime: RuntimeKind) -> bool {
@@ -184,8 +163,11 @@ impl FungiDaemon {
     }
 
     pub async fn start_service_by_name(&self, name: String) -> Result<()> {
-        self.runtime_control().start_by_name(&name).await?;
-        self.sync_service_endpoint_listeners_by_name(&name, true)
+        self.devices()
+            .local()
+            .services()
+            .service(name)
+            .start()
             .await
     }
 
@@ -196,9 +178,7 @@ impl FungiDaemon {
     }
 
     pub async fn stop_service_by_name(&self, name: String) -> Result<()> {
-        self.runtime_control().stop_by_name(&name).await?;
-        self.sync_service_endpoint_listeners_by_name(&name, false)
-            .await
+        self.devices().local().services().service(name).stop().await
     }
 
     pub async fn remove_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
@@ -209,9 +189,11 @@ impl FungiDaemon {
     }
 
     pub async fn remove_service_by_name(&self, name: String) -> Result<()> {
-        let manifest = self.runtime_control().get_service_manifest(&name);
-        self.runtime_control().remove_by_name(&name).await?;
-        self.sync_service_endpoint_listeners_for_manifest(manifest.as_ref(), false)
+        self.devices()
+            .local()
+            .services()
+            .service(name)
+            .remove()
             .await
     }
 
@@ -253,15 +235,11 @@ impl FungiDaemon {
     }
 
     pub async fn list_exposed_services(&self) -> Result<Vec<DeviceService>> {
-        self.runtime_control()
-            .list_published_device_services()
-            .await
+        self.devices().local().services().published().await
     }
 
     pub async fn list_peer_services(&self, peer_id: PeerId) -> Result<Vec<DeviceService>> {
-        self.service_discovery_control()
-            .list_peer_services(peer_id)
-            .await
+        self.devices().peer(peer_id).services().published().await
     }
 
     pub async fn list_service_recipes(&self, refresh: bool) -> Result<Vec<ServiceRecipeSummary>> {
@@ -303,67 +281,22 @@ impl FungiDaemon {
         &self,
         device_id: PeerId,
     ) -> Result<Option<DeviceServiceSnapshot>> {
-        let fungi_dir = self.config_fungi_dir()?;
-        let cache =
-            fungi_config::service_cache::DeviceServiceSnapshotCache::apply_from_dir(&fungi_dir)?;
-        let Some(snapshot_json) = cache.get_device_snapshot_json(&device_id.to_string())? else {
-            return Ok(None);
-        };
-        serde_json::from_str(&snapshot_json)
-            .map(Some)
-            .map_err(|error| {
-                anyhow::anyhow!("failed to decode cached device service snapshot: {}", error)
-            })
+        self.devices().peer(device_id).services().snapshot()
     }
 
     pub async fn refresh_device_service_snapshot(
         &self,
         device_id: PeerId,
     ) -> Result<DeviceServiceSnapshot> {
-        let managed_response = self
-            .service_control_protocol_control()
-            .list_peer_services(device_id)
-            .await;
-        let published = self.list_peer_services(device_id).await;
-
-        let managed_response = managed_response.with_context(|| {
-            format!("failed to refresh managed services for device {device_id}")
-        })?;
-        let published = published.with_context(|| {
-            format!("failed to refresh published services for device {device_id}")
-        })?;
-
-        let managed = managed_response
-            .services_json
-            .as_deref()
-            .map(serde_json::from_str::<Vec<ServiceInstance>>)
-            .transpose()
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "failed to decode managed services from device {device_id}: {error}"
-                )
-            })?
-            .unwrap_or_default();
-
-        let snapshot = merge_device_service_snapshot(device_id, managed, published);
-        self.save_device_service_snapshot(&snapshot)?;
-        Ok(snapshot)
+        self.devices().peer(device_id).services().refresh().await
     }
 
     pub fn save_device_service_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        let snapshot_json = serde_json::to_string(snapshot)?;
-        let fungi_dir = self.config_fungi_dir()?;
-        let cache =
-            fungi_config::service_cache::DeviceServiceSnapshotCache::apply_from_dir(&fungi_dir)?;
-        cache.set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
-        Ok(())
+        self.devices().save_snapshot(snapshot)
     }
 
     pub fn remove_device_service_snapshot(&self, device_id: PeerId) -> Result<bool> {
-        let fungi_dir = self.config_fungi_dir()?;
-        let cache =
-            fungi_config::service_cache::DeviceServiceSnapshotCache::apply_from_dir(&fungi_dir)?;
-        cache.remove_device_snapshot(&device_id.to_string())
+        self.devices().peer(device_id).services().remove_snapshot()
     }
 
     pub async fn get_device_service_snapshot(
@@ -420,40 +353,21 @@ impl FungiDaemon {
         }
     }
 
-    async fn refresh_or_keep_device_service_snapshot(&self, device_id: PeerId) {
-        if let Err(refresh_error) = self.refresh_device_service_snapshot(device_id).await {
-            log::warn!(
-                "Failed to refresh device service snapshot for device {device_id} after remote mutation: {refresh_error}"
-            );
-        }
-    }
-
-    fn remove_cached_device_service(&self, device_id: PeerId, name: &str) -> Result<bool> {
-        let Some(mut snapshot) = self.load_device_service_snapshot(device_id)? else {
-            return Ok(false);
-        };
-        let before = snapshot.services.len();
-        snapshot.services.retain(|service| service.name != name);
-        if snapshot.services.len() == before {
-            return Ok(false);
-        }
-
-        self.save_device_service_snapshot(&snapshot)?;
-        Ok(true)
-    }
-
     pub async fn forget_device_service(
         &self,
         device_id: PeerId,
         name: &str,
     ) -> Result<ServiceControlResponse> {
-        if !self.remove_cached_device_service(device_id, name)? {
+        if !self
+            .devices()
+            .peer(device_id)
+            .services()
+            .service(name)
+            .forget_cached_observation()
+            .await?
+        {
             anyhow::bail!("cached service not found for device: {name}");
         }
-
-        self.forget_service_access(device_id, name.to_string())
-            .await
-            .with_context(|| format!("failed to forget local access records for service {name}"))?;
         Ok(ServiceControlResponse::success_forgotten_locally(
             None,
             name.to_string(),
@@ -544,12 +458,16 @@ impl FungiDaemon {
         peer_id: PeerId,
         manifest_yaml: String,
     ) -> Result<ServiceControlResponse> {
-        let response = self
-            .service_control_protocol_control()
-            .pull_peer_service(peer_id, manifest_yaml)
+        let service = self
+            .devices()
+            .peer(peer_id)
+            .services()
+            .apply_manifest_yaml(manifest_yaml, None)
             .await?;
-        self.refresh_or_keep_device_service_snapshot(peer_id).await;
-        Ok(response)
+        Ok(ServiceControlResponse::success(
+            None,
+            service.name().to_string(),
+        ))
     }
 
     pub async fn remote_start_service(
@@ -557,25 +475,12 @@ impl FungiDaemon {
         peer_id: PeerId,
         name: String,
     ) -> Result<ServiceControlResponse> {
-        let response = self
-            .service_control_protocol_control()
-            .start_peer_service(peer_id, name.clone())
-            .await?;
-        let service_key = response
-            .service
-            .as_ref()
-            .map(|service| service.name.as_str())
-            .unwrap_or(name.as_str())
-            .to_string();
-        self.refresh_or_keep_device_service_snapshot(peer_id).await;
-        self.restore_saved_service_access(peer_id, service_key.clone())
-            .await
-            .with_context(|| {
-                format!(
-                    "remote service started, but failed to restore saved local access listeners for {service_key}"
-                )
-            })?;
-        Ok(response)
+        let service = self.devices().peer(peer_id).services().service(name);
+        service.start().await?;
+        Ok(ServiceControlResponse::success(
+            None,
+            service.name().to_string(),
+        ))
     }
 
     pub async fn remote_list_services(&self, peer_id: PeerId) -> Result<ServiceControlResponse> {
@@ -592,20 +497,12 @@ impl FungiDaemon {
         name: String,
         tail: Option<usize>,
     ) -> Result<ServiceLogs> {
-        let tail = tail
-            .unwrap_or(crate::DEFAULT_REMOTE_SERVICE_LOG_TAIL)
-            .clamp(1, crate::MAX_REMOTE_SERVICE_LOG_TAIL);
-        let response = self
-            .service_control_protocol_control()
-            .get_peer_service_logs(peer_id, name, tail)
-            .await?;
-        let text = response
-            .logs_text
-            .ok_or_else(|| anyhow::anyhow!("remote service log response did not include logs"))?;
-        Ok(ServiceLogs {
-            raw: Vec::new(),
-            text,
-        })
+        self.devices()
+            .peer(peer_id)
+            .services()
+            .service(name)
+            .logs(tail)
+            .await
     }
 
     pub async fn remote_stop_service(
@@ -613,26 +510,12 @@ impl FungiDaemon {
         peer_id: PeerId,
         name: String,
     ) -> Result<ServiceControlResponse> {
-        let response = self
-            .service_control_protocol_control()
-            .stop_peer_service(peer_id, name)
-            .await?;
-        let service_key = response
-            .service
-            .as_ref()
-            .map(|service| service.name.as_str())
-            .unwrap_or_default()
-            .to_string();
-        if !service_key.is_empty() {
-            self.detach_service_access_by_match(peer_id, &service_key)
-                .with_context(|| {
-                    format!(
-                        "remote service stopped, but failed to disconnect local access listeners for {service_key}"
-                    )
-                })?;
-        }
-        self.refresh_or_keep_device_service_snapshot(peer_id).await;
-        Ok(response)
+        let service = self.devices().peer(peer_id).services().service(name);
+        service.stop().await?;
+        Ok(ServiceControlResponse::success(
+            None,
+            service.name().to_string(),
+        ))
     }
 
     pub async fn remote_remove_service(
@@ -640,65 +523,12 @@ impl FungiDaemon {
         peer_id: PeerId,
         name: String,
     ) -> Result<ServiceControlResponse> {
-        let response = self
-            .service_control_protocol_control()
-            .remove_peer_service(peer_id, name.clone())
-            .await?;
-        let service_key = response
-            .service
-            .as_ref()
-            .map(|service| service.name.as_str())
-            .unwrap_or_default()
-            .to_string();
-        if !service_key.is_empty() {
-            self.forget_service_access(peer_id, service_key.clone())
-                .await
-                .with_context(|| {
-                    format!(
-                        "remote service removed, but failed to forget local access records for {service_key}"
-                    )
-                })?;
-        }
-        self.refresh_or_keep_device_service_snapshot(peer_id).await;
-        Ok(response)
-    }
-}
-
-fn merge_device_service_snapshot(
-    device_id: PeerId,
-    managed: Vec<ServiceInstance>,
-    published: Vec<DeviceService>,
-) -> DeviceServiceSnapshot {
-    let mut services_by_name = BTreeMap::<String, DeviceService>::new();
-
-    for service in managed {
-        services_by_name.insert(service.name.clone(), device_service_from_instance(service));
-    }
-
-    for service in published {
-        services_by_name
-            .entry(service.name.clone())
-            .and_modify(|existing| {
-                existing.metadata = service.metadata.clone();
-                existing.endpoints = service.endpoints.clone();
-            })
-            .or_insert(service);
-    }
-
-    DeviceServiceSnapshot {
-        peer_id: device_id.to_string(),
-        services: services_by_name.into_values().collect(),
-        updated_at: SystemTime::now(),
-    }
-}
-
-fn device_service_from_instance(instance: ServiceInstance) -> DeviceService {
-    DeviceService {
-        name: instance.name,
-        runtime: instance.runtime,
-        metadata: Default::default(),
-        endpoints: Vec::new(),
-        status: instance.status,
+        let service = self.devices().peer(peer_id).services().service(name);
+        service.remove().await?;
+        Ok(ServiceControlResponse::success(
+            None,
+            service.name().to_string(),
+        ))
     }
 }
 
@@ -728,6 +558,9 @@ fn runtime_status_warning(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::devices::merge_device_service_snapshot;
     use crate::test_support::TestDaemon;
     use crate::{
         DeviceServiceEndpoint, ServiceExposeUsage, ServiceExposeUsageKind, ServicePhase,

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -277,35 +277,14 @@ impl FungiControl {
         Ok(resolved)
     }
 
-    pub fn load_device_service_snapshot(
-        &self,
-        device_id: PeerId,
-    ) -> Result<Option<DeviceServiceSnapshot>> {
-        self.devices().peer(device_id).services().snapshot()
-    }
-
-    pub async fn refresh_device_service_snapshot(
-        &self,
-        device_id: PeerId,
-    ) -> Result<DeviceServiceSnapshot> {
-        self.devices().peer(device_id).services().refresh().await
-    }
-
-    pub fn save_device_service_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        self.services().save_snapshot(snapshot)
-    }
-
-    pub fn remove_device_service_snapshot(&self, device_id: PeerId) -> Result<bool> {
-        self.services().remove_snapshot(device_id)
-    }
-
     pub async fn get_device_service_snapshot(
         &self,
         device_id: PeerId,
         refresh: bool,
     ) -> Result<DeviceServiceSnapshotLookup> {
+        let device_services = self.services().for_device(device_id);
         if refresh {
-            match self.refresh_device_service_snapshot(device_id).await {
+            match device_services.refresh().await {
                 Ok(snapshot) => {
                     return Ok(DeviceServiceSnapshotLookup {
                         snapshot,
@@ -314,7 +293,7 @@ impl FungiControl {
                     });
                 }
                 Err(error) => {
-                    if let Some(snapshot) = self.load_device_service_snapshot(device_id)? {
+                    if let Some(snapshot) = device_services.snapshot()? {
                         return Ok(DeviceServiceSnapshotLookup {
                             snapshot,
                             source: DeviceServiceSnapshotSource::Cache,
@@ -334,7 +313,7 @@ impl FungiControl {
             }
         }
 
-        if let Some(snapshot) = self.load_device_service_snapshot(device_id)? {
+        if let Some(snapshot) = device_services.snapshot()? {
             Ok(DeviceServiceSnapshotLookup {
                 snapshot,
                 source: DeviceServiceSnapshotSource::Cache,
@@ -686,12 +665,7 @@ mod tests {
                 .is_some()
         );
 
-        assert!(
-            daemon
-                .daemon()
-                .remove_device_service_snapshot(peer_id)
-                .unwrap()
-        );
+        assert!(daemon.daemon().services().remove_snapshot(peer_id).unwrap());
         assert!(
             cache
                 .get_device_snapshot_json(&peer_id.to_string())

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -3,7 +3,7 @@ use std::{
     time::SystemTime,
 };
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use fungi_config::runtime::Runtime as RuntimeConfig;
 use libp2p::PeerId;
 
@@ -358,16 +358,18 @@ impl FungiControl {
         device_id: PeerId,
         name: &str,
     ) -> Result<ServiceControlResponse> {
-        if !self
+        let removed = self
             .devices()
             .peer(device_id)
             .services()
             .service(name)
-            .forget_cached_observation()
-            .await?
-        {
+            .forget_cached_observation()?;
+        if !removed {
             anyhow::bail!("cached service not found for device: {name}");
         }
+        self.service_access_manager()
+            .forget_service(device_id, name)
+            .await?;
         Ok(ServiceControlResponse::success_forgotten_locally(
             None,
             name.to_string(),
@@ -477,6 +479,14 @@ impl FungiControl {
     ) -> Result<ServiceControlResponse> {
         let service = self.devices().peer(peer_id).services().service(name);
         service.start().await?;
+        self.restore_saved_service_access(peer_id, service.name().to_string())
+            .await
+            .with_context(|| {
+                format!(
+                    "remote service started, but failed to restore saved local access listeners for {}",
+                    service.name()
+                )
+            })?;
         Ok(ServiceControlResponse::success(
             None,
             service.name().to_string(),
@@ -512,6 +522,14 @@ impl FungiControl {
     ) -> Result<ServiceControlResponse> {
         let service = self.devices().peer(peer_id).services().service(name);
         service.stop().await?;
+        self.service_access_manager()
+            .detach(peer_id, service.name())
+            .with_context(|| {
+                format!(
+                    "remote service stopped, but failed to disconnect local access listeners for {}",
+                    service.name()
+                )
+            })?;
         Ok(ServiceControlResponse::success(
             None,
             service.name().to_string(),
@@ -525,6 +543,15 @@ impl FungiControl {
     ) -> Result<ServiceControlResponse> {
         let service = self.devices().peer(peer_id).services().service(name);
         service.remove().await?;
+        self.service_access_manager()
+            .forget_service(peer_id, service.name())
+            .await
+            .with_context(|| {
+                format!(
+                    "remote service removed, but failed to forget local access records for {}",
+                    service.name()
+                )
+            })?;
         Ok(ServiceControlResponse::success(
             None,
             service.name().to_string(),

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -336,7 +336,7 @@ impl FungiControl {
         if !removed {
             anyhow::bail!("cached service not found for device: {name}");
         }
-        self.service_access_manager()
+        self.service_access()
             .forget_service(device_id, name)
             .await?;
         Ok(ServiceControlResponse::success_forgotten_locally(
@@ -492,7 +492,7 @@ impl FungiControl {
     ) -> Result<ServiceControlResponse> {
         let service = self.devices().peer(peer_id).services().service(name);
         service.stop().await?;
-        self.service_access_manager()
+        self.service_access()
             .detach(peer_id, service.name())
             .with_context(|| {
                 format!(
@@ -513,7 +513,7 @@ impl FungiControl {
     ) -> Result<ServiceControlResponse> {
         let service = self.devices().peer(peer_id).services().service(name);
         service.remove().await?;
-        self.service_access_manager()
+        self.service_access()
             .forget_service(peer_id, service.name())
             .await
             .with_context(|| {

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -68,8 +68,8 @@ impl FungiControl {
         enabled: bool,
     ) -> Result<()> {
         sync_service_endpoint_listeners_by_name(
-            self.runtime_control(),
-            self.tcp_tunneling_control(),
+            self.services().runtime(),
+            self.services().tcp_tunneling(),
             name,
             enabled,
         )
@@ -82,7 +82,7 @@ impl FungiControl {
         enabled: bool,
     ) -> Result<()> {
         sync_service_endpoint_listeners_for_manifest(
-            self.tcp_tunneling_control(),
+            self.services().tcp_tunneling(),
             manifest,
             enabled,
         )
@@ -90,7 +90,7 @@ impl FungiControl {
     }
 
     pub fn supports_runtime(&self, runtime: RuntimeKind) -> bool {
-        self.runtime_control().supports(runtime)
+        self.services().runtime().supports(runtime)
     }
 
     fn fungi_home_dir(&self) -> PathBuf {
@@ -109,7 +109,7 @@ impl FungiControl {
     }
 
     pub async fn pull_service(&self, manifest: ServiceManifest) -> Result<ServiceInstance> {
-        let applied = self.runtime_control().apply(&manifest).await?;
+        let applied = self.services().runtime().apply(&manifest).await?;
         if applied.desired_state == DesiredServiceState::Running {
             self.sync_service_endpoint_listeners_for_manifest(
                 applied.previous_manifest.as_ref(),
@@ -131,7 +131,8 @@ impl FungiControl {
         let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
         let policy = self.manifest_resolution_policy();
         let applied = self
-            .runtime_control()
+            .services()
+            .runtime()
             .apply_manifest_yaml(&manifest_yaml, &base_dir, &fungi_home, &policy)
             .await?;
         if applied.desired_state == DesiredServiceState::Running {
@@ -147,7 +148,7 @@ impl FungiControl {
     }
 
     pub async fn start_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
-        self.runtime_control().start(runtime, &name).await?;
+        self.services().runtime().start(runtime, &name).await?;
         self.sync_service_endpoint_listeners_by_name(&name, true)
             .await
     }
@@ -162,7 +163,7 @@ impl FungiControl {
     }
 
     pub async fn stop_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
-        self.runtime_control().stop(runtime, &name).await?;
+        self.services().runtime().stop(runtime, &name).await?;
         self.sync_service_endpoint_listeners_by_name(&name, false)
             .await
     }
@@ -172,8 +173,8 @@ impl FungiControl {
     }
 
     pub async fn remove_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
-        let manifest = self.runtime_control().get_service_manifest(&name);
-        self.runtime_control().remove(runtime, &name).await?;
+        let manifest = self.services().runtime().get_service_manifest(&name);
+        self.services().runtime().remove(runtime, &name).await?;
         self.sync_service_endpoint_listeners_for_manifest(manifest.as_ref(), false)
             .await
     }
@@ -192,11 +193,11 @@ impl FungiControl {
         runtime: RuntimeKind,
         name: String,
     ) -> Result<ServiceInstance> {
-        self.runtime_control().inspect(runtime, &name).await
+        self.services().runtime().inspect(runtime, &name).await
     }
 
     pub async fn inspect_service_by_name(&self, name: String) -> Result<ServiceInstance> {
-        self.runtime_control().inspect_by_name(&name).await
+        self.services().runtime().inspect_by_name(&name).await
     }
 
     pub async fn get_service_logs(
@@ -205,7 +206,8 @@ impl FungiControl {
         name: String,
         tail: Option<String>,
     ) -> Result<ServiceLogs> {
-        self.runtime_control()
+        self.services()
+            .runtime()
             .logs(runtime, &name, &ServiceLogsOptions { tail })
             .await
     }
@@ -215,13 +217,14 @@ impl FungiControl {
         name: String,
         tail: Option<String>,
     ) -> Result<ServiceLogs> {
-        self.runtime_control()
+        self.services()
+            .runtime()
             .logs_by_name(&name, &ServiceLogsOptions { tail })
             .await
     }
 
     pub async fn list_services(&self) -> Result<Vec<ServiceInstance>> {
-        self.runtime_control().list_services().await
+        self.services().runtime().list_services().await
     }
 
     pub async fn list_exposed_services(&self) -> Result<Vec<DeviceService>> {
@@ -347,12 +350,12 @@ impl FungiControl {
 
     pub fn local_node_capabilities(&self) -> NodeCapabilities {
         let config = self.settings().snapshot();
-        build_local_node_capabilities(&config, self.runtime_control())
+        build_local_node_capabilities(&config, self.services().runtime())
     }
 
     pub fn local_runtime_status(&self) -> LocalRuntimeStatus {
         let config = self.settings().snapshot();
-        build_local_runtime_status(&config, self.runtime_control())
+        build_local_runtime_status(&config, self.services().runtime())
     }
 
     pub async fn get_peer_capability_summary(&self, peer_id: PeerId) -> Result<NodeCapabilities> {

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -292,11 +292,11 @@ impl FungiControl {
     }
 
     pub fn save_device_service_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        self.devices().save_snapshot(snapshot)
+        self.services().save_snapshot(snapshot)
     }
 
     pub fn remove_device_service_snapshot(&self, device_id: PeerId) -> Result<bool> {
-        self.devices().peer(device_id).services().remove_snapshot()
+        self.services().remove_snapshot(device_id)
     }
 
     pub async fn get_device_service_snapshot(
@@ -560,7 +560,7 @@ fn runtime_status_warning(
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::devices::merge_device_service_snapshot;
+    use crate::services::merge_device_service_snapshot;
     use crate::test_support::TestDaemon;
     use crate::{
         DeviceServiceEndpoint, ServiceExposeUsage, ServiceExposeUsageKind, ServicePhase,

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -16,7 +16,7 @@ use crate::service_endpoints::{
 };
 use crate::service_state::DesiredServiceState;
 use crate::{
-    FungiDaemon, LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities,
+    FungiControl, LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities,
     ResolvedServiceRecipe, ServiceControlResponse, ServiceRecipeDetail, ServiceRecipeRuntime,
     ServiceRecipeSummary, build_local_node_capabilities, build_local_runtime_status,
 };
@@ -43,7 +43,7 @@ impl DeviceServiceSnapshotSource {
     }
 }
 
-impl FungiDaemon {
+impl FungiControl {
     pub fn docker_enabled(&self) -> bool {
         self.config().lock().runtime.docker_enabled()
     }

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -1,97 +1,23 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    net::TcpListener as StdTcpListener,
-    time::Duration,
-};
+#[cfg(test)]
+use std::{collections::BTreeMap, net::TcpListener as StdTcpListener};
 
-use anyhow::{Result, bail};
-use fungi_config::{
-    local_preferences::{LocalPortSource, LocalPreferenceCache, LocalServicePreference},
-    tcp_tunneling::ForwardingRule,
-};
+use anyhow::Result;
+use fungi_config::tcp_tunneling::ForwardingRule;
 use libp2p::PeerId;
 
-use crate::{DeviceServiceEndpoint, FungiDaemon};
+use crate::{FungiDaemon, service_access_manager::restore_saved_service_accesses};
 
-use super::types::{ServiceAccess, ServiceAccessEndpoint};
+use super::types::ServiceAccess;
 
 impl FungiDaemon {
     pub fn get_service_access_forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
-        self.tcp_tunneling_control().get_forwarding_rules()
+        self.service_access_manager().forwarding_rules()
     }
 
     pub fn get_service_endpoint_listening_rules(
         &self,
     ) -> Vec<(String, fungi_config::tcp_tunneling::ListeningRule)> {
         self.tcp_tunneling_control().get_listening_rules()
-    }
-
-    async fn start_service_access_forwarding_rule(
-        &self,
-        record: &LocalServicePreference,
-        remote_protocol: String,
-    ) -> Result<String> {
-        let rule = ForwardingRule {
-            local_host: record.local_host.clone(),
-            local_port: record.local_port,
-            remote_peer_id: record.remote_peer_id.clone(),
-            remote_protocol: Some(remote_protocol),
-            remote_port: None,
-            remote_service_id: None,
-            remote_service_name: Some(record.remote_service_name.clone()),
-            remote_service_port_name: Some(record.remote_service_port_name.clone()),
-        };
-        self.add_service_access_forwarding_rule_internal(rule).await
-    }
-
-    async fn restore_service_access_forwarding_record(
-        &self,
-        record: &LocalServicePreference,
-        endpoint: &DeviceServiceEndpoint,
-    ) -> Result<()> {
-        let existing_active_rule = find_active_rule(
-            &self.get_service_access_forwarding_rules(),
-            &record.remote_peer_id,
-            &record.remote_service_name,
-            &record.remote_service_port_name,
-        );
-
-        let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
-            rule.local_host == record.local_host
-                && rule.local_port == record.local_port
-                && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
-        });
-        if active_rule_matches {
-            return Ok(());
-        }
-
-        let mut removed_active_rule = None;
-        if let Some((rule_id, rule)) = existing_active_rule {
-            self.remove_service_access_forwarding_rule_internal(&rule_id)?;
-            removed_active_rule = Some(rule);
-        }
-
-        match self
-            .start_service_access_forwarding_rule(record, endpoint.protocol.clone())
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(error) => {
-                if let Some(rule) = removed_active_rule {
-                    self.restore_service_access_forwarding_rule(rule).await;
-                }
-                Err(error)
-            }
-        }
-    }
-
-    async fn restore_service_access_forwarding_rule(&self, rule: ForwardingRule) {
-        if let Err(error) = self.add_service_access_forwarding_rule_internal(rule).await {
-            log::warn!(
-                "Failed to restore previous service access listener after attach failure: {}",
-                error
-            );
-        }
     }
 
     pub async fn attach_service_access(
@@ -101,316 +27,28 @@ impl FungiDaemon {
         entry: Option<String>,
         local_port: Option<u16>,
     ) -> Result<ServiceAccess> {
-        let snapshot = self.get_device_service_snapshot(peer_id, true).await?;
-        if let Some(error) = snapshot.error {
-            bail!("failed to refresh remote service before attaching access: {error}");
-        }
-        let service = snapshot
-            .snapshot
-            .services
-            .into_iter()
-            .find(|service| service.name == service_name)
-            .ok_or_else(|| anyhow::anyhow!("remote service not found: {}", service_name))?;
-
-        if service.endpoints.is_empty() {
-            bail!(
-                "remote service exposes no named TCP endpoints: {}",
-                service.name
-            );
-        }
-
-        if local_port.is_some() && service.endpoints.len() > 1 && entry.is_none() {
-            bail!("choose a service entry before assigning a fixed local port");
-        }
-
-        let local_preferences_lock = self.local_preferences_lock();
-        let _local_preferences_guard = local_preferences_lock.lock().await;
-
-        let peer_id_string = peer_id.to_string();
-        let mut local_preferences = self.local_preferences()?;
-        let mut active_rules = self.get_service_access_forwarding_rules();
-        let mut reserved_local_ports = local_preferences
-            .records
-            .iter()
-            .map(|record| record.local_port)
-            .chain(active_rules.iter().map(|(_, rule)| rule.local_port))
-            .collect::<BTreeSet<_>>();
-        let mut enabled_endpoints = Vec::new();
-        let endpoints = service
-            .endpoints
-            .into_iter()
-            .filter(|endpoint| {
-                entry
-                    .as_deref()
-                    .map(|entry| endpoint.name == entry)
-                    .unwrap_or(true)
-            })
-            .collect::<Vec<_>>();
-
-        if endpoints.is_empty() {
-            let entry = entry.unwrap_or_else(|| "default".to_string());
-            bail!("remote service entry not found: {}", entry);
-        }
-
-        for endpoint in endpoints {
-            let existing_record = local_preferences
-                .find_record(&peer_id_string, &service.name, &endpoint.name)
-                .cloned();
-            let existing_active_rule = find_active_rule(
-                &active_rules,
-                &peer_id_string,
-                &service.name,
-                &endpoint.name,
-            );
-
-            if let Some(record) = &existing_record {
-                reserved_local_ports.remove(&record.local_port);
-            }
-            if let Some((_, rule)) = &existing_active_rule {
-                reserved_local_ports.remove(&rule.local_port);
-            }
-
-            let selected_local_port = match (local_port, existing_record.as_ref()) {
-                (Some(local_port), _) => local_port,
-                (None, Some(record)) => record.local_port,
-                (None, None) => allocate_free_local_port(&reserved_local_ports)?,
-            };
-            let local_port_source = if local_port.is_some() {
-                LocalPortSource::User
-            } else {
-                existing_record
-                    .as_ref()
-                    .map(|record| record.local_port_source)
-                    .unwrap_or_default()
-            };
-
-            let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
-                rule.local_host == "127.0.0.1"
-                    && rule.local_port == selected_local_port
-                    && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
-            });
-            let active_rule_owns_selected_port =
-                existing_active_rule.as_ref().is_some_and(|(_, rule)| {
-                    rule.local_host == "127.0.0.1" && rule.local_port == selected_local_port
-                });
-
-            if !active_rule_matches && !active_rule_owns_selected_port {
-                ensure_local_port_available(selected_local_port, &reserved_local_ports)?;
-            }
-
-            let record = LocalServicePreference {
-                remote_peer_id: peer_id_string.clone(),
-                remote_service_name: service.name.clone(),
-                remote_service_port_name: endpoint.name.clone(),
-                local_host: "127.0.0.1".to_string(),
-                local_port: selected_local_port,
-                local_port_source,
-            };
-
-            let updated_local_preferences =
-                local_preferences.with_upserted_record(record.clone())?;
-
-            let mut removed_active_rule = None;
-            let mut started_rule_id = None;
-            if !active_rule_matches {
-                if let Some((rule_id, rule)) = existing_active_rule {
-                    self.remove_service_access_forwarding_rule_internal(&rule_id)?;
-                    removed_active_rule = Some(rule);
-                }
-
-                match self
-                    .start_service_access_forwarding_rule(&record, endpoint.protocol.clone())
-                    .await
-                {
-                    Ok(rule_id) => started_rule_id = Some(rule_id),
-                    Err(error) => {
-                        if let Some(rule) = removed_active_rule {
-                            self.restore_service_access_forwarding_rule(rule).await;
-                        }
-                        return Err(error);
-                    }
-                }
-            }
-
-            if let Err(error) = updated_local_preferences.save_to_file() {
-                if let Some(rule_id) = started_rule_id
-                    && let Err(rollback_error) =
-                        self.remove_service_access_forwarding_rule_internal(&rule_id)
-                {
-                    log::warn!(
-                        "Failed to roll back service access listener after save failure: {}",
-                        rollback_error
-                    );
-                }
-                if let Some(rule) = removed_active_rule {
-                    self.restore_service_access_forwarding_rule(rule).await;
-                }
-                return Err(error);
-            }
-
-            local_preferences = updated_local_preferences;
-
-            if !active_rule_matches {
-                active_rules = self.get_service_access_forwarding_rules();
-            }
-
-            reserved_local_ports.insert(selected_local_port);
-            enabled_endpoints.push(ServiceAccessEndpoint {
-                name: endpoint.name,
-                protocol: endpoint.protocol,
-                local_host: record.local_host,
-                local_port: record.local_port,
-            });
-        }
-
-        enabled_endpoints.sort_by(|left, right| left.name.cmp(&right.name));
-        Ok(ServiceAccess {
-            peer_id: peer_id_string,
-            service_name: service.name,
-            endpoints: enabled_endpoints,
-        })
+        self.devices()
+            .peer(peer_id)
+            .services()
+            .service(service_name)
+            .attach_access(entry, local_port)
+            .await
     }
 
     pub async fn restore_saved_service_access_from_snapshots(&self) {
-        let records = match self.local_preference_records().await {
-            Ok(records) => records,
-            Err(error) => {
-                log::warn!("Failed to read local service access preferences: {}", error);
-                return;
-            }
-        };
-
-        if records.is_empty() {
-            return;
-        }
-
-        self.restore_service_access_records_from_cached_snapshots(&records)
-            .await;
-
-        let mut peer_ids = BTreeSet::new();
-        for record in &records {
-            match record.remote_peer_id.parse::<PeerId>() {
-                Ok(peer_id) => {
-                    peer_ids.insert(peer_id);
-                }
-                Err(error) => {
-                    log::warn!(
-                        "Skipping service access restore for invalid peer id '{}': {}",
-                        record.remote_peer_id,
-                        error
-                    );
-                }
-            }
-        }
-
-        for peer_id in peer_ids {
-            match tokio::time::timeout(
-                Duration::from_secs(5),
-                self.refresh_device_service_snapshot(peer_id),
-            )
-            .await
-            {
-                Ok(Ok(_)) => {}
-                Ok(Err(error)) => {
-                    log::warn!(
-                        "Failed to refresh device service snapshot during startup restore for {}: {}",
-                        peer_id,
-                        error
-                    );
-                }
-                Err(_) => {
-                    log::warn!(
-                        "Timed out refreshing device service snapshot during startup restore for {}",
-                        peer_id
-                    );
-                }
-            }
-        }
-
-        self.restore_service_access_records_from_cached_snapshots(&records)
-            .await;
-    }
-
-    async fn local_preference_records(&self) -> Result<Vec<LocalServicePreference>> {
-        let local_preferences_lock = self.local_preferences_lock();
-        let _local_preferences_guard = local_preferences_lock.lock().await;
-        Ok(self.local_preferences()?.records)
-    }
-
-    async fn restore_service_access_records_from_cached_snapshots(
-        &self,
-        records: &[LocalServicePreference],
-    ) {
-        for record in records {
-            let peer_id = match record.remote_peer_id.parse::<PeerId>() {
-                Ok(peer_id) => peer_id,
-                Err(_) => continue,
-            };
-            let snapshot = match self.load_device_service_snapshot(peer_id) {
-                Ok(Some(snapshot)) => snapshot,
-                Ok(None) => {
-                    log::debug!(
-                        "No cached device service snapshot for {}; skipping service access restore",
-                        record.remote_peer_id
-                    );
-                    continue;
-                }
-                Err(error) => {
-                    log::warn!(
-                        "Failed to load cached device service snapshot for {}: {}",
-                        record.remote_peer_id,
-                        error
-                    );
-                    continue;
-                }
-            };
-
-            let Some(service) = snapshot
-                .services
-                .iter()
-                .find(|service| service.name == record.remote_service_name)
-            else {
-                log::warn!(
-                    "Cached device service snapshot for {} does not include service {}; skipping service access restore",
-                    record.remote_peer_id,
-                    record.remote_service_name
-                );
-                continue;
-            };
-
-            let Some(endpoint) = service
-                .endpoints
-                .iter()
-                .find(|endpoint| endpoint.name == record.remote_service_port_name)
-            else {
-                log::warn!(
-                    "Cached device service snapshot for {} service {} does not include entry {}; skipping service access restore",
-                    record.remote_peer_id,
-                    record.remote_service_name,
-                    record.remote_service_port_name
-                );
-                continue;
-            };
-
-            if let Err(error) = self
-                .restore_service_access_forwarding_record(record, endpoint)
-                .await
-            {
-                log::warn!(
-                    "Failed to restore local listener for {}@{} entry {} on {}:{}: {}",
-                    record.remote_service_name,
-                    record.remote_peer_id,
-                    record.remote_service_port_name,
-                    record.local_host,
-                    record.local_port,
-                    error
-                );
-            }
-        }
+        restore_saved_service_accesses(
+            self.service_access_manager().clone(),
+            self.devices().clone(),
+        )
+        .await;
     }
 
     pub fn detach_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.detach_service_access_by_match(peer_id, &service_name)
+        self.devices()
+            .peer(peer_id)
+            .services()
+            .service(service_name)
+            .detach_access()
     }
 
     pub async fn restore_saved_service_access(
@@ -418,174 +56,48 @@ impl FungiDaemon {
         peer_id: PeerId,
         service_name: String,
     ) -> Result<()> {
-        let peer_id_string = peer_id.to_string();
-        let saved_entries = {
-            let local_preferences_lock = self.local_preferences_lock();
-            let _local_preferences_guard = local_preferences_lock.lock().await;
-            self.local_preferences()?
-                .records
-                .into_iter()
-                .filter(|record| {
-                    record.remote_peer_id == peer_id_string
-                        && record.remote_service_name == service_name
-                })
-                .map(|record| record.remote_service_port_name)
-                .collect::<BTreeSet<_>>()
-        };
-
+        let saved_entries = self
+            .service_access_manager()
+            .saved_entries(peer_id, &service_name)
+            .await?;
         for entry in saved_entries {
-            self.attach_service_access(peer_id, service_name.clone(), Some(entry), None)
+            self.devices()
+                .peer(peer_id)
+                .services()
+                .service(service_name.clone())
+                .attach_access(Some(entry), None)
                 .await?;
         }
-
         Ok(())
     }
 
     pub fn detach_service_access_by_match(&self, peer_id: PeerId, matcher: &str) -> Result<()> {
-        let peer_id_string = peer_id.to_string();
-        let rules_to_remove = self
-            .get_service_access_forwarding_rules()
-            .into_iter()
-            .filter(|(_, rule)| {
-                rule.remote_peer_id == peer_id_string
-                    && rule.remote_service_name.as_deref() == Some(matcher)
-            })
-            .map(|(rule_id, _)| rule_id)
-            .collect::<Vec<_>>();
-
-        for rule_id in rules_to_remove {
-            self.remove_service_access_forwarding_rule_internal(&rule_id)?;
-        }
-
-        Ok(())
+        self.devices()
+            .peer(peer_id)
+            .services()
+            .service(matcher)
+            .detach_access()
     }
 
     pub async fn forget_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        let local_preferences_lock = self.local_preferences_lock();
-        let _local_preferences_guard = local_preferences_lock.lock().await;
-
-        self.detach_service_access_by_match(peer_id, &service_name)?;
-        let peer_id_string = peer_id.to_string();
-        self.local_preferences()?
-            .remove_service_records(&peer_id_string, &service_name)?;
-        Ok(())
+        self.devices()
+            .peer(peer_id)
+            .services()
+            .service(service_name)
+            .forget_access()
+            .await
     }
 
     pub async fn forget_device_service_accesses(&self, peer_id: PeerId) -> Result<()> {
-        let local_preferences_lock = self.local_preferences_lock();
-        let _local_preferences_guard = local_preferences_lock.lock().await;
-
-        let peer_id_string = peer_id.to_string();
-        let rules_to_remove = self
-            .get_service_access_forwarding_rules()
-            .into_iter()
-            .filter(|(_, rule)| rule.remote_peer_id == peer_id_string)
-            .map(|(rule_id, _)| rule_id)
-            .collect::<Vec<_>>();
-
-        for rule_id in rules_to_remove {
-            self.remove_service_access_forwarding_rule_internal(&rule_id)?;
-        }
-
-        self.local_preferences()?
-            .remove_device_records(&peer_id_string)?;
-        Ok(())
+        self.service_access_manager().forget_device(peer_id).await
     }
 
     pub async fn list_service_accesses(
         &self,
         peer_id: Option<PeerId>,
     ) -> Result<Vec<ServiceAccess>> {
-        let local_preferences_lock = self.local_preferences_lock();
-        let _local_preferences_guard = local_preferences_lock.lock().await;
-
-        let peer_filter = peer_id.map(|peer_id| peer_id.to_string());
-        let mut grouped = BTreeMap::<(String, String), Vec<ServiceAccessEndpoint>>::new();
-
-        for record in self.local_preferences()?.records {
-            if let Some(peer_filter) = &peer_filter
-                && &record.remote_peer_id != peer_filter
-            {
-                continue;
-            }
-
-            grouped
-                .entry((
-                    record.remote_peer_id.clone(),
-                    record.remote_service_name.clone(),
-                ))
-                .or_default()
-                .push(ServiceAccessEndpoint {
-                    name: record.remote_service_port_name,
-                    protocol: String::new(),
-                    local_host: record.local_host,
-                    local_port: record.local_port,
-                });
-        }
-
-        let mut services = grouped
-            .into_iter()
-            .map(|((peer_id, service_name), mut endpoints)| {
-                endpoints.sort_by(|left, right| left.name.cmp(&right.name));
-                ServiceAccess {
-                    peer_id,
-                    service_name,
-                    endpoints,
-                }
-            })
-            .collect::<Vec<_>>();
-        services.sort_by(|left, right| {
-            left.peer_id
-                .cmp(&right.peer_id)
-                .then(left.service_name.cmp(&right.service_name))
-        });
-        Ok(services)
+        self.service_access_manager().list(peer_id).await
     }
-
-    fn local_preferences(&self) -> Result<LocalPreferenceCache> {
-        let fungi_dir = self.config_fungi_dir()?;
-        LocalPreferenceCache::apply_from_dir(&fungi_dir)
-    }
-}
-
-fn find_active_rule(
-    active_rules: &[(String, ForwardingRule)],
-    remote_peer_id: &str,
-    remote_service_name: &str,
-    remote_service_port_name: &str,
-) -> Option<(String, ForwardingRule)> {
-    active_rules
-        .iter()
-        .find(|(_, rule)| {
-            rule.remote_peer_id == remote_peer_id
-                && rule.remote_service_name.as_deref() == Some(remote_service_name)
-                && rule.remote_service_port_name.as_deref() == Some(remote_service_port_name)
-        })
-        .cloned()
-}
-
-fn ensure_local_port_available(port: u16, reserved_ports: &BTreeSet<u16>) -> Result<()> {
-    if reserved_ports.contains(&port) {
-        bail!(
-            "local port is already reserved by another service access: {}",
-            port
-        );
-    }
-    StdTcpListener::bind(("127.0.0.1", port))
-        .map(|_| ())
-        .map_err(|error| anyhow::anyhow!("local port {} is not available: {}", port, error))
-}
-
-fn allocate_free_local_port(reserved_ports: &BTreeSet<u16>) -> Result<u16> {
-    for _ in 0..32 {
-        let listener = StdTcpListener::bind(("127.0.0.1", 0))?;
-        let port = listener.local_addr()?.port();
-        if !reserved_ports.contains(&port) {
-            return Ok(port);
-        }
-    }
-
-    bail!("failed to allocate a free local TCP port for remote service access")
 }
 
 #[cfg(test)]
@@ -663,6 +175,170 @@ mod tests {
             .filter(|access| access.service_name == service_name)
             .count();
         assert!(saved_count <= 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_does_not_recreate_forgotten_listener() -> Result<()> {
+        let service_name = "forgotten-restore";
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                None,
+            )
+            .await?;
+        let stale_records = client
+            .daemon()
+            .service_access_manager()
+            .preference_records()
+            .await?;
+
+        client
+            .daemon()
+            .forget_service_access(peer_id, service_name.to_string())
+            .await?;
+        client
+            .daemon()
+            .service_access_manager()
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .await;
+
+        assert!(
+            client
+                .daemon()
+                .get_service_access_forwarding_rules()
+                .is_empty()
+        );
+        assert!(
+            client
+                .daemon()
+                .list_service_accesses(Some(peer_id))
+                .await?
+                .is_empty()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_preserves_reattached_listener() -> Result<()> {
+        let service_name = "reattached-restore";
+        let first_local_port = free_tcp_port()?;
+        let mut second_local_port = free_tcp_port()?;
+        while second_local_port == first_local_port {
+            second_local_port = free_tcp_port()?;
+        }
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(first_local_port),
+            )
+            .await?;
+        let stale_records = client
+            .daemon()
+            .service_access_manager()
+            .preference_records()
+            .await?;
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(second_local_port),
+            )
+            .await?;
+        client
+            .daemon()
+            .service_access_manager()
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .await;
+
+        let active_ports = client
+            .daemon()
+            .get_service_access_forwarding_rules()
+            .into_iter()
+            .filter(|(_, rule)| rule.remote_service_name.as_deref() == Some(service_name))
+            .map(|(_, rule)| rule.local_port)
+            .collect::<Vec<_>>();
+        assert_eq!(active_ports, vec![second_local_port]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_restore_preserves_explicit_detach_until_reattach() -> Result<()> {
+        let service_name = "detached-restore";
+        let local_port = free_tcp_port()?;
+        let (client, server) =
+            setup_access_test_pair(service_name, vec![("main", free_tcp_port()?)]).await?;
+        let peer_id = server.peer_id();
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                Some(local_port),
+            )
+            .await?;
+        let stale_records = client
+            .daemon()
+            .service_access_manager()
+            .preference_records()
+            .await?;
+
+        client
+            .daemon()
+            .detach_service_access(peer_id, service_name.to_string())?;
+        client
+            .daemon()
+            .service_access_manager()
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .await;
+
+        assert!(
+            client
+                .daemon()
+                .get_service_access_forwarding_rules()
+                .is_empty()
+        );
+        assert_eq!(
+            client
+                .daemon()
+                .list_service_accesses(Some(peer_id))
+                .await?
+                .len(),
+            1
+        );
+
+        client
+            .daemon()
+            .attach_service_access(
+                peer_id,
+                service_name.to_string(),
+                Some("main".to_string()),
+                None,
+            )
+            .await?;
+        assert_eq!(
+            client.daemon().get_service_access_forwarding_rules().len(),
+            1
+        );
         Ok(())
     }
 

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -17,7 +17,7 @@ impl FungiControl {
     pub fn get_service_endpoint_listening_rules(
         &self,
     ) -> Vec<(String, fungi_config::tcp_tunneling::ListeningRule)> {
-        self.tcp_tunneling_control().get_listening_rules()
+        self.services().tcp_tunneling().get_listening_rules()
     }
 
     pub async fn attach_service_access(

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -38,7 +38,7 @@ impl FungiControl {
     pub async fn restore_saved_service_access_from_snapshots(&self) {
         restore_saved_service_accesses(
             self.service_access_manager().clone(),
-            self.devices().clone(),
+            self.services().clone(),
         )
         .await;
     }
@@ -207,7 +207,7 @@ mod tests {
         client
             .daemon()
             .service_access_manager()
-            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 
         assert!(
@@ -265,7 +265,7 @@ mod tests {
         client
             .daemon()
             .service_access_manager()
-            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 
         let active_ports = client
@@ -308,7 +308,7 @@ mod tests {
         client
             .daemon()
             .service_access_manager()
-            .restore_records_from_cached_snapshots(&stale_records, client.daemon().devices())
+            .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 
         assert!(

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -5,11 +5,11 @@ use anyhow::Result;
 use fungi_config::tcp_tunneling::ForwardingRule;
 use libp2p::PeerId;
 
-use crate::{FungiDaemon, service_access_manager::restore_saved_service_accesses};
+use crate::{FungiControl, service_access_manager::restore_saved_service_accesses};
 
 use super::types::ServiceAccess;
 
-impl FungiDaemon {
+impl FungiControl {
     pub fn get_service_access_forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
         self.service_access_manager().forwarding_rules()
     }

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -27,11 +27,21 @@ impl FungiControl {
         entry: Option<String>,
         local_port: Option<u16>,
     ) -> Result<ServiceAccess> {
-        self.devices()
-            .peer(peer_id)
+        anyhow::ensure!(
+            peer_id != self.devices().local().id(),
+            "local services do not use remote service access listeners"
+        );
+        let service = self
             .services()
+            .for_device(peer_id)
             .service(service_name)
-            .attach_access(entry, local_port)
+            .inspect()
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
+            })?;
+        self.service_access_manager()
+            .attach(peer_id, service, entry, local_port)
             .await
     }
 
@@ -44,11 +54,7 @@ impl FungiControl {
     }
 
     pub fn detach_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.devices()
-            .peer(peer_id)
-            .services()
-            .service(service_name)
-            .detach_access()
+        self.service_access_manager().detach(peer_id, &service_name)
     }
 
     pub async fn restore_saved_service_access(
@@ -60,31 +66,30 @@ impl FungiControl {
             .service_access_manager()
             .saved_entries(peer_id, &service_name)
             .await?;
+        if saved_entries.is_empty() {
+            return Ok(());
+        }
+        let service = self
+            .services()
+            .for_device(peer_id)
+            .service(service_name)
+            .inspect()
+            .await?;
         for entry in saved_entries {
-            self.devices()
-                .peer(peer_id)
-                .services()
-                .service(service_name.clone())
-                .attach_access(Some(entry), None)
+            self.service_access_manager()
+                .attach(peer_id, service.clone(), Some(entry), None)
                 .await?;
         }
         Ok(())
     }
 
     pub fn detach_service_access_by_match(&self, peer_id: PeerId, matcher: &str) -> Result<()> {
-        self.devices()
-            .peer(peer_id)
-            .services()
-            .service(matcher)
-            .detach_access()
+        self.service_access_manager().detach(peer_id, matcher)
     }
 
     pub async fn forget_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.devices()
-            .peer(peer_id)
-            .services()
-            .service(service_name)
-            .forget_access()
+        self.service_access_manager()
+            .forget_service(peer_id, &service_name)
             .await
     }
 

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -5,13 +5,13 @@ use anyhow::Result;
 use fungi_config::tcp_tunneling::ForwardingRule;
 use libp2p::PeerId;
 
-use crate::{FungiControl, service_access_manager::restore_saved_service_accesses};
+use crate::{FungiControl, service_accesses::restore_saved_service_accesses};
 
 use super::types::ServiceAccess;
 
 impl FungiControl {
     pub fn get_service_access_forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
-        self.service_access_manager().forwarding_rules()
+        self.service_access().forwarding_rules()
     }
 
     pub fn get_service_endpoint_listening_rules(
@@ -40,21 +40,18 @@ impl FungiControl {
             .map_err(|error| {
                 anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
             })?;
-        self.service_access_manager()
+        self.service_access()
             .attach(peer_id, service, entry, local_port)
             .await
     }
 
     pub async fn restore_saved_service_access_from_snapshots(&self) {
-        restore_saved_service_accesses(
-            self.service_access_manager().clone(),
-            self.services().clone(),
-        )
-        .await;
+        restore_saved_service_accesses(self.service_access().clone(), self.services().clone())
+            .await;
     }
 
     pub fn detach_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.service_access_manager().detach(peer_id, &service_name)
+        self.service_access().detach(peer_id, &service_name)
     }
 
     pub async fn restore_saved_service_access(
@@ -63,7 +60,7 @@ impl FungiControl {
         service_name: String,
     ) -> Result<()> {
         let saved_entries = self
-            .service_access_manager()
+            .service_access()
             .saved_entries(peer_id, &service_name)
             .await?;
         if saved_entries.is_empty() {
@@ -76,7 +73,7 @@ impl FungiControl {
             .inspect()
             .await?;
         for entry in saved_entries {
-            self.service_access_manager()
+            self.service_access()
                 .attach(peer_id, service.clone(), Some(entry), None)
                 .await?;
         }
@@ -84,24 +81,24 @@ impl FungiControl {
     }
 
     pub fn detach_service_access_by_match(&self, peer_id: PeerId, matcher: &str) -> Result<()> {
-        self.service_access_manager().detach(peer_id, matcher)
+        self.service_access().detach(peer_id, matcher)
     }
 
     pub async fn forget_service_access(&self, peer_id: PeerId, service_name: String) -> Result<()> {
-        self.service_access_manager()
+        self.service_access()
             .forget_service(peer_id, &service_name)
             .await
     }
 
     pub async fn forget_device_service_accesses(&self, peer_id: PeerId) -> Result<()> {
-        self.service_access_manager().forget_device(peer_id).await
+        self.service_access().forget_device(peer_id).await
     }
 
     pub async fn list_service_accesses(
         &self,
         peer_id: Option<PeerId>,
     ) -> Result<Vec<ServiceAccess>> {
-        self.service_access_manager().list(peer_id).await
+        self.service_access().list(peer_id).await
     }
 }
 
@@ -201,7 +198,7 @@ mod tests {
             .await?;
         let stale_records = client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .preference_records()
             .await?;
 
@@ -211,7 +208,7 @@ mod tests {
             .await?;
         client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 
@@ -254,7 +251,7 @@ mod tests {
             .await?;
         let stale_records = client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .preference_records()
             .await?;
 
@@ -269,7 +266,7 @@ mod tests {
             .await?;
         client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 
@@ -303,7 +300,7 @@ mod tests {
             .await?;
         let stale_records = client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .preference_records()
             .await?;
 
@@ -312,7 +309,7 @@ mod tests {
             .detach_service_access(peer_id, service_name.to_string())?;
         client
             .daemon()
-            .service_access_manager()
+            .service_access()
             .restore_records_from_cached_snapshots(&stale_records, client.daemon().services())
             .await;
 

--- a/crates/daemon/src/connectivity.rs
+++ b/crates/daemon/src/connectivity.rs
@@ -21,6 +21,8 @@ struct ConnectivityInner {
 }
 
 /// Shared connectivity capabilities backed by the daemon's single libp2p swarm.
+///
+/// Domain handles share this boundary instead of carrying independent low-level network controls.
 #[derive(Clone)]
 pub struct Connectivity {
     inner: Arc<ConnectivityInner>,

--- a/crates/daemon/src/connectivity.rs
+++ b/crates/daemon/src/connectivity.rs
@@ -1,0 +1,258 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use fungi_config::{devices::DeviceInfo, direct_addresses::DirectAddressCache};
+use fungi_swarm::{ConnectionDirection, PeerAddressSource, State, SwarmControl};
+use libp2p::Multiaddr;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::controls::mdns::MdnsControl;
+
+const DIRECT_ADDRESS_CACHE_SYNC_INTERVAL: Duration = Duration::from_secs(30);
+
+struct ConnectivityInner {
+    swarm: SwarmControl,
+    mdns: MdnsControl,
+    direct_address_cache: Arc<Mutex<DirectAddressCache>>,
+}
+
+/// Shared connectivity capabilities backed by the daemon's single libp2p swarm.
+#[derive(Clone)]
+pub struct Connectivity {
+    inner: Arc<ConnectivityInner>,
+}
+
+impl Connectivity {
+    pub(crate) fn new(
+        swarm: SwarmControl,
+        mdns: MdnsControl,
+        direct_address_cache: DirectAddressCache,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ConnectivityInner {
+                swarm,
+                mdns,
+                direct_address_cache: Arc::new(Mutex::new(direct_address_cache)),
+            }),
+        }
+    }
+
+    pub fn swarm_control(&self) -> &SwarmControl {
+        &self.inner.swarm
+    }
+
+    pub fn mdns_control(&self) -> &MdnsControl {
+        &self.inner.mdns
+    }
+
+    pub(crate) fn record_device_addresses(&self, device_info: &DeviceInfo) {
+        for address in &device_info.multiaddrs {
+            match address.parse::<Multiaddr>() {
+                Ok(multiaddr) => {
+                    self.inner.swarm.state().record_peer_address(
+                        device_info.peer_id,
+                        multiaddr,
+                        PeerAddressSource::DeviceConfig,
+                    );
+                }
+                Err(error) => log::debug!(
+                    "Ignoring invalid device multiaddr for peer {}: {} ({})",
+                    device_info.peer_id,
+                    address,
+                    error
+                ),
+            }
+        }
+    }
+
+    pub(crate) fn spawn_direct_address_cache_sync(&self) -> JoinHandle<()> {
+        let swarm = self.inner.swarm.clone();
+        let direct_address_cache = self.inner.direct_address_cache.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(DIRECT_ADDRESS_CACHE_SYNC_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut last_synced_pairs = BTreeSet::<(String, String)>::new();
+
+            loop {
+                interval.tick().await;
+
+                let grouped = collect_direct_connection_addresses(swarm.state());
+                let grouped = new_direct_address_successes(grouped, &mut last_synced_pairs);
+                if grouped.is_empty() {
+                    continue;
+                }
+
+                let mut current = direct_address_cache.lock().clone();
+                let mut updated_any = false;
+                for (peer_id, addresses) in grouped {
+                    match current.record_successful_addresses(peer_id, addresses) {
+                        Ok(updated) => {
+                            current = updated;
+                            updated_any = true;
+                        }
+                        Err(error) => {
+                            log::warn!("Failed to save cached direct address: {error}");
+                        }
+                    }
+                }
+
+                if updated_any {
+                    *direct_address_cache.lock() = current;
+                }
+            }
+        })
+    }
+}
+
+fn collect_direct_connection_addresses(state: &State) -> BTreeMap<String, Vec<String>> {
+    let mut grouped = BTreeMap::<String, Vec<String>>::new();
+    for peer_id in state.connected_peer_ids() {
+        for connection in state.get_connections_by_peer_id(&peer_id) {
+            if !matches!(connection.direction, ConnectionDirection::Outbound)
+                || connection.is_relay()
+            {
+                continue;
+            }
+
+            grouped
+                .entry(peer_id.to_string())
+                .or_default()
+                .push(connection.remote_addr.to_string());
+        }
+    }
+
+    normalize_direct_address_groups(grouped)
+}
+
+fn new_direct_address_successes(
+    grouped: BTreeMap<String, Vec<String>>,
+    last_synced_pairs: &mut BTreeSet<(String, String)>,
+) -> BTreeMap<String, Vec<String>> {
+    let current_pairs = direct_address_pairs(&grouped);
+    let mut new_pairs = BTreeMap::<String, Vec<String>>::new();
+
+    for (peer_id, address) in current_pairs.difference(last_synced_pairs) {
+        new_pairs
+            .entry(peer_id.clone())
+            .or_default()
+            .push(address.clone());
+    }
+
+    *last_synced_pairs = current_pairs;
+    new_pairs
+}
+
+fn direct_address_pairs(grouped: &BTreeMap<String, Vec<String>>) -> BTreeSet<(String, String)> {
+    grouped
+        .iter()
+        .flat_map(|(peer_id, addresses)| {
+            addresses
+                .iter()
+                .map(|address| (peer_id.clone(), address.clone()))
+        })
+        .collect()
+}
+
+fn normalize_direct_address_groups(
+    mut grouped: BTreeMap<String, Vec<String>>,
+) -> BTreeMap<String, Vec<String>> {
+    grouped.retain(|_, addresses| {
+        addresses.retain(|address| !address.trim().is_empty());
+        for address in addresses.iter_mut() {
+            *address = address.trim().to_string();
+        }
+        addresses.sort();
+        addresses.dedup();
+        !addresses.is_empty()
+    });
+    grouped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_direct_address_successes_only_returns_new_pairs() {
+        let mut last_synced_pairs = BTreeSet::new();
+
+        let first = new_direct_address_successes(
+            BTreeMap::from([
+                (
+                    "peer-a".to_string(),
+                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
+                ),
+                (
+                    "peer-b".to_string(),
+                    vec!["/ip4/192.168.1.8/tcp/4001".to_string()],
+                ),
+            ]),
+            &mut last_synced_pairs,
+        );
+        assert_eq!(first.len(), 2);
+
+        let second = new_direct_address_successes(
+            BTreeMap::from([
+                (
+                    "peer-a".to_string(),
+                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
+                ),
+                (
+                    "peer-b".to_string(),
+                    vec![
+                        "/ip4/192.168.1.8/tcp/4001".to_string(),
+                        "/ip4/192.168.1.9/tcp/4001".to_string(),
+                    ],
+                ),
+            ]),
+            &mut last_synced_pairs,
+        );
+        assert_eq!(
+            second,
+            BTreeMap::from([(
+                "peer-b".to_string(),
+                vec!["/ip4/192.168.1.9/tcp/4001".to_string()]
+            )])
+        );
+
+        let third = new_direct_address_successes(
+            BTreeMap::from([
+                (
+                    "peer-a".to_string(),
+                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
+                ),
+                (
+                    "peer-b".to_string(),
+                    vec![
+                        "/ip4/192.168.1.8/tcp/4001".to_string(),
+                        "/ip4/192.168.1.9/tcp/4001".to_string(),
+                    ],
+                ),
+            ]),
+            &mut last_synced_pairs,
+        );
+        assert!(third.is_empty());
+
+        let empty = new_direct_address_successes(BTreeMap::new(), &mut last_synced_pairs);
+        assert!(empty.is_empty());
+
+        let after_disconnect = new_direct_address_successes(
+            BTreeMap::from([(
+                "peer-a".to_string(),
+                vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
+            )]),
+            &mut last_synced_pairs,
+        );
+        assert_eq!(
+            after_disconnect,
+            BTreeMap::from([(
+                "peer-a".to_string(),
+                vec!["/ip4/192.168.1.7/tcp/4001".to_string()]
+            )])
+        );
+    }
+}

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -1,0 +1,131 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::Result;
+use fungi_config::{FungiConfig, devices::DevicesConfig, trusted_devices::TrustedDevicesConfig};
+use fungi_swarm::SwarmControl;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::{
+    controls::{
+        DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
+        ServiceDiscoveryControl, TcpTunnelingControl, mdns::MdnsControl,
+    },
+    devices::Devices,
+    runtime::RuntimeControl,
+    service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
+};
+
+/// Cloneable entry point for all daemon application APIs.
+///
+/// `FungiControl` owns only shared handles. The unique daemon tasks and their lifecycle remain
+/// owned by [`crate::FungiDaemon`]. The low-level fields below are transitional and will move into
+/// their corresponding domain handles as the refactor progresses.
+#[derive(Clone)]
+pub struct FungiControl {
+    config: Arc<Mutex<FungiConfig>>,
+    devices: Devices,
+    trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
+    swarm_control: SwarmControl,
+    mdns_control: MdnsControl,
+    docker_control: Option<DockerControl>,
+    node_capabilities_control: NodeCapabilitiesControl,
+}
+
+pub(crate) struct FungiControlInit {
+    pub config: Arc<Mutex<FungiConfig>>,
+    pub devices: Devices,
+    pub trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
+    pub swarm_control: SwarmControl,
+    pub mdns_control: MdnsControl,
+    pub docker_control: Option<DockerControl>,
+    pub node_capabilities_control: NodeCapabilitiesControl,
+}
+
+impl FungiControl {
+    pub(crate) fn new(init: FungiControlInit) -> Self {
+        Self {
+            config: init.config,
+            devices: init.devices,
+            trusted_devices_config: init.trusted_devices_config,
+            swarm_control: init.swarm_control,
+            mdns_control: init.mdns_control,
+            docker_control: init.docker_control,
+            node_capabilities_control: init.node_capabilities_control,
+        }
+    }
+
+    pub fn config(&self) -> Arc<Mutex<FungiConfig>> {
+        self.config.clone()
+    }
+
+    pub fn devices(&self) -> &Devices {
+        &self.devices
+    }
+
+    pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
+        self.devices.config()
+    }
+
+    pub fn trusted_devices(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
+        self.trusted_devices_config.clone()
+    }
+
+    pub fn swarm_control(&self) -> &SwarmControl {
+        &self.swarm_control
+    }
+
+    pub fn docker_control(&self) -> Option<&DockerControl> {
+        self.docker_control.as_ref()
+    }
+
+    pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
+        self.devices.tcp_tunneling()
+    }
+
+    pub(crate) fn service_access_manager(&self) -> &ServiceAccessManager {
+        self.devices.service_access()
+    }
+
+    pub fn runtime_control(&self) -> &RuntimeControl {
+        self.devices.runtime()
+    }
+
+    pub fn service_discovery_control(&self) -> &ServiceDiscoveryControl {
+        self.devices.service_discovery()
+    }
+
+    pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
+        &self.node_capabilities_control
+    }
+
+    pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
+        self.devices.service_control()
+    }
+
+    pub fn mdns_control(&self) -> &MdnsControl {
+        &self.mdns_control
+    }
+
+    /// Starts the one-shot restoration of saved remote service accesses.
+    ///
+    /// The task owns only the two domain handles it needs, not the whole control facade.
+    pub fn spawn_saved_service_access_restore(&self) -> JoinHandle<()> {
+        let service_access = self.devices.service_access().clone();
+        let devices = self.devices.clone();
+        tokio::spawn(async move {
+            log::info!("Restoring saved service access in the background...");
+            restore_saved_service_accesses(service_access, devices).await;
+            log::info!("Finished restoring saved service access");
+        })
+    }
+
+    pub fn config_fungi_dir(&self) -> Result<PathBuf> {
+        self.config
+            .lock()
+            .config_file_path()
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .ok_or_else(|| anyhow::anyhow!("config file has no parent directory"))
+    }
+}

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
-    Connectivity,
+    Connectivity, InboundAccessPolicy,
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
         ServiceDiscoveryControl, TcpTunnelingControl, mdns::MdnsControl,
@@ -29,7 +29,7 @@ pub struct FungiControl {
     devices: Devices,
     services: Services,
     service_access: ServiceAccessManager,
-    trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
+    inbound_access: InboundAccessPolicy,
     connectivity: Connectivity,
     docker_control: Option<DockerControl>,
     node_capabilities_control: NodeCapabilitiesControl,
@@ -40,7 +40,7 @@ pub(crate) struct FungiControlInit {
     pub devices: Devices,
     pub services: Services,
     pub service_access: ServiceAccessManager,
-    pub trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
+    pub inbound_access: InboundAccessPolicy,
     pub connectivity: Connectivity,
     pub docker_control: Option<DockerControl>,
     pub node_capabilities_control: NodeCapabilitiesControl,
@@ -53,7 +53,7 @@ impl FungiControl {
             devices: init.devices,
             services: init.services,
             service_access: init.service_access,
-            trusted_devices_config: init.trusted_devices_config,
+            inbound_access: init.inbound_access,
             connectivity: init.connectivity,
             docker_control: init.docker_control,
             node_capabilities_control: init.node_capabilities_control,
@@ -76,12 +76,16 @@ impl FungiControl {
         &self.connectivity
     }
 
+    pub fn inbound_access(&self) -> &InboundAccessPolicy {
+        &self.inbound_access
+    }
+
     pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
         self.devices.config()
     }
 
     pub fn trusted_devices(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
-        self.trusted_devices_config.clone()
+        self.inbound_access.trusted_peers_config()
     }
 
     pub fn swarm_control(&self) -> &SwarmControl {

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -7,15 +7,15 @@ use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
-    Connectivity, InboundAccessPolicy,
+    Connectivity, InboundAccessPolicy, Settings,
     controls::{
-        DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
-        ServiceDiscoveryControl, TcpTunnelingControl, mdns::MdnsControl,
+        NodeCapabilitiesControl, ServiceControlProtocolControl, ServiceDiscoveryControl,
+        TcpTunnelingControl, mdns::MdnsControl,
     },
-    devices::Devices,
+    devices::{DeviceHandle, Devices},
     runtime::RuntimeControl,
     service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
-    services::Services,
+    services::{ServiceHandle, ServiceKey, Services},
 };
 
 /// Cloneable entry point for all daemon application APIs.
@@ -25,51 +25,62 @@ use crate::{
 /// their corresponding domain handles as the refactor progresses.
 #[derive(Clone)]
 pub struct FungiControl {
-    config: Arc<Mutex<FungiConfig>>,
+    settings: Settings,
     devices: Devices,
     services: Services,
     service_access: ServiceAccessManager,
     inbound_access: InboundAccessPolicy,
     connectivity: Connectivity,
-    docker_control: Option<DockerControl>,
-    node_capabilities_control: NodeCapabilitiesControl,
 }
 
 pub(crate) struct FungiControlInit {
-    pub config: Arc<Mutex<FungiConfig>>,
+    pub settings: Settings,
     pub devices: Devices,
     pub services: Services,
     pub service_access: ServiceAccessManager,
     pub inbound_access: InboundAccessPolicy,
     pub connectivity: Connectivity,
-    pub docker_control: Option<DockerControl>,
-    pub node_capabilities_control: NodeCapabilitiesControl,
 }
 
 impl FungiControl {
     pub(crate) fn new(init: FungiControlInit) -> Self {
         Self {
-            config: init.config,
+            settings: init.settings,
             devices: init.devices,
             services: init.services,
             service_access: init.service_access,
             inbound_access: init.inbound_access,
             connectivity: init.connectivity,
-            docker_control: init.docker_control,
-            node_capabilities_control: init.node_capabilities_control,
         }
     }
 
+    pub fn settings(&self) -> &Settings {
+        &self.settings
+    }
+
+    /// Compatibility handle for callers that still need to inspect the complete config.
     pub fn config(&self) -> Arc<Mutex<FungiConfig>> {
-        self.config.clone()
+        self.settings.config_handle()
     }
 
     pub fn devices(&self) -> &Devices {
         &self.devices
     }
 
+    pub fn device(&self, device_id: libp2p::PeerId) -> Result<DeviceHandle> {
+        self.devices
+            .get(device_id)
+            .ok_or_else(|| anyhow::anyhow!("device is not managed: {device_id}"))
+    }
+
     pub fn services(&self) -> &Services {
         &self.services
+    }
+
+    pub fn service(&self, key: ServiceKey) -> ServiceHandle {
+        self.services
+            .for_device(key.device_id)
+            .service(key.service_name)
     }
 
     pub fn connectivity(&self) -> &Connectivity {
@@ -92,10 +103,6 @@ impl FungiControl {
         self.connectivity.swarm_control()
     }
 
-    pub fn docker_control(&self) -> Option<&DockerControl> {
-        self.docker_control.as_ref()
-    }
-
     pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
         self.services.tcp_tunneling()
     }
@@ -112,8 +119,9 @@ impl FungiControl {
         self.services.service_discovery()
     }
 
+    /// Low-level compatibility accessor used by protocol integration tests.
     pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
-        &self.node_capabilities_control
+        self.devices.node_capabilities()
     }
 
     pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
@@ -138,11 +146,6 @@ impl FungiControl {
     }
 
     pub fn config_fungi_dir(&self) -> Result<PathBuf> {
-        self.config
-            .lock()
-            .config_file_path()
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .ok_or_else(|| anyhow::anyhow!("config file has no parent directory"))
+        self.settings.fungi_dir()
     }
 }

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -14,21 +14,20 @@ use crate::{
     },
     devices::{DeviceHandle, Devices},
     runtime::RuntimeControl,
-    service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
+    service_accesses::{ServiceAccesses, restore_saved_service_accesses},
     services::{ServiceHandle, ServiceKey, Services},
 };
 
 /// Cloneable entry point for all daemon application APIs.
 ///
-/// `FungiControl` owns only shared handles. The unique daemon tasks and their lifecycle remain
-/// owned by [`crate::FungiDaemon`]. The low-level fields below are transitional and will move into
-/// their corresponding domain handles as the refactor progresses.
+/// `FungiControl` owns only shared domain handles. The unique daemon tasks and their lifecycle
+/// remain owned by [`crate::FungiDaemon`].
 #[derive(Clone)]
 pub struct FungiControl {
     settings: Settings,
     devices: Devices,
     services: Services,
-    service_access: ServiceAccessManager,
+    service_access: ServiceAccesses,
     inbound_access: InboundAccessPolicy,
     connectivity: Connectivity,
 }
@@ -37,7 +36,7 @@ pub(crate) struct FungiControlInit {
     pub settings: Settings,
     pub devices: Devices,
     pub services: Services,
-    pub service_access: ServiceAccessManager,
+    pub service_access: ServiceAccesses,
     pub inbound_access: InboundAccessPolicy,
     pub connectivity: Connectivity,
 }
@@ -107,7 +106,7 @@ impl FungiControl {
         self.services.tcp_tunneling()
     }
 
-    pub(crate) fn service_access_manager(&self) -> &ServiceAccessManager {
+    pub fn service_access(&self) -> &ServiceAccesses {
         &self.service_access
     }
 

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -1,19 +1,11 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use anyhow::Result;
-use fungi_config::{FungiConfig, devices::DevicesConfig, trusted_devices::TrustedDevicesConfig};
-use fungi_swarm::SwarmControl;
-use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
     Connectivity, InboundAccessPolicy, Settings,
-    controls::{
-        NodeCapabilitiesControl, ServiceControlProtocolControl, ServiceDiscoveryControl,
-        TcpTunnelingControl, mdns::MdnsControl,
-    },
     devices::{DeviceHandle, Devices},
-    runtime::RuntimeControl,
     service_accesses::{ServiceAccesses, restore_saved_service_accesses},
     services::{ServiceHandle, ServiceKey, Services},
 };
@@ -57,11 +49,6 @@ impl FungiControl {
         &self.settings
     }
 
-    /// Compatibility handle for callers that still need to inspect the complete config.
-    pub fn config(&self) -> Arc<Mutex<FungiConfig>> {
-        self.settings.config_handle()
-    }
-
     pub fn devices(&self) -> &Devices {
         &self.devices
     }
@@ -90,45 +77,8 @@ impl FungiControl {
         &self.inbound_access
     }
 
-    pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
-        self.devices.config()
-    }
-
-    pub fn trusted_devices(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
-        self.inbound_access.trusted_peers_config()
-    }
-
-    pub fn swarm_control(&self) -> &SwarmControl {
-        self.connectivity.swarm_control()
-    }
-
-    pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
-        self.services.tcp_tunneling()
-    }
-
     pub fn service_access(&self) -> &ServiceAccesses {
         &self.service_access
-    }
-
-    pub fn runtime_control(&self) -> &RuntimeControl {
-        self.services.runtime()
-    }
-
-    pub fn service_discovery_control(&self) -> &ServiceDiscoveryControl {
-        self.services.service_discovery()
-    }
-
-    /// Low-level compatibility accessor used by protocol integration tests.
-    pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
-        self.devices.node_capabilities()
-    }
-
-    pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
-        self.services.service_control()
-    }
-
-    pub fn mdns_control(&self) -> &MdnsControl {
-        self.connectivity.mdns_control()
     }
 
     /// Starts the one-shot restoration of saved remote service accesses.

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
+    Connectivity,
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
         ServiceDiscoveryControl, TcpTunnelingControl, mdns::MdnsControl,
@@ -29,8 +30,7 @@ pub struct FungiControl {
     services: Services,
     service_access: ServiceAccessManager,
     trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
-    swarm_control: SwarmControl,
-    mdns_control: MdnsControl,
+    connectivity: Connectivity,
     docker_control: Option<DockerControl>,
     node_capabilities_control: NodeCapabilitiesControl,
 }
@@ -41,8 +41,7 @@ pub(crate) struct FungiControlInit {
     pub services: Services,
     pub service_access: ServiceAccessManager,
     pub trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
-    pub swarm_control: SwarmControl,
-    pub mdns_control: MdnsControl,
+    pub connectivity: Connectivity,
     pub docker_control: Option<DockerControl>,
     pub node_capabilities_control: NodeCapabilitiesControl,
 }
@@ -55,8 +54,7 @@ impl FungiControl {
             services: init.services,
             service_access: init.service_access,
             trusted_devices_config: init.trusted_devices_config,
-            swarm_control: init.swarm_control,
-            mdns_control: init.mdns_control,
+            connectivity: init.connectivity,
             docker_control: init.docker_control,
             node_capabilities_control: init.node_capabilities_control,
         }
@@ -74,6 +72,10 @@ impl FungiControl {
         &self.services
     }
 
+    pub fn connectivity(&self) -> &Connectivity {
+        &self.connectivity
+    }
+
     pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
         self.devices.config()
     }
@@ -83,7 +85,7 @@ impl FungiControl {
     }
 
     pub fn swarm_control(&self) -> &SwarmControl {
-        &self.swarm_control
+        self.connectivity.swarm_control()
     }
 
     pub fn docker_control(&self) -> Option<&DockerControl> {
@@ -115,7 +117,7 @@ impl FungiControl {
     }
 
     pub fn mdns_control(&self) -> &MdnsControl {
-        &self.mdns_control
+        self.connectivity.mdns_control()
     }
 
     /// Starts the one-shot restoration of saved remote service accesses.

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -123,10 +123,10 @@ impl FungiControl {
     /// The task owns only the two domain handles it needs, not the whole control facade.
     pub fn spawn_saved_service_access_restore(&self) -> JoinHandle<()> {
         let service_access = self.service_access.clone();
-        let devices = self.devices.clone();
+        let services = self.services.clone();
         tokio::spawn(async move {
             log::info!("Restoring saved service access in the background...");
-            restore_saved_service_accesses(service_access, devices).await;
+            restore_saved_service_accesses(service_access, services).await;
             log::info!("Finished restoring saved service access");
         })
     }

--- a/crates/daemon/src/control.rs
+++ b/crates/daemon/src/control.rs
@@ -14,6 +14,7 @@ use crate::{
     devices::Devices,
     runtime::RuntimeControl,
     service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
+    services::Services,
 };
 
 /// Cloneable entry point for all daemon application APIs.
@@ -25,6 +26,8 @@ use crate::{
 pub struct FungiControl {
     config: Arc<Mutex<FungiConfig>>,
     devices: Devices,
+    services: Services,
+    service_access: ServiceAccessManager,
     trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
     swarm_control: SwarmControl,
     mdns_control: MdnsControl,
@@ -35,6 +38,8 @@ pub struct FungiControl {
 pub(crate) struct FungiControlInit {
     pub config: Arc<Mutex<FungiConfig>>,
     pub devices: Devices,
+    pub services: Services,
+    pub service_access: ServiceAccessManager,
     pub trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
     pub swarm_control: SwarmControl,
     pub mdns_control: MdnsControl,
@@ -47,6 +52,8 @@ impl FungiControl {
         Self {
             config: init.config,
             devices: init.devices,
+            services: init.services,
+            service_access: init.service_access,
             trusted_devices_config: init.trusted_devices_config,
             swarm_control: init.swarm_control,
             mdns_control: init.mdns_control,
@@ -61,6 +68,10 @@ impl FungiControl {
 
     pub fn devices(&self) -> &Devices {
         &self.devices
+    }
+
+    pub fn services(&self) -> &Services {
+        &self.services
     }
 
     pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
@@ -80,19 +91,19 @@ impl FungiControl {
     }
 
     pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
-        self.devices.tcp_tunneling()
+        self.services.tcp_tunneling()
     }
 
     pub(crate) fn service_access_manager(&self) -> &ServiceAccessManager {
-        self.devices.service_access()
+        &self.service_access
     }
 
     pub fn runtime_control(&self) -> &RuntimeControl {
-        self.devices.runtime()
+        self.services.runtime()
     }
 
     pub fn service_discovery_control(&self) -> &ServiceDiscoveryControl {
-        self.devices.service_discovery()
+        self.services.service_discovery()
     }
 
     pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
@@ -100,7 +111,7 @@ impl FungiControl {
     }
 
     pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
-        self.devices.service_control()
+        self.services.service_control()
     }
 
     pub fn mdns_control(&self) -> &MdnsControl {
@@ -111,7 +122,7 @@ impl FungiControl {
     ///
     /// The task owns only the two domain handles it needs, not the whole control facade.
     pub fn spawn_saved_service_access_restore(&self) -> JoinHandle<()> {
-        let service_access = self.devices.service_access().clone();
+        let service_access = self.service_access.clone();
         let devices = self.devices.clone();
         tokio::spawn(async move {
             log::info!("Restoring saved service access in the background...");

--- a/crates/daemon/src/controls/service_control.rs
+++ b/crates/daemon/src/controls/service_control.rs
@@ -15,7 +15,11 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::controls::TcpTunnelingControl;
 use crate::{
     ManifestResolutionPolicy, RuntimeControl, ServiceControlRequest, ServiceControlResponse,
-    ServiceManifest, service_expose_endpoint_bindings, service_state::DesiredServiceState,
+    ServiceManifest,
+    service_endpoints::{
+        sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
+    },
+    service_state::DesiredServiceState,
 };
 
 const MAX_CONTROL_FRAME_LEN: usize = 2 * 1024 * 1024;
@@ -350,9 +354,13 @@ impl ServiceControlProtocolControl {
         name: &str,
         enabled: bool,
     ) -> Result<()> {
-        let manifest = self.runtime_control.get_service_manifest(name);
-        self.sync_service_endpoint_listeners_for_manifest(manifest.as_ref(), enabled)
-            .await
+        sync_service_endpoint_listeners_by_name(
+            &self.runtime_control,
+            &self.tcp_tunneling_control,
+            name,
+            enabled,
+        )
+        .await
     }
 
     async fn sync_service_endpoint_listeners_for_manifest(
@@ -360,38 +368,8 @@ impl ServiceControlProtocolControl {
         manifest: Option<&ServiceManifest>,
         enabled: bool,
     ) -> Result<()> {
-        let Some(manifest) = manifest else {
-            return Ok(());
-        };
-
-        let endpoints = service_expose_endpoint_bindings(manifest);
-        let listening_rules = self.tcp_tunneling_control.get_listening_rules();
-
-        for endpoint in endpoints {
-            let existing_rule_id = listening_rules
-                .iter()
-                .find(|(_, rule)| {
-                    rule.port == endpoint.host_port
-                        && rule.protocol.as_deref() == Some(endpoint.protocol.as_str())
-                })
-                .map(|(rule_id, _)| rule_id.clone());
-
-            if enabled {
-                if existing_rule_id.is_none() {
-                    self.tcp_tunneling_control
-                        .add_listening_rule(fungi_config::tcp_tunneling::ListeningRule {
-                            host: "127.0.0.1".to_string(),
-                            port: endpoint.host_port,
-                            protocol: Some(endpoint.protocol),
-                        })
-                        .await?;
-                }
-            } else if let Some(rule_id) = existing_rule_id {
-                self.tcp_tunneling_control.remove_listening_rule(&rule_id)?;
-            }
-        }
-
-        Ok(())
+        sync_service_endpoint_listeners_for_manifest(&self.tcp_tunneling_control, manifest, enabled)
+            .await
     }
 }
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -178,7 +178,6 @@ impl FungiDaemon {
             service_discovery: service_discovery_control,
             service_control: service_control_protocol_control,
             tcp_tunneling: tcp_tunneling_control,
-            service_access: service_access_manager.clone(),
         });
         let devices = Devices::new(DevicesInit {
             local_device: device_info,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -28,7 +28,12 @@ use fungi_swarm::{
 use fungi_util::keypair::get_keypair_from_dir;
 use libp2p::{Multiaddr, identity::Keypair, multiaddr::Protocol};
 use parking_lot::Mutex;
-use tokio::{sync::Mutex as AsyncMutex, task::JoinHandle};
+use tokio::task::JoinHandle;
+
+use crate::{
+    devices::{Devices, DevicesInit},
+    service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
+};
 
 const DIRECT_ADDRESS_CACHE_SYNC_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -41,20 +46,15 @@ struct TaskHandles {
 #[allow(dead_code)]
 pub struct FungiDaemon {
     config: Arc<Mutex<FungiConfig>>,
-    devices_config: Arc<Mutex<DevicesConfig>>,
+    devices: Devices,
     trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
     direct_address_cache: Arc<Mutex<DirectAddressCache>>,
-    local_preferences_lock: Arc<AsyncMutex<()>>,
     args: DaemonArgs,
 
     swarm_control: SwarmControl,
     mdns_control: MdnsControl,
     docker_control: Option<DockerControl>,
-    tcp_tunneling_control: TcpTunnelingControl,
-    runtime_control: RuntimeControl,
-    service_discovery_control: ServiceDiscoveryControl,
     node_capabilities_control: NodeCapabilitiesControl,
-    service_control_protocol_control: ServiceControlProtocolControl,
 
     task_handles: TaskHandles,
 }
@@ -64,16 +64,16 @@ impl FungiDaemon {
         self.config.clone()
     }
 
-    pub fn devices(&self) -> Arc<Mutex<DevicesConfig>> {
-        self.devices_config.clone()
+    pub fn devices(&self) -> &Devices {
+        &self.devices
+    }
+
+    pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
+        self.devices.config()
     }
 
     pub fn trusted_devices(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
         self.trusted_devices_config.clone()
-    }
-
-    pub(crate) fn local_preferences_lock(&self) -> Arc<AsyncMutex<()>> {
-        self.local_preferences_lock.clone()
     }
 
     pub fn swarm_control(&self) -> &SwarmControl {
@@ -85,15 +85,19 @@ impl FungiDaemon {
     }
 
     pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
-        &self.tcp_tunneling_control
+        self.devices.tcp_tunneling()
+    }
+
+    pub(crate) fn service_access_manager(&self) -> &ServiceAccessManager {
+        self.devices.service_access()
     }
 
     pub fn runtime_control(&self) -> &RuntimeControl {
-        &self.runtime_control
+        self.devices.runtime()
     }
 
     pub fn service_discovery_control(&self) -> &ServiceDiscoveryControl {
-        &self.service_discovery_control
+        self.devices.service_discovery()
     }
 
     pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
@@ -101,7 +105,21 @@ impl FungiDaemon {
     }
 
     pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
-        &self.service_control_protocol_control
+        self.devices.service_control()
+    }
+
+    /// Starts the one-shot restoration of saved remote service accesses.
+    ///
+    /// The task owns only the two domain handles it needs, so the daemon and its RPC server do not
+    /// need an additional outer `Arc`.
+    pub fn spawn_saved_service_access_restore(&self) -> JoinHandle<()> {
+        let service_access = self.devices.service_access().clone();
+        let devices = self.devices.clone();
+        tokio::spawn(async move {
+            log::info!("Restoring saved service access in the background...");
+            restore_saved_service_accesses(service_access, devices).await;
+            log::info!("Finished restoring saved service access");
+        })
     }
 
     pub fn mdns_control(&self) -> &MdnsControl {
@@ -177,7 +195,7 @@ impl FungiDaemon {
         let mdns_control = MdnsControl::new();
         // TODO duplicate with libp2p-mdns?
         let device_info = mdns_device_info(&config, swarm_control.local_peer_id());
-        mdns_control.start(device_info, state.clone())?;
+        mdns_control.start(device_info.clone(), state.clone())?;
 
         let fungi_home = config
             .config_file_path()
@@ -216,17 +234,28 @@ impl FungiDaemon {
 
         let service_control_protocol_control = ServiceControlProtocolControl::new(
             swarm_control.clone(),
-            fungi_home,
+            fungi_home.clone(),
             runtime_control.clone(),
             tcp_tunneling_control.clone(),
         );
         service_control_protocol_control.start()?;
 
-        let devices_config = Arc::new(Mutex::new(devices_config));
+        let service_access_manager =
+            ServiceAccessManager::new(fungi_home.clone(), tcp_tunneling_control.clone());
+        let devices = Devices::new(DevicesInit {
+            local_device: device_info,
+            config: devices_config,
+            fungi_dir: fungi_home,
+            swarm_state: state,
+            runtime: runtime_control,
+            service_discovery: service_discovery_control,
+            service_control: service_control_protocol_control,
+            tcp_tunneling: tcp_tunneling_control,
+            service_access: service_access_manager,
+        });
+
         let trusted_devices_config = Arc::new(Mutex::new(trusted_devices_config));
         let direct_address_cache = Arc::new(Mutex::new(direct_address_cache));
-        let local_preferences_lock = Arc::new(AsyncMutex::new(()));
-
         let task_handles = TaskHandles {
             swarm_task,
             direct_address_cache_sync_task: spawn_direct_address_cache_sync_task(
@@ -236,24 +265,18 @@ impl FungiDaemon {
         };
         let daemon = Self {
             config: shared_config,
-            devices_config,
+            devices,
             trusted_devices_config,
             direct_address_cache,
-            local_preferences_lock,
             args,
             swarm_control,
             mdns_control,
             docker_control,
-            tcp_tunneling_control,
-            runtime_control,
-            service_discovery_control,
             node_capabilities_control,
-            service_control_protocol_control,
             task_handles,
         };
 
         daemon.restore_service_endpoint_listeners().await?;
-        daemon.restore_saved_service_access_from_snapshots().await;
 
         Ok(daemon)
     }
@@ -270,17 +293,17 @@ impl FungiDaemon {
     }
 
     async fn restore_service_endpoint_listeners(&self) -> Result<()> {
-        let mut listening_rules = self.tcp_tunneling_control.get_listening_rules();
+        let mut listening_rules = self.tcp_tunneling_control().get_listening_rules();
         let mut restored_protocols = std::collections::BTreeSet::new();
 
-        for service in self.runtime_control.list_services().await? {
+        for service in self.runtime_control().list_services().await? {
             if !service.status.is_running() {
                 continue;
             }
 
             for endpoint in service.exposed_endpoints {
                 restore_service_endpoint_listener(
-                    &self.tcp_tunneling_control,
+                    self.tcp_tunneling_control(),
                     &mut listening_rules,
                     &mut restored_protocols,
                     endpoint.host_port,
@@ -290,10 +313,10 @@ impl FungiDaemon {
             }
         }
 
-        for manifest in self.runtime_control.desired_running_service_manifests() {
+        for manifest in self.runtime_control().desired_running_service_manifests() {
             for endpoint in crate::runtime::service_expose_endpoint_bindings(&manifest) {
                 restore_service_endpoint_listener(
-                    &self.tcp_tunneling_control,
+                    self.tcp_tunneling_control(),
                     &mut listening_rules,
                     &mut restored_protocols,
                     endpoint.host_port,
@@ -306,21 +329,6 @@ impl FungiDaemon {
         Ok(())
     }
 
-    pub(crate) async fn add_service_access_forwarding_rule_internal(
-        &self,
-        rule: fungi_config::tcp_tunneling::ForwardingRule,
-    ) -> Result<String> {
-        ensure_service_access_forwarding_rule(&rule)?;
-        self.tcp_tunneling_control.add_forwarding_rule(rule).await
-    }
-
-    pub(crate) fn remove_service_access_forwarding_rule_internal(
-        &self,
-        rule_id: &str,
-    ) -> Result<()> {
-        self.tcp_tunneling_control.remove_forwarding_rule(rule_id)
-    }
-
     pub fn config_fungi_dir(&self) -> Result<PathBuf> {
         self.config
             .lock()
@@ -329,23 +337,6 @@ impl FungiDaemon {
             .map(std::path::Path::to_path_buf)
             .ok_or_else(|| anyhow::anyhow!("config file has no parent directory"))
     }
-}
-
-fn ensure_service_access_forwarding_rule(
-    rule: &fungi_config::tcp_tunneling::ForwardingRule,
-) -> Result<()> {
-    if rule
-        .remote_service_name
-        .as_deref()
-        .is_none_or(str::is_empty)
-        || rule
-            .remote_service_port_name
-            .as_deref()
-            .is_none_or(str::is_empty)
-    {
-        anyhow::bail!("service access forwarding rules require remote service metadata");
-    }
-    Ok(())
 }
 
 fn hydrate_device_addresses(state: &State, devices_config: &DevicesConfig) {

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -33,7 +33,6 @@ use crate::{
     services::{Services, ServicesInit},
 };
 
-#[allow(dead_code)]
 pub struct FungiDaemon {
     control: FungiControl,
     swarm_task: JoinHandle<()>,
@@ -196,7 +195,7 @@ impl FungiDaemon {
             connectivity,
         });
 
-        restore_service_endpoint_listeners(&control).await?;
+        restore_local_service_endpoint_listeners(&control).await?;
 
         Ok(Self {
             control,
@@ -227,18 +226,19 @@ impl Drop for FungiDaemon {
     }
 }
 
-async fn restore_service_endpoint_listeners(control: &FungiControl) -> Result<()> {
-    let mut listening_rules = control.tcp_tunneling_control().get_listening_rules();
+/// Restores listeners for services running on this device. This path performs no remote refresh.
+async fn restore_local_service_endpoint_listeners(control: &FungiControl) -> Result<()> {
+    let mut listening_rules = control.services().tcp_tunneling().get_listening_rules();
     let mut restored_protocols = std::collections::BTreeSet::new();
 
-    for service in control.runtime_control().list_services().await? {
+    for service in control.services().runtime().list_services().await? {
         if !service.status.is_running() {
             continue;
         }
 
         for endpoint in service.exposed_endpoints {
             restore_service_endpoint_listener(
-                control.tcp_tunneling_control(),
+                control.services().tcp_tunneling(),
                 &mut listening_rules,
                 &mut restored_protocols,
                 endpoint.host_port,
@@ -249,12 +249,13 @@ async fn restore_service_endpoint_listeners(control: &FungiControl) -> Result<()
     }
 
     for manifest in control
-        .runtime_control()
+        .services()
+        .runtime()
         .desired_running_service_manifests()
     {
         for endpoint in crate::runtime::service_expose_endpoint_bindings(&manifest) {
             restore_service_endpoint_listener(
-                control.tcp_tunneling_control(),
+                control.services().tcp_tunneling(),
                 &mut listening_rules,
                 &mut restored_protocols,
                 endpoint.host_port,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -33,6 +33,10 @@ use crate::{
     services::{Services, ServicesInit},
 };
 
+/// Owns the lifecycle of one running daemon instance.
+///
+/// Shared application APIs live in [`FungiControl`]; this non-cloneable root retains the unique
+/// background tasks and aborts them when dropped.
 pub struct FungiDaemon {
     control: FungiControl,
     swarm_task: Option<JoinHandle<()>>,
@@ -227,6 +231,8 @@ impl Drop for FungiDaemon {
     }
 }
 
+/// Keeps the handle in its owner while pending, then removes it after consuming the result.
+/// This remains cancellation-safe inside `tokio::select!` and prevents a second join.
 async fn await_task_once(
     task: &mut Option<JoinHandle<()>>,
 ) -> Option<std::result::Result<(), tokio::task::JoinError>> {

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -35,8 +35,8 @@ use crate::{
 
 pub struct FungiDaemon {
     control: FungiControl,
-    swarm_task: JoinHandle<()>,
-    direct_address_cache_sync_task: JoinHandle<()>,
+    swarm_task: Option<JoinHandle<()>>,
+    direct_address_cache_sync_task: Option<JoinHandle<()>>,
 }
 
 impl FungiDaemon {
@@ -199,30 +199,52 @@ impl FungiDaemon {
 
         Ok(Self {
             control,
-            swarm_task,
-            direct_address_cache_sync_task,
+            swarm_task: Some(swarm_task),
+            direct_address_cache_sync_task: Some(direct_address_cache_sync_task),
         })
     }
 
     pub async fn wait(&mut self) -> Result<()> {
-        match (&mut self.swarm_task).await {
+        let result = await_task_once(&mut self.swarm_task)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("swarm task has already been joined"))?;
+        match result {
             Ok(()) => bail!("swarm task stopped unexpectedly"),
             Err(error) => Err(anyhow::anyhow!("swarm task failed: {error}")),
         }
     }
 
     pub async fn shutdown(mut self) {
-        self.swarm_task.abort();
-        self.direct_address_cache_sync_task.abort();
-        let _ = (&mut self.swarm_task).await;
-        let _ = (&mut self.direct_address_cache_sync_task).await;
+        abort_and_join_task(&mut self.swarm_task).await;
+        abort_and_join_task(&mut self.direct_address_cache_sync_task).await;
     }
 }
 
 impl Drop for FungiDaemon {
     fn drop(&mut self) {
-        self.swarm_task.abort();
-        self.direct_address_cache_sync_task.abort();
+        abort_task(&self.swarm_task);
+        abort_task(&self.direct_address_cache_sync_task);
+    }
+}
+
+async fn await_task_once(
+    task: &mut Option<JoinHandle<()>>,
+) -> Option<std::result::Result<(), tokio::task::JoinError>> {
+    let result = task.as_mut()?.await;
+    task.take();
+    Some(result)
+}
+
+async fn abort_and_join_task(task: &mut Option<JoinHandle<()>>) {
+    if let Some(task) = task.take() {
+        task.abort();
+        let _ = task.await;
+    }
+}
+
+fn abort_task(task: &Option<JoinHandle<()>>) {
+    if let Some(task) = task {
+        task.abort();
     }
 }
 
@@ -473,4 +495,33 @@ fn apply_listen(swarm: &mut TSwarm, config: &FungiConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn completed_task_is_removed_after_its_result_is_joined() {
+        let mut task = Some(tokio::spawn(async {}));
+
+        let result = await_task_once(&mut task).await.unwrap();
+
+        assert!(result.is_ok());
+        assert!(task.is_none());
+        abort_and_join_task(&mut task).await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_task_wait_preserves_daemon_ownership() {
+        let mut task = Some(tokio::spawn(std::future::pending::<()>()));
+        let mut wait = Box::pin(await_task_once(&mut task));
+
+        assert!(futures::poll!(&mut wait).is_pending());
+        drop(wait);
+
+        assert!(task.is_some());
+        abort_and_join_task(&mut task).await;
+        assert!(task.is_none());
+    }
 }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -34,6 +34,7 @@ use tokio::task::JoinHandle;
 use crate::{
     devices::{Devices, DevicesInit},
     service_access_manager::ServiceAccessManager,
+    services::{Services, ServicesInit},
 };
 
 const DIRECT_ADDRESS_CACHE_SYNC_INTERVAL: Duration = Duration::from_secs(30);
@@ -170,16 +171,20 @@ impl FungiDaemon {
 
         let service_access_manager =
             ServiceAccessManager::new(fungi_home.clone(), tcp_tunneling_control.clone());
-        let devices = Devices::new(DevicesInit {
-            local_device: device_info,
-            config: devices_config,
+        let services = Services::new(ServicesInit {
+            local_device_id: device_info.peer_id,
             fungi_dir: fungi_home,
-            swarm_state: state,
             runtime: runtime_control,
             service_discovery: service_discovery_control,
             service_control: service_control_protocol_control,
             tcp_tunneling: tcp_tunneling_control,
-            service_access: service_access_manager,
+            service_access: service_access_manager.clone(),
+        });
+        let devices = Devices::new(DevicesInit {
+            local_device: device_info,
+            config: devices_config,
+            swarm_state: state,
+            services: services.clone(),
         });
 
         let trusted_devices_config = Arc::new(Mutex::new(trusted_devices_config));
@@ -191,6 +196,8 @@ impl FungiDaemon {
         let control = FungiControl::new(FungiControlInit {
             config: shared_config,
             devices,
+            services,
+            service_access: service_access_manager,
             trusted_devices_config,
             swarm_control,
             mdns_control,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -3,12 +3,11 @@ use std::{
     env,
     net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
-    sync::Arc,
     time::Duration,
 };
 
 use crate::{
-    Connectivity, DaemonArgs, InboundAccessPolicy,
+    Connectivity, DaemonArgs, InboundAccessPolicy, Settings,
     control::{FungiControl, FungiControlInit},
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
@@ -26,7 +25,6 @@ use fungi_config::{
 use fungi_swarm::{FungiSwarm, PeerAddressSource, State, TSwarm};
 use fungi_util::keypair::get_keypair_from_dir;
 use libp2p::{Multiaddr, identity::Keypair, multiaddr::Protocol};
-use parking_lot::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -132,7 +130,7 @@ impl FungiDaemon {
             .unwrap_or_else(|| std::path::Path::new("."))
             .to_path_buf();
         let docker_control = DockerControl::from_config(&config.runtime, &fungi_home)?;
-        let shared_config = Arc::new(Mutex::new(config.clone()));
+        let settings = Settings::new(config.clone());
         let runtime_root = config
             .config_file_path()
             .parent()
@@ -154,7 +152,7 @@ impl FungiDaemon {
         service_discovery_control.start()?;
         let node_capabilities_control = NodeCapabilitiesControl::new(
             swarm_control.clone(),
-            shared_config.clone(),
+            settings.config_handle(),
             runtime_control.clone(),
         );
         node_capabilities_control.start()?;
@@ -175,6 +173,7 @@ impl FungiDaemon {
             local_device_id: device_info.peer_id,
             fungi_dir: fungi_home,
             runtime: runtime_control,
+            docker: docker_control,
             service_discovery: service_discovery_control,
             service_control: service_control_protocol_control,
             tcp_tunneling: tcp_tunneling_control,
@@ -184,18 +183,17 @@ impl FungiDaemon {
             config: devices_config,
             connectivity: connectivity.clone(),
             services: services.clone(),
+            node_capabilities: node_capabilities_control,
         });
 
         let direct_address_cache_sync_task = connectivity.spawn_direct_address_cache_sync();
         let control = FungiControl::new(FungiControlInit {
-            config: shared_config,
+            settings,
             devices,
             services,
             service_access: service_access_manager,
             inbound_access,
             connectivity,
-            docker_control,
-            node_capabilities_control,
         });
 
         restore_service_endpoint_listeners(&control).await?;

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -29,7 +29,7 @@ use tokio::task::JoinHandle;
 
 use crate::{
     devices::{Devices, DevicesInit},
-    service_access_manager::ServiceAccessManager,
+    service_accesses::ServiceAccesses,
     services::{Services, ServicesInit},
 };
 
@@ -167,8 +167,8 @@ impl FungiDaemon {
         );
         service_control_protocol_control.start()?;
 
-        let service_access_manager =
-            ServiceAccessManager::new(fungi_home.clone(), tcp_tunneling_control.clone());
+        let service_access =
+            ServiceAccesses::new(fungi_home.clone(), tcp_tunneling_control.clone());
         let services = Services::new(ServicesInit {
             local_device_id: device_info.peer_id,
             fungi_dir: fungi_home,
@@ -191,7 +191,7 @@ impl FungiDaemon {
             settings,
             devices,
             services,
-            service_access: service_access_manager,
+            service_access,
             inbound_access,
             connectivity,
         });

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -9,6 +9,7 @@ use std::{
 
 use crate::{
     DaemonArgs,
+    control::{FungiControl, FungiControlInit},
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
         ServiceDiscoveryControl, TcpTunnelingControl, mdns::MdnsControl,
@@ -32,98 +33,25 @@ use tokio::task::JoinHandle;
 
 use crate::{
     devices::{Devices, DevicesInit},
-    service_access_manager::{ServiceAccessManager, restore_saved_service_accesses},
+    service_access_manager::ServiceAccessManager,
 };
 
 const DIRECT_ADDRESS_CACHE_SYNC_INTERVAL: Duration = Duration::from_secs(30);
 
 #[allow(dead_code)]
-struct TaskHandles {
+pub struct FungiDaemon {
+    control: FungiControl,
     swarm_task: JoinHandle<()>,
     direct_address_cache_sync_task: JoinHandle<()>,
 }
 
-#[allow(dead_code)]
-pub struct FungiDaemon {
-    config: Arc<Mutex<FungiConfig>>,
-    devices: Devices,
-    trusted_devices_config: Arc<Mutex<TrustedDevicesConfig>>,
-    direct_address_cache: Arc<Mutex<DirectAddressCache>>,
-    args: DaemonArgs,
-
-    swarm_control: SwarmControl,
-    mdns_control: MdnsControl,
-    docker_control: Option<DockerControl>,
-    node_capabilities_control: NodeCapabilitiesControl,
-
-    task_handles: TaskHandles,
-}
-
 impl FungiDaemon {
-    pub fn config(&self) -> Arc<Mutex<FungiConfig>> {
-        self.config.clone()
+    pub fn control(&self) -> FungiControl {
+        self.control.clone()
     }
 
-    pub fn devices(&self) -> &Devices {
-        &self.devices
-    }
-
-    pub fn devices_config(&self) -> Arc<Mutex<DevicesConfig>> {
-        self.devices.config()
-    }
-
-    pub fn trusted_devices(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
-        self.trusted_devices_config.clone()
-    }
-
-    pub fn swarm_control(&self) -> &SwarmControl {
-        &self.swarm_control
-    }
-
-    pub fn docker_control(&self) -> Option<&DockerControl> {
-        self.docker_control.as_ref()
-    }
-
-    pub fn tcp_tunneling_control(&self) -> &TcpTunnelingControl {
-        self.devices.tcp_tunneling()
-    }
-
-    pub(crate) fn service_access_manager(&self) -> &ServiceAccessManager {
-        self.devices.service_access()
-    }
-
-    pub fn runtime_control(&self) -> &RuntimeControl {
-        self.devices.runtime()
-    }
-
-    pub fn service_discovery_control(&self) -> &ServiceDiscoveryControl {
-        self.devices.service_discovery()
-    }
-
-    pub fn node_capabilities_control(&self) -> &NodeCapabilitiesControl {
-        &self.node_capabilities_control
-    }
-
-    pub fn service_control_protocol_control(&self) -> &ServiceControlProtocolControl {
-        self.devices.service_control()
-    }
-
-    /// Starts the one-shot restoration of saved remote service accesses.
-    ///
-    /// The task owns only the two domain handles it needs, so the daemon and its RPC server do not
-    /// need an additional outer `Arc`.
-    pub fn spawn_saved_service_access_restore(&self) -> JoinHandle<()> {
-        let service_access = self.devices.service_access().clone();
-        let devices = self.devices.clone();
-        tokio::spawn(async move {
-            log::info!("Restoring saved service access in the background...");
-            restore_saved_service_accesses(service_access, devices).await;
-            log::info!("Finished restoring saved service access");
-        })
-    }
-
-    pub fn mdns_control(&self) -> &MdnsControl {
-        &self.mdns_control
+    pub(crate) fn control_ref(&self) -> &FungiControl {
+        &self.control
     }
 
     pub async fn start(fungi_dir: PathBuf, args: DaemonArgs) -> Result<Self> {
@@ -148,7 +76,7 @@ impl FungiDaemon {
     }
 
     pub async fn start_with(
-        args: DaemonArgs,
+        _args: DaemonArgs,
         config: FungiConfig,
         keypair: Keypair,
         devices_config: DevicesConfig,
@@ -256,87 +184,89 @@ impl FungiDaemon {
 
         let trusted_devices_config = Arc::new(Mutex::new(trusted_devices_config));
         let direct_address_cache = Arc::new(Mutex::new(direct_address_cache));
-        let task_handles = TaskHandles {
-            swarm_task,
-            direct_address_cache_sync_task: spawn_direct_address_cache_sync_task(
-                swarm_control.clone(),
-                direct_address_cache.clone(),
-            ),
-        };
-        let daemon = Self {
+        let direct_address_cache_sync_task = spawn_direct_address_cache_sync_task(
+            swarm_control.clone(),
+            direct_address_cache.clone(),
+        );
+        let control = FungiControl::new(FungiControlInit {
             config: shared_config,
             devices,
             trusted_devices_config,
-            direct_address_cache,
-            args,
             swarm_control,
             mdns_control,
             docker_control,
             node_capabilities_control,
-            task_handles,
-        };
+        });
 
-        daemon.restore_service_endpoint_listeners().await?;
+        restore_service_endpoint_listeners(&control).await?;
 
-        Ok(daemon)
+        Ok(Self {
+            control,
+            swarm_task,
+            direct_address_cache_sync_task,
+        })
     }
 
-    pub async fn wait_all(self) {
-        tokio::select! {
-            _ = self.task_handles.swarm_task => {
-                println!("Swarm task is closed");
-            },
-            // _ = self.task_handles.daemon_rpc_task => {
-            //     println!("Daemon RPC task is closed");
-            // },
+    pub async fn wait(&mut self) -> Result<()> {
+        match (&mut self.swarm_task).await {
+            Ok(()) => bail!("swarm task stopped unexpectedly"),
+            Err(error) => Err(anyhow::anyhow!("swarm task failed: {error}")),
         }
     }
 
-    async fn restore_service_endpoint_listeners(&self) -> Result<()> {
-        let mut listening_rules = self.tcp_tunneling_control().get_listening_rules();
-        let mut restored_protocols = std::collections::BTreeSet::new();
+    pub async fn shutdown(mut self) {
+        self.swarm_task.abort();
+        self.direct_address_cache_sync_task.abort();
+        let _ = (&mut self.swarm_task).await;
+        let _ = (&mut self.direct_address_cache_sync_task).await;
+    }
+}
 
-        for service in self.runtime_control().list_services().await? {
-            if !service.status.is_running() {
-                continue;
-            }
+impl Drop for FungiDaemon {
+    fn drop(&mut self) {
+        self.swarm_task.abort();
+        self.direct_address_cache_sync_task.abort();
+    }
+}
 
-            for endpoint in service.exposed_endpoints {
-                restore_service_endpoint_listener(
-                    self.tcp_tunneling_control(),
-                    &mut listening_rules,
-                    &mut restored_protocols,
-                    endpoint.host_port,
-                    endpoint.protocol,
-                )
-                .await;
-            }
+async fn restore_service_endpoint_listeners(control: &FungiControl) -> Result<()> {
+    let mut listening_rules = control.tcp_tunneling_control().get_listening_rules();
+    let mut restored_protocols = std::collections::BTreeSet::new();
+
+    for service in control.runtime_control().list_services().await? {
+        if !service.status.is_running() {
+            continue;
         }
 
-        for manifest in self.runtime_control().desired_running_service_manifests() {
-            for endpoint in crate::runtime::service_expose_endpoint_bindings(&manifest) {
-                restore_service_endpoint_listener(
-                    self.tcp_tunneling_control(),
-                    &mut listening_rules,
-                    &mut restored_protocols,
-                    endpoint.host_port,
-                    endpoint.protocol,
-                )
-                .await;
-            }
+        for endpoint in service.exposed_endpoints {
+            restore_service_endpoint_listener(
+                control.tcp_tunneling_control(),
+                &mut listening_rules,
+                &mut restored_protocols,
+                endpoint.host_port,
+                endpoint.protocol,
+            )
+            .await;
         }
-
-        Ok(())
     }
 
-    pub fn config_fungi_dir(&self) -> Result<PathBuf> {
-        self.config
-            .lock()
-            .config_file_path()
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .ok_or_else(|| anyhow::anyhow!("config file has no parent directory"))
+    for manifest in control
+        .runtime_control()
+        .desired_running_service_manifests()
+    {
+        for endpoint in crate::runtime::service_expose_endpoint_bindings(&manifest) {
+            restore_service_endpoint_listener(
+                control.tcp_tunneling_control(),
+                &mut listening_rules,
+                &mut restored_protocols,
+                endpoint.host_port,
+                endpoint.protocol,
+            )
+            .await;
+        }
     }
+
+    Ok(())
 }
 
 fn hydrate_device_addresses(state: &State, devices_config: &DevicesConfig) {

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    Connectivity, DaemonArgs,
+    Connectivity, DaemonArgs, InboundAccessPolicy,
     control::{FungiControl, FungiControlInit},
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
@@ -87,6 +87,8 @@ impl FungiDaemon {
                 .into_iter()
                 .collect(),
         );
+        let inbound_access =
+            InboundAccessPolicy::new(trusted_devices_config, state.incoming_allowed_peers());
         hydrate_device_addresses(&state, &devices_config);
         hydrate_direct_address_cache(&state, &direct_address_cache);
 
@@ -184,14 +186,13 @@ impl FungiDaemon {
             services: services.clone(),
         });
 
-        let trusted_devices_config = Arc::new(Mutex::new(trusted_devices_config));
         let direct_address_cache_sync_task = connectivity.spawn_direct_address_cache_sync();
         let control = FungiControl::new(FungiControlInit {
             config: shared_config,
             devices,
             services,
             service_access: service_access_manager,
-            trusted_devices_config,
+            inbound_access,
             connectivity,
             docker_control,
             node_capabilities_control,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     env,
     net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    DaemonArgs,
+    Connectivity, DaemonArgs,
     control::{FungiControl, FungiControlInit},
     controls::{
         DockerControl, NodeCapabilitiesControl, ServiceControlProtocolControl,
@@ -23,9 +23,7 @@ use fungi_config::{
     direct_addresses::DirectAddressCache,
     trusted_devices::TrustedDevicesConfig,
 };
-use fungi_swarm::{
-    ConnectionDirection, FungiSwarm, PeerAddressSource, State, SwarmControl, TSwarm,
-};
+use fungi_swarm::{FungiSwarm, PeerAddressSource, State, TSwarm};
 use fungi_util::keypair::get_keypair_from_dir;
 use libp2p::{Multiaddr, identity::Keypair, multiaddr::Protocol};
 use parking_lot::Mutex;
@@ -36,8 +34,6 @@ use crate::{
     service_access_manager::ServiceAccessManager,
     services::{Services, ServicesInit},
 };
-
-const DIRECT_ADDRESS_CACHE_SYNC_INTERVAL: Duration = Duration::from_secs(30);
 
 #[allow(dead_code)]
 pub struct FungiDaemon {
@@ -125,6 +121,8 @@ impl FungiDaemon {
         // TODO duplicate with libp2p-mdns?
         let device_info = mdns_device_info(&config, swarm_control.local_peer_id());
         mdns_control.start(device_info.clone(), state.clone())?;
+        let connectivity =
+            Connectivity::new(swarm_control.clone(), mdns_control, direct_address_cache);
 
         let fungi_home = config
             .config_file_path()
@@ -182,24 +180,19 @@ impl FungiDaemon {
         let devices = Devices::new(DevicesInit {
             local_device: device_info,
             config: devices_config,
-            swarm_state: state,
+            connectivity: connectivity.clone(),
             services: services.clone(),
         });
 
         let trusted_devices_config = Arc::new(Mutex::new(trusted_devices_config));
-        let direct_address_cache = Arc::new(Mutex::new(direct_address_cache));
-        let direct_address_cache_sync_task = spawn_direct_address_cache_sync_task(
-            swarm_control.clone(),
-            direct_address_cache.clone(),
-        );
+        let direct_address_cache_sync_task = connectivity.spawn_direct_address_cache_sync();
         let control = FungiControl::new(FungiControlInit {
             config: shared_config,
             devices,
             services,
             service_access: service_access_manager,
             trusted_devices_config,
-            swarm_control,
-            mdns_control,
+            connectivity,
             docker_control,
             node_capabilities_control,
         });
@@ -386,109 +379,6 @@ fn mdns_device_info(config: &FungiConfig, peer_id: libp2p::PeerId) -> DeviceInfo
     device_info
 }
 
-fn spawn_direct_address_cache_sync_task(
-    swarm_control: SwarmControl,
-    direct_address_cache: Arc<Mutex<DirectAddressCache>>,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(DIRECT_ADDRESS_CACHE_SYNC_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let mut last_synced_pairs = BTreeSet::<(String, String)>::new();
-
-        loop {
-            interval.tick().await;
-
-            let grouped = collect_direct_connection_addresses(swarm_control.state());
-            let grouped = new_direct_address_successes(grouped, &mut last_synced_pairs);
-            if grouped.is_empty() {
-                continue;
-            }
-
-            let mut current = direct_address_cache.lock().clone();
-            let mut updated_any = false;
-            for (peer_id, addresses) in grouped {
-                match current.record_successful_addresses(peer_id, addresses) {
-                    Ok(updated) => {
-                        current = updated;
-                        updated_any = true;
-                    }
-                    Err(error) => {
-                        log::warn!("Failed to save cached direct address: {error}");
-                    }
-                }
-            }
-
-            if updated_any {
-                *direct_address_cache.lock() = current;
-            }
-        }
-    })
-}
-
-fn collect_direct_connection_addresses(state: &State) -> BTreeMap<String, Vec<String>> {
-    let mut grouped = BTreeMap::<String, Vec<String>>::new();
-    for peer_id in state.connected_peer_ids() {
-        for connection in state.get_connections_by_peer_id(&peer_id) {
-            if !matches!(connection.direction, ConnectionDirection::Outbound)
-                || connection.is_relay()
-            {
-                continue;
-            }
-
-            grouped
-                .entry(peer_id.to_string())
-                .or_default()
-                .push(connection.remote_addr.to_string());
-        }
-    }
-
-    normalize_direct_address_groups(grouped)
-}
-
-fn new_direct_address_successes(
-    grouped: BTreeMap<String, Vec<String>>,
-    last_synced_pairs: &mut BTreeSet<(String, String)>,
-) -> BTreeMap<String, Vec<String>> {
-    let current_pairs = direct_address_pairs(&grouped);
-    let mut new_pairs = BTreeMap::<String, Vec<String>>::new();
-
-    for (peer_id, address) in current_pairs.difference(last_synced_pairs) {
-        new_pairs
-            .entry(peer_id.clone())
-            .or_default()
-            .push(address.clone());
-    }
-
-    *last_synced_pairs = current_pairs;
-    new_pairs
-}
-
-fn direct_address_pairs(grouped: &BTreeMap<String, Vec<String>>) -> BTreeSet<(String, String)> {
-    grouped
-        .iter()
-        .flat_map(|(peer_id, addresses)| {
-            addresses
-                .iter()
-                .map(|address| (peer_id.clone(), address.clone()))
-        })
-        .collect()
-}
-
-fn normalize_direct_address_groups(
-    mut grouped: BTreeMap<String, Vec<String>>,
-) -> BTreeMap<String, Vec<String>> {
-    grouped.retain(|_, addresses| {
-        addresses.retain(|address| !address.trim().is_empty());
-        for address in addresses.iter_mut() {
-            *address = address.trim().to_string();
-        }
-        addresses.sort();
-        addresses.dedup();
-        !addresses.is_empty()
-    });
-    grouped
-}
-
 async fn restore_service_endpoint_listener(
     tcp_tunneling_control: &TcpTunnelingControl,
     listening_rules: &mut Vec<(String, fungi_config::tcp_tunneling::ListeningRule)>,
@@ -583,89 +473,4 @@ fn apply_listen(swarm: &mut TSwarm, config: &FungiConfig) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn new_direct_address_successes_only_returns_new_pairs() {
-        let mut last_synced_pairs = BTreeSet::new();
-
-        let first = new_direct_address_successes(
-            BTreeMap::from([
-                (
-                    "peer-a".to_string(),
-                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
-                ),
-                (
-                    "peer-b".to_string(),
-                    vec!["/ip4/192.168.1.8/tcp/4001".to_string()],
-                ),
-            ]),
-            &mut last_synced_pairs,
-        );
-        assert_eq!(first.len(), 2);
-
-        let second = new_direct_address_successes(
-            BTreeMap::from([
-                (
-                    "peer-a".to_string(),
-                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
-                ),
-                (
-                    "peer-b".to_string(),
-                    vec![
-                        "/ip4/192.168.1.8/tcp/4001".to_string(),
-                        "/ip4/192.168.1.9/tcp/4001".to_string(),
-                    ],
-                ),
-            ]),
-            &mut last_synced_pairs,
-        );
-        assert_eq!(
-            second,
-            BTreeMap::from([(
-                "peer-b".to_string(),
-                vec!["/ip4/192.168.1.9/tcp/4001".to_string()]
-            )])
-        );
-
-        let third = new_direct_address_successes(
-            BTreeMap::from([
-                (
-                    "peer-a".to_string(),
-                    vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
-                ),
-                (
-                    "peer-b".to_string(),
-                    vec![
-                        "/ip4/192.168.1.8/tcp/4001".to_string(),
-                        "/ip4/192.168.1.9/tcp/4001".to_string(),
-                    ],
-                ),
-            ]),
-            &mut last_synced_pairs,
-        );
-        assert!(third.is_empty());
-
-        let empty = new_direct_address_successes(BTreeMap::new(), &mut last_synced_pairs);
-        assert!(empty.is_empty());
-
-        let after_disconnect = new_direct_address_successes(
-            BTreeMap::from([(
-                "peer-a".to_string(),
-                vec!["/ip4/192.168.1.7/tcp/4001".to_string()],
-            )]),
-            &mut last_synced_pairs,
-        );
-        assert_eq!(
-            after_disconnect,
-            BTreeMap::from([(
-                "peer-a".to_string(),
-                vec!["/ip4/192.168.1.7/tcp/4001".to_string()]
-            )])
-        );
-    }
 }

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -5,13 +5,14 @@ use fungi_config::devices::{DeviceInfo, DevicesConfig};
 use libp2p::PeerId;
 use parking_lot::Mutex;
 
-use crate::{Connectivity, DeviceServices, Services};
+use crate::{Connectivity, DeviceServices, Services, controls::NodeCapabilitiesControl};
 
 struct DevicesInner {
     local_device: DeviceInfo,
     config: Arc<Mutex<DevicesConfig>>,
     connectivity: Connectivity,
     services: Services,
+    node_capabilities: NodeCapabilitiesControl,
 }
 
 pub(crate) struct DevicesInit {
@@ -19,6 +20,7 @@ pub(crate) struct DevicesInit {
     pub config: DevicesConfig,
     pub connectivity: Connectivity,
     pub services: Services,
+    pub node_capabilities: NodeCapabilitiesControl,
 }
 
 /// Directory and shared capabilities for devices actively managed by this daemon.
@@ -38,6 +40,7 @@ impl Devices {
                 config: Arc::new(Mutex::new(init.config)),
                 connectivity: init.connectivity,
                 services: init.services,
+                node_capabilities: init.node_capabilities,
             }),
         }
     }
@@ -120,6 +123,10 @@ impl Devices {
 
     pub(crate) fn config(&self) -> Arc<Mutex<DevicesConfig>> {
         self.inner.config.clone()
+    }
+
+    pub(crate) fn node_capabilities(&self) -> &NodeCapabilitiesControl {
+        &self.inner.node_capabilities
     }
 
     fn record_addresses(&self, device_info: &DeviceInfo) {

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -189,7 +189,7 @@ impl DeviceHandle {
     }
 
     pub fn services(&self) -> DeviceServices {
-        self.devices.inner.services.for_device(self.clone())
+        self.devices.inner.services.for_device(self.peer_id)
     }
 }
 

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -1,47 +1,25 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{Result, bail};
-use fungi_config::{
-    devices::{DeviceInfo, DevicesConfig},
-    service_cache::DeviceServiceSnapshotCache,
-};
+use fungi_config::devices::{DeviceInfo, DevicesConfig};
 use fungi_swarm::{PeerAddressSource, State};
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
 
-use crate::{
-    DeviceServiceSnapshot, RuntimeControl,
-    controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
-    service_access_manager::ServiceAccessManager,
-};
-
-mod services;
-#[cfg(test)]
-pub(crate) use services::merge_device_service_snapshot;
-pub use services::{DeviceServices, ServiceHandle};
+use crate::{DeviceServices, Services};
 
 struct DevicesInner {
     local_device: DeviceInfo,
     config: Arc<Mutex<DevicesConfig>>,
-    fungi_dir: PathBuf,
     swarm_state: State,
-    runtime: RuntimeControl,
-    service_discovery: ServiceDiscoveryControl,
-    service_control: ServiceControlProtocolControl,
-    tcp_tunneling: TcpTunnelingControl,
-    service_access: ServiceAccessManager,
+    services: Services,
 }
 
 pub(crate) struct DevicesInit {
     pub local_device: DeviceInfo,
     pub config: DevicesConfig,
-    pub fungi_dir: PathBuf,
     pub swarm_state: State,
-    pub runtime: RuntimeControl,
-    pub service_discovery: ServiceDiscoveryControl,
-    pub service_control: ServiceControlProtocolControl,
-    pub tcp_tunneling: TcpTunnelingControl,
-    pub service_access: ServiceAccessManager,
+    pub services: Services,
 }
 
 /// Directory and shared capabilities for devices actively managed by this daemon.
@@ -59,13 +37,8 @@ impl Devices {
             inner: Arc::new(DevicesInner {
                 local_device: init.local_device,
                 config: Arc::new(Mutex::new(init.config)),
-                fungi_dir: init.fungi_dir,
                 swarm_state: init.swarm_state,
-                runtime: init.runtime,
-                service_discovery: init.service_discovery,
-                service_control: init.service_control,
-                tcp_tunneling: init.tcp_tunneling,
-                service_access: init.service_access,
+                services: init.services,
             }),
         }
     }
@@ -142,44 +115,12 @@ impl Devices {
             *config = updated;
         }
 
-        self.inner.service_access.forget_device(peer_id).await?;
-        let _ = self.peer(peer_id).services().remove_snapshot()?;
+        let _ = self.inner.services.remove_snapshot(peer_id)?;
         Ok(())
     }
 
     pub(crate) fn config(&self) -> Arc<Mutex<DevicesConfig>> {
         self.inner.config.clone()
-    }
-
-    pub(crate) fn service_discovery(&self) -> &ServiceDiscoveryControl {
-        &self.inner.service_discovery
-    }
-
-    pub(crate) fn service_control(&self) -> &ServiceControlProtocolControl {
-        &self.inner.service_control
-    }
-
-    pub(crate) fn runtime(&self) -> &RuntimeControl {
-        &self.inner.runtime
-    }
-
-    pub(crate) fn tcp_tunneling(&self) -> &TcpTunnelingControl {
-        &self.inner.tcp_tunneling
-    }
-
-    pub(crate) fn service_access(&self) -> &ServiceAccessManager {
-        &self.inner.service_access
-    }
-
-    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        let snapshot_json = serde_json::to_string(snapshot)?;
-        self.snapshot_cache()?
-            .set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
-        Ok(())
-    }
-
-    fn snapshot_cache(&self) -> Result<DeviceServiceSnapshotCache> {
-        DeviceServiceSnapshotCache::apply_from_dir(&self.inner.fungi_dir)
     }
 
     fn record_addresses(&self, device_info: &DeviceInfo) {
@@ -248,9 +189,7 @@ impl DeviceHandle {
     }
 
     pub fn services(&self) -> DeviceServices {
-        DeviceServices {
-            device: self.clone(),
-        }
+        self.devices.inner.services.for_device(self.clone())
     }
 }
 

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -121,11 +121,8 @@ impl Devices {
         Ok(())
     }
 
-    pub(crate) fn config(&self) -> Arc<Mutex<DevicesConfig>> {
-        self.inner.config.clone()
-    }
-
-    pub(crate) fn node_capabilities(&self) -> &NodeCapabilitiesControl {
+    /// Low-level protocol handle for focused integration tests.
+    pub fn node_capabilities(&self) -> &NodeCapabilitiesControl {
         &self.inner.node_capabilities
     }
 

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -1,0 +1,326 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::{Result, bail};
+use fungi_config::{
+    devices::{DeviceInfo, DevicesConfig},
+    service_cache::DeviceServiceSnapshotCache,
+};
+use fungi_swarm::{PeerAddressSource, State};
+use libp2p::{Multiaddr, PeerId};
+use parking_lot::Mutex;
+
+use crate::{
+    DeviceServiceSnapshot, RuntimeControl,
+    controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
+    service_access_manager::ServiceAccessManager,
+};
+
+mod services;
+#[cfg(test)]
+pub(crate) use services::merge_device_service_snapshot;
+pub use services::{DeviceServices, ServiceHandle};
+
+struct DevicesInner {
+    local_device: DeviceInfo,
+    config: Arc<Mutex<DevicesConfig>>,
+    fungi_dir: PathBuf,
+    swarm_state: State,
+    runtime: RuntimeControl,
+    service_discovery: ServiceDiscoveryControl,
+    service_control: ServiceControlProtocolControl,
+    tcp_tunneling: TcpTunnelingControl,
+    service_access: ServiceAccessManager,
+}
+
+pub(crate) struct DevicesInit {
+    pub local_device: DeviceInfo,
+    pub config: DevicesConfig,
+    pub fungi_dir: PathBuf,
+    pub swarm_state: State,
+    pub runtime: RuntimeControl,
+    pub service_discovery: ServiceDiscoveryControl,
+    pub service_control: ServiceControlProtocolControl,
+    pub tcp_tunneling: TcpTunnelingControl,
+    pub service_access: ServiceAccessManager,
+}
+
+/// Directory and shared capabilities for devices actively managed by this daemon.
+///
+/// `DevicesConfig` remains the single directory state. Handles are cheap identity views created
+/// on demand, rather than entries in a second in-memory map.
+#[derive(Clone)]
+pub struct Devices {
+    inner: Arc<DevicesInner>,
+}
+
+impl Devices {
+    pub(crate) fn new(init: DevicesInit) -> Self {
+        Self {
+            inner: Arc::new(DevicesInner {
+                local_device: init.local_device,
+                config: Arc::new(Mutex::new(init.config)),
+                fungi_dir: init.fungi_dir,
+                swarm_state: init.swarm_state,
+                runtime: init.runtime,
+                service_discovery: init.service_discovery,
+                service_control: init.service_control,
+                tcp_tunneling: init.tcp_tunneling,
+                service_access: init.service_access,
+            }),
+        }
+    }
+
+    /// Compatibility view for callers that still read `DevicesConfig` directly.
+    /// New code should prefer the domain methods on `Devices` and `DeviceHandle`.
+    pub fn lock(&self) -> parking_lot::MutexGuard<'_, DevicesConfig> {
+        self.inner.config.lock()
+    }
+
+    /// Returns this daemon's device handle.
+    pub fn local(&self) -> DeviceHandle {
+        self.peer(self.inner.local_device.peer_id)
+    }
+
+    /// Returns a handle only when the peer is local or belongs to the saved device directory.
+    pub fn get(&self, peer_id: PeerId) -> Option<DeviceHandle> {
+        if peer_id == self.inner.local_device.peer_id
+            || self.inner.config.lock().get_device_info(&peer_id).is_some()
+        {
+            Some(self.peer(peer_id))
+        } else {
+            None
+        }
+    }
+
+    /// Creates an addressable handle for any peer.
+    ///
+    /// This is used for persisted service-access records that can outlive directory membership.
+    /// Call [`Devices::get`] when saved membership is required.
+    pub fn peer(&self, peer_id: PeerId) -> DeviceHandle {
+        DeviceHandle {
+            peer_id,
+            devices: self.clone(),
+        }
+    }
+
+    /// Lists local and saved remote devices using the common handle shape.
+    pub fn list(&self) -> Vec<DeviceHandle> {
+        std::iter::once(self.local()).chain(self.saved()).collect()
+    }
+
+    /// Lists only devices persisted in `devices.toml`.
+    pub fn saved(&self) -> Vec<DeviceHandle> {
+        self.saved_device_infos()
+            .into_iter()
+            .map(|device| self.peer(device.peer_id))
+            .collect()
+    }
+
+    pub fn saved_device_infos(&self) -> Vec<DeviceInfo> {
+        self.inner.config.lock().get_all_devices().clone()
+    }
+
+    pub fn add_or_update(&self, device_info: DeviceInfo) -> Result<()> {
+        {
+            let mut config = self.inner.config.lock();
+            let updated = config.add_or_update_device(device_info.clone())?;
+            *config = updated;
+        }
+        self.record_addresses(&device_info);
+        Ok(())
+    }
+
+    /// Removes active-management state without changing inbound authorization.
+    pub async fn remove(&self, peer_id: PeerId) -> Result<()> {
+        if peer_id == self.inner.local_device.peer_id {
+            bail!("cannot remove the local device");
+        }
+
+        {
+            let mut config = self.inner.config.lock();
+            let updated = config.remove_device(&peer_id)?;
+            *config = updated;
+        }
+
+        self.inner.service_access.forget_device(peer_id).await?;
+        let _ = self.peer(peer_id).services().remove_snapshot()?;
+        Ok(())
+    }
+
+    pub(crate) fn config(&self) -> Arc<Mutex<DevicesConfig>> {
+        self.inner.config.clone()
+    }
+
+    pub(crate) fn service_discovery(&self) -> &ServiceDiscoveryControl {
+        &self.inner.service_discovery
+    }
+
+    pub(crate) fn service_control(&self) -> &ServiceControlProtocolControl {
+        &self.inner.service_control
+    }
+
+    pub(crate) fn runtime(&self) -> &RuntimeControl {
+        &self.inner.runtime
+    }
+
+    pub(crate) fn tcp_tunneling(&self) -> &TcpTunnelingControl {
+        &self.inner.tcp_tunneling
+    }
+
+    pub(crate) fn service_access(&self) -> &ServiceAccessManager {
+        &self.inner.service_access
+    }
+
+    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
+        let snapshot_json = serde_json::to_string(snapshot)?;
+        self.snapshot_cache()?
+            .set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
+        Ok(())
+    }
+
+    fn snapshot_cache(&self) -> Result<DeviceServiceSnapshotCache> {
+        DeviceServiceSnapshotCache::apply_from_dir(&self.inner.fungi_dir)
+    }
+
+    fn record_addresses(&self, device_info: &DeviceInfo) {
+        for address in &device_info.multiaddrs {
+            match address.parse::<Multiaddr>() {
+                Ok(multiaddr) => {
+                    self.inner.swarm_state.record_peer_address(
+                        device_info.peer_id,
+                        multiaddr,
+                        PeerAddressSource::DeviceConfig,
+                    );
+                }
+                Err(error) => log::debug!(
+                    "Ignoring invalid device multiaddr for peer {}: {} ({})",
+                    device_info.peer_id,
+                    address,
+                    error
+                ),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceKind {
+    Local,
+    Remote,
+}
+
+/// Stable identity and entry point for one local or remote device.
+#[derive(Clone)]
+pub struct DeviceHandle {
+    peer_id: PeerId,
+    devices: Devices,
+}
+
+impl DeviceHandle {
+    pub fn id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub fn kind(&self) -> DeviceKind {
+        if self.is_local() {
+            DeviceKind::Local
+        } else {
+            DeviceKind::Remote
+        }
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.peer_id == self.devices.inner.local_device.peer_id
+    }
+
+    /// Resolves current device metadata without storing it in the handle.
+    pub fn info(&self) -> Option<DeviceInfo> {
+        if self.is_local() {
+            Some(self.devices.inner.local_device.clone())
+        } else {
+            self.devices
+                .inner
+                .config
+                .lock()
+                .get_device_info(&self.peer_id)
+                .cloned()
+        }
+    }
+
+    pub fn services(&self) -> DeviceServices {
+        DeviceServices {
+            device: self.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{TestDaemon, spawn_connected_pair};
+
+    #[tokio::test]
+    async fn local_and_remote_devices_share_the_handle_shape() {
+        let daemon = TestDaemon::spawn().await.unwrap();
+        let devices = daemon.daemon().devices();
+        let local = devices.local();
+
+        assert_eq!(local.id(), daemon.peer_id());
+        assert_eq!(local.kind(), DeviceKind::Local);
+        assert!(local.info().is_some());
+        assert!(local.services().snapshot().unwrap().is_none());
+
+        let remote_id = PeerId::random();
+        let remote = devices.peer(remote_id);
+        assert_eq!(remote.kind(), DeviceKind::Remote);
+        assert_eq!(remote.services().service("ssh").name(), "ssh");
+        assert!(remote.info().is_none());
+        assert!(devices.get(remote_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn handles_reflect_directory_updates_without_a_second_state_map() {
+        let daemon = TestDaemon::spawn().await.unwrap();
+        let devices = daemon.daemon().devices();
+        let remote_id = PeerId::random();
+        let remote = devices.peer(remote_id);
+
+        let mut info = DeviceInfo::new_unknown(remote_id);
+        info.name = Some("workstation".to_string());
+        devices.add_or_update(info).unwrap();
+
+        assert_eq!(
+            remote.info().and_then(|info| info.name).as_deref(),
+            Some("workstation")
+        );
+        assert_eq!(devices.saved().len(), 1);
+        assert_eq!(devices.list().len(), 2);
+
+        devices.remove(remote_id).await.unwrap();
+        assert!(remote.info().is_none());
+        assert!(devices.get(remote_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn removing_managed_device_does_not_implicitly_revoke_inbound_authorization() {
+        let (client, server) = spawn_connected_pair().await.unwrap();
+        let server_id = server.peer_id();
+        let mut server_info = DeviceInfo::new_unknown(server_id);
+        server_info.name = Some("server".to_string());
+        client
+            .daemon()
+            .devices()
+            .add_or_update(server_info)
+            .unwrap();
+
+        client.daemon().devices().remove(server_id).await.unwrap();
+
+        assert!(
+            client
+                .daemon()
+                .list_trusted_devices()
+                .iter()
+                .any(|device| device.peer_id == server_id)
+        );
+    }
+}

--- a/crates/daemon/src/devices/mod.rs
+++ b/crates/daemon/src/devices/mod.rs
@@ -2,23 +2,22 @@ use std::sync::Arc;
 
 use anyhow::{Result, bail};
 use fungi_config::devices::{DeviceInfo, DevicesConfig};
-use fungi_swarm::{PeerAddressSource, State};
-use libp2p::{Multiaddr, PeerId};
+use libp2p::PeerId;
 use parking_lot::Mutex;
 
-use crate::{DeviceServices, Services};
+use crate::{Connectivity, DeviceServices, Services};
 
 struct DevicesInner {
     local_device: DeviceInfo,
     config: Arc<Mutex<DevicesConfig>>,
-    swarm_state: State,
+    connectivity: Connectivity,
     services: Services,
 }
 
 pub(crate) struct DevicesInit {
     pub local_device: DeviceInfo,
     pub config: DevicesConfig,
-    pub swarm_state: State,
+    pub connectivity: Connectivity,
     pub services: Services,
 }
 
@@ -37,7 +36,7 @@ impl Devices {
             inner: Arc::new(DevicesInner {
                 local_device: init.local_device,
                 config: Arc::new(Mutex::new(init.config)),
-                swarm_state: init.swarm_state,
+                connectivity: init.connectivity,
                 services: init.services,
             }),
         }
@@ -124,23 +123,7 @@ impl Devices {
     }
 
     fn record_addresses(&self, device_info: &DeviceInfo) {
-        for address in &device_info.multiaddrs {
-            match address.parse::<Multiaddr>() {
-                Ok(multiaddr) => {
-                    self.inner.swarm_state.record_peer_address(
-                        device_info.peer_id,
-                        multiaddr,
-                        PeerAddressSource::DeviceConfig,
-                    );
-                }
-                Err(error) => log::debug!(
-                    "Ignoring invalid device multiaddr for peer {}: {} ({})",
-                    device_info.peer_id,
-                    address,
-                    error
-                ),
-            }
-        }
+        self.inner.connectivity.record_device_addresses(device_info);
     }
 }
 

--- a/crates/daemon/src/devices/services.rs
+++ b/crates/daemon/src/devices/services.rs
@@ -1,0 +1,557 @@
+use std::{collections::BTreeMap, path::PathBuf, time::SystemTime};
+
+use anyhow::{Context as _, Result, bail};
+use libp2p::PeerId;
+
+use crate::{
+    DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceAccess, ServiceInstance,
+    ServiceLogs, ServiceLogsOptions,
+    service_endpoints::{
+        sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
+    },
+    service_state::DesiredServiceState,
+};
+
+use super::DeviceHandle;
+
+/// Collection and observation boundary for one device's services.
+#[derive(Clone)]
+pub struct DeviceServices {
+    pub(super) device: DeviceHandle,
+}
+
+impl DeviceServices {
+    pub fn device(&self) -> &DeviceHandle {
+        &self.device
+    }
+
+    /// Reads the last successful remote observation without network access.
+    ///
+    /// Local services do not maintain a stale shadow, so this returns `None` for the local device.
+    pub fn snapshot(&self) -> Result<Option<DeviceServiceSnapshot>> {
+        if self.device.is_local() {
+            return Ok(None);
+        }
+
+        let cache = self.device.devices.snapshot_cache()?;
+        let Some(snapshot_json) =
+            cache.get_device_snapshot_json(&self.device.peer_id.to_string())?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_str(&snapshot_json)
+            .map(Some)
+            .map_err(|error| {
+                anyhow::anyhow!("failed to decode cached device service snapshot: {error}")
+            })
+    }
+
+    /// Observes this device now. Remote successes replace the persisted shadow; local
+    /// observations are returned directly without creating a redundant cache.
+    pub async fn refresh(&self) -> Result<DeviceServiceSnapshot> {
+        let peer_id = self.device.peer_id;
+        let snapshot = if self.device.is_local() {
+            let (managed, published) = tokio::try_join!(
+                self.device.devices.inner.runtime.list_services(),
+                self.device
+                    .devices
+                    .inner
+                    .runtime
+                    .list_published_device_services(),
+            )?;
+            merge_device_service_snapshot(peer_id, managed, published)
+        } else {
+            let control = self.device.devices.inner.service_control.clone();
+            let discovery = self.device.devices.inner.service_discovery.clone();
+            let (managed_response, published) = tokio::try_join!(
+                async move {
+                    control.list_peer_services(peer_id).await.with_context(|| {
+                        format!("failed to refresh managed services for device {peer_id}")
+                    })
+                },
+                async move {
+                    discovery
+                        .list_peer_services(peer_id)
+                        .await
+                        .with_context(|| {
+                            format!("failed to refresh published services for device {peer_id}")
+                        })
+                },
+            )?;
+            let managed = managed_response
+                .services_json
+                .as_deref()
+                .map(serde_json::from_str::<Vec<ServiceInstance>>)
+                .transpose()
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to decode managed services from device {peer_id}: {error}"
+                    )
+                })?
+                .unwrap_or_default();
+            merge_device_service_snapshot(peer_id, managed, published)
+        };
+
+        if !self.device.is_local() {
+            self.device.devices.save_snapshot(&snapshot)?;
+        }
+        Ok(snapshot)
+    }
+
+    pub async fn list(&self) -> Result<Vec<DeviceService>> {
+        Ok(self.refresh().await?.services)
+    }
+
+    /// Lists only endpoints published for connection, without the managed-service merge.
+    pub async fn published(&self) -> Result<Vec<DeviceService>> {
+        if self.device.is_local() {
+            self.device
+                .devices
+                .inner
+                .runtime
+                .list_published_device_services()
+                .await
+        } else {
+            self.device
+                .devices
+                .inner
+                .service_discovery
+                .list_peer_services(self.device.peer_id)
+                .await
+        }
+    }
+
+    pub fn service(&self, name: impl Into<String>) -> ServiceHandle {
+        ServiceHandle {
+            device: self.device.clone(),
+            name: name.into(),
+        }
+    }
+
+    pub async fn apply_manifest_yaml(
+        &self,
+        manifest_yaml: String,
+        manifest_base_dir: Option<PathBuf>,
+    ) -> Result<ServiceHandle> {
+        if self.device.is_local() {
+            let fungi_home = self.device.devices.inner.fungi_dir.clone();
+            let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
+            let applied = self
+                .device
+                .devices
+                .inner
+                .runtime
+                .apply_manifest_yaml(
+                    &manifest_yaml,
+                    &base_dir,
+                    &fungi_home,
+                    &ManifestResolutionPolicy,
+                )
+                .await?;
+            if applied.desired_state == DesiredServiceState::Running {
+                sync_service_endpoint_listeners_for_manifest(
+                    &self.device.devices.inner.tcp_tunneling,
+                    applied.previous_manifest.as_ref(),
+                    false,
+                )
+                .await?;
+                sync_service_endpoint_listeners_by_name(
+                    &self.device.devices.inner.runtime,
+                    &self.device.devices.inner.tcp_tunneling,
+                    &applied.instance.name,
+                    true,
+                )
+                .await?;
+            }
+            Ok(self.service(applied.instance.name))
+        } else {
+            let response = self
+                .device
+                .devices
+                .inner
+                .service_control
+                .pull_peer_service(self.device.peer_id, manifest_yaml)
+                .await?;
+            self.refresh_or_keep_after_mutation().await;
+            let service_name = response
+                .service
+                .map(|service| service.name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("service apply response did not include a service")
+                })?;
+            Ok(self.service(service_name))
+        }
+    }
+
+    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
+        self.device.devices.save_snapshot(snapshot)
+    }
+
+    pub(crate) fn remove_snapshot(&self) -> Result<bool> {
+        if self.device.is_local() {
+            return Ok(false);
+        }
+        self.device
+            .devices
+            .snapshot_cache()?
+            .remove_device_snapshot(&self.device.peer_id.to_string())
+    }
+
+    pub(crate) fn remove_cached_service(&self, name: &str) -> Result<bool> {
+        let Some(mut snapshot) = self.snapshot()? else {
+            return Ok(false);
+        };
+        let before = snapshot.services.len();
+        snapshot.services.retain(|service| service.name != name);
+        if snapshot.services.len() == before {
+            return Ok(false);
+        }
+        self.save_snapshot(&snapshot)?;
+        Ok(true)
+    }
+
+    async fn refresh_or_keep_after_mutation(&self) {
+        if let Err(error) = self.refresh().await {
+            log::warn!(
+                "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
+                self.device.peer_id
+            );
+        }
+    }
+}
+
+/// Service identity on a device. The handle never stores a service observation, which could
+/// become stale; observation and mutation always go through the owning `DeviceServices`.
+#[derive(Clone)]
+pub struct ServiceHandle {
+    device: DeviceHandle,
+    name: String,
+}
+
+impl ServiceHandle {
+    pub fn device(&self) -> &DeviceHandle {
+        &self.device
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn observation(&self) -> Result<Option<DeviceService>> {
+        Ok(self
+            .device
+            .services()
+            .snapshot()?
+            .and_then(|snapshot| find_service(snapshot, &self.name)))
+    }
+
+    pub async fn inspect(&self) -> Result<DeviceService> {
+        let snapshot = self.device.services().refresh().await?;
+        find_service(snapshot, &self.name)
+            .ok_or_else(|| anyhow::anyhow!("service not found: {}", self.name))
+    }
+
+    pub async fn start(&self) -> Result<()> {
+        if self.device.is_local() {
+            self.device
+                .devices
+                .inner
+                .runtime
+                .start_by_name(&self.name)
+                .await?;
+            sync_service_endpoint_listeners_by_name(
+                &self.device.devices.inner.runtime,
+                &self.device.devices.inner.tcp_tunneling,
+                &self.name,
+                true,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let response = self
+            .device
+            .devices
+            .inner
+            .service_control
+            .start_peer_service(self.device.peer_id, self.name.clone())
+            .await?;
+        let service_name = response
+            .service
+            .as_ref()
+            .map(|service| service.name.clone())
+            .unwrap_or_else(|| self.name.clone());
+        self.restore_saved_access_after_start(&service_name)
+            .await
+            .with_context(|| {
+                format!(
+                    "remote service started, but failed to restore saved local access listeners for {service_name}"
+                )
+            })?;
+        Ok(())
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+        if self.device.is_local() {
+            self.device
+                .devices
+                .inner
+                .runtime
+                .stop_by_name(&self.name)
+                .await?;
+            sync_service_endpoint_listeners_by_name(
+                &self.device.devices.inner.runtime,
+                &self.device.devices.inner.tcp_tunneling,
+                &self.name,
+                false,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let response = self
+            .device
+            .devices
+            .inner
+            .service_control
+            .stop_peer_service(self.device.peer_id, self.name.clone())
+            .await?;
+        let service_name = response
+            .service
+            .as_ref()
+            .map(|service| service.name.as_str())
+            .unwrap_or(self.name.as_str());
+        self.device
+            .devices
+            .inner
+            .service_access
+            .detach(self.device.peer_id, service_name)
+            .with_context(|| {
+                format!(
+                    "remote service stopped, but failed to disconnect local access listeners for {service_name}"
+                )
+            })?;
+        self.device
+            .services()
+            .refresh_or_keep_after_mutation()
+            .await;
+        Ok(())
+    }
+
+    pub async fn remove(&self) -> Result<()> {
+        if self.device.is_local() {
+            let manifest = self
+                .device
+                .devices
+                .inner
+                .runtime
+                .get_service_manifest(&self.name);
+            self.device
+                .devices
+                .inner
+                .runtime
+                .remove_by_name(&self.name)
+                .await?;
+            sync_service_endpoint_listeners_for_manifest(
+                &self.device.devices.inner.tcp_tunneling,
+                manifest.as_ref(),
+                false,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let response = self
+            .device
+            .devices
+            .inner
+            .service_control
+            .remove_peer_service(self.device.peer_id, self.name.clone())
+            .await?;
+        let service_name = response
+            .service
+            .as_ref()
+            .map(|service| service.name.as_str())
+            .unwrap_or(self.name.as_str());
+        self.device
+            .devices
+            .inner
+            .service_access
+            .forget_service(self.device.peer_id, service_name)
+            .await
+            .with_context(|| {
+                format!(
+                    "remote service removed, but failed to forget local access records for {service_name}"
+                )
+            })?;
+        self.device
+            .services()
+            .refresh_or_keep_after_mutation()
+            .await;
+        Ok(())
+    }
+
+    pub async fn logs(&self, tail: Option<usize>) -> Result<ServiceLogs> {
+        if self.device.is_local() {
+            return self
+                .device
+                .devices
+                .inner
+                .runtime
+                .logs_by_name(
+                    &self.name,
+                    &ServiceLogsOptions {
+                        tail: tail.map(|tail| tail.to_string()),
+                    },
+                )
+                .await;
+        }
+
+        let tail = tail
+            .unwrap_or(crate::DEFAULT_REMOTE_SERVICE_LOG_TAIL)
+            .clamp(1, crate::MAX_REMOTE_SERVICE_LOG_TAIL);
+        let response = self
+            .device
+            .devices
+            .inner
+            .service_control
+            .get_peer_service_logs(self.device.peer_id, self.name.clone(), tail)
+            .await?;
+        let text = response
+            .logs_text
+            .ok_or_else(|| anyhow::anyhow!("remote service log response did not include logs"))?;
+        Ok(ServiceLogs {
+            raw: Vec::new(),
+            text,
+        })
+    }
+
+    pub async fn attach_access(
+        &self,
+        entry: Option<String>,
+        local_port: Option<u16>,
+    ) -> Result<ServiceAccess> {
+        self.ensure_remote_access()?;
+        let snapshot = self.device.services().refresh().await.map_err(|error| {
+            anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
+        })?;
+        let service = find_service(snapshot, &self.name)
+            .ok_or_else(|| anyhow::anyhow!("remote service not found: {}", self.name))?;
+        self.device
+            .devices
+            .inner
+            .service_access
+            .attach(self.device.peer_id, service, entry, local_port)
+            .await
+    }
+
+    pub fn detach_access(&self) -> Result<()> {
+        self.ensure_remote_access()?;
+        self.device
+            .devices
+            .inner
+            .service_access
+            .detach(self.device.peer_id, &self.name)
+    }
+
+    pub async fn forget_access(&self) -> Result<()> {
+        self.ensure_remote_access()?;
+        self.device
+            .devices
+            .inner
+            .service_access
+            .forget_service(self.device.peer_id, &self.name)
+            .await
+    }
+
+    pub async fn forget_cached_observation(&self) -> Result<bool> {
+        self.ensure_remote_access()?;
+        let removed = self.device.services().remove_cached_service(&self.name)?;
+        if removed {
+            self.forget_access().await?;
+        }
+        Ok(removed)
+    }
+
+    async fn restore_saved_access_after_start(&self, service_name: &str) -> Result<()> {
+        let saved_entries = self
+            .device
+            .devices
+            .inner
+            .service_access
+            .saved_entries(self.device.peer_id, service_name)
+            .await?;
+        let snapshot = self.device.services().refresh().await;
+        if saved_entries.is_empty() {
+            if let Err(error) = snapshot {
+                log::warn!(
+                    "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
+                    self.device.peer_id
+                );
+            }
+            return Ok(());
+        }
+
+        let service = find_service(snapshot?, service_name)
+            .ok_or_else(|| anyhow::anyhow!("remote service not found: {service_name}"))?;
+        for entry in saved_entries {
+            self.device
+                .devices
+                .inner
+                .service_access
+                .attach(self.device.peer_id, service.clone(), Some(entry), None)
+                .await?;
+        }
+        Ok(())
+    }
+
+    fn ensure_remote_access(&self) -> Result<()> {
+        if self.device.is_local() {
+            bail!("local services do not use remote service access listeners");
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn merge_device_service_snapshot(
+    peer_id: PeerId,
+    managed: Vec<ServiceInstance>,
+    published: Vec<DeviceService>,
+) -> DeviceServiceSnapshot {
+    let mut services_by_name = BTreeMap::<String, DeviceService>::new();
+    for service in managed {
+        services_by_name.insert(service.name.clone(), device_service_from_instance(service));
+    }
+    for service in published {
+        services_by_name
+            .entry(service.name.clone())
+            .and_modify(|existing| {
+                existing.metadata = service.metadata.clone();
+                existing.endpoints = service.endpoints.clone();
+            })
+            .or_insert(service);
+    }
+
+    DeviceServiceSnapshot {
+        peer_id: peer_id.to_string(),
+        services: services_by_name.into_values().collect(),
+        updated_at: SystemTime::now(),
+    }
+}
+
+fn device_service_from_instance(instance: ServiceInstance) -> DeviceService {
+    DeviceService {
+        name: instance.name,
+        runtime: instance.runtime,
+        metadata: Default::default(),
+        endpoints: Vec::new(),
+        status: instance.status,
+    }
+}
+
+fn find_service(snapshot: DeviceServiceSnapshot, name: &str) -> Option<DeviceService> {
+    snapshot
+        .services
+        .into_iter()
+        .find(|service| service.name == name)
+}

--- a/crates/daemon/src/inbound_access.rs
+++ b/crates/daemon/src/inbound_access.rs
@@ -1,0 +1,147 @@
+use std::{collections::HashSet, sync::Arc};
+
+use anyhow::Result;
+use fungi_config::trusted_devices::TrustedDevicesConfig;
+use libp2p::PeerId;
+use parking_lot::{Mutex, RwLock};
+
+struct InboundAccessPolicyInner {
+    trusted_peers: Arc<Mutex<TrustedDevicesConfig>>,
+    incoming_allow_list: Arc<RwLock<HashSet<PeerId>>>,
+}
+
+/// Controls which peers may use this daemon's inbound protocols.
+///
+/// This policy is intentionally independent from the actively managed device directory: a peer
+/// can be authorized without being a device this daemon controls, and vice versa.
+#[derive(Clone)]
+pub struct InboundAccessPolicy {
+    inner: Arc<InboundAccessPolicyInner>,
+}
+
+impl InboundAccessPolicy {
+    pub(crate) fn new(
+        trusted_peers: TrustedDevicesConfig,
+        incoming_allow_list: Arc<RwLock<HashSet<PeerId>>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(InboundAccessPolicyInner {
+                trusted_peers: Arc::new(Mutex::new(trusted_peers)),
+                incoming_allow_list,
+            }),
+        }
+    }
+
+    pub fn authorize(&self, peer_id: PeerId) -> Result<()> {
+        let mut trusted_peers = self.inner.trusted_peers.lock();
+        *trusted_peers = trusted_peers.add_trusted_device(&peer_id)?;
+        drop(trusted_peers);
+        self.inner.incoming_allow_list.write().insert(peer_id);
+        Ok(())
+    }
+
+    pub fn revoke(&self, peer_id: PeerId) -> Result<()> {
+        let mut trusted_peers = self.inner.trusted_peers.lock();
+        *trusted_peers = trusted_peers.remove_trusted_device(&peer_id)?;
+        drop(trusted_peers);
+        self.inner.incoming_allow_list.write().remove(&peer_id);
+        Ok(())
+    }
+
+    pub fn is_authorized(&self, peer_id: PeerId) -> bool {
+        self.inner.incoming_allow_list.read().contains(&peer_id)
+    }
+
+    pub fn authorized_peers(&self) -> Vec<PeerId> {
+        let mut peers = self
+            .inner
+            .incoming_allow_list
+            .read()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        peers.sort();
+        peers
+    }
+
+    pub(crate) fn trusted_peers_config(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
+        self.inner.trusted_peers.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, sync::Barrier, thread};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn policy(config: TrustedDevicesConfig) -> InboundAccessPolicy {
+        InboundAccessPolicy::new(config, Arc::new(RwLock::new(HashSet::new())))
+    }
+
+    #[test]
+    fn authorization_updates_persisted_and_runtime_policy() {
+        let temp_dir = TempDir::new().unwrap();
+        let policy = policy(TrustedDevicesConfig::apply_from_dir(temp_dir.path()).unwrap());
+        let peer_id = PeerId::random();
+
+        policy.authorize(peer_id).unwrap();
+
+        assert!(policy.is_authorized(peer_id));
+        let reloaded = TrustedDevicesConfig::apply_from_dir(temp_dir.path()).unwrap();
+        assert_eq!(reloaded.trusted_devices, vec![peer_id]);
+
+        policy.revoke(peer_id).unwrap();
+
+        assert!(!policy.is_authorized(peer_id));
+        let reloaded = TrustedDevicesConfig::apply_from_dir(temp_dir.path()).unwrap();
+        assert!(reloaded.trusted_devices.is_empty());
+    }
+
+    #[test]
+    fn concurrent_authorizations_do_not_overwrite_each_other() {
+        let policy = policy(TrustedDevicesConfig::in_memory(Vec::new()));
+        let first_peer = PeerId::random();
+        let second_peer = PeerId::random();
+        let barrier = Arc::new(Barrier::new(3));
+
+        let first_task = {
+            let policy = policy.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                policy.authorize(first_peer).unwrap();
+            })
+        };
+        let second_task = {
+            let policy = policy.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                policy.authorize(second_peer).unwrap();
+            })
+        };
+
+        barrier.wait();
+        first_task.join().unwrap();
+        second_task.join().unwrap();
+
+        assert_eq!(policy.authorized_peers().len(), 2);
+        let trusted_peers = policy.trusted_peers_config();
+        assert_eq!(trusted_peers.lock().trusted_devices.len(), 2);
+    }
+
+    #[test]
+    fn failed_persistence_does_not_change_runtime_policy() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = TrustedDevicesConfig::apply_from_dir(temp_dir.path()).unwrap();
+        drop(temp_dir);
+        let policy = policy(config);
+        let peer_id = PeerId::random();
+
+        assert!(policy.authorize(peer_id).is_err());
+        assert!(!policy.is_authorized(peer_id));
+    }
+}

--- a/crates/daemon/src/inbound_access.rs
+++ b/crates/daemon/src/inbound_access.rs
@@ -63,10 +63,6 @@ impl InboundAccessPolicy {
         peers.sort();
         peers
     }
-
-    pub(crate) fn trusted_peers_config(&self) -> Arc<Mutex<TrustedDevicesConfig>> {
-        self.inner.trusted_peers.clone()
-    }
 }
 
 #[cfg(test)]
@@ -129,8 +125,7 @@ mod tests {
         second_task.join().unwrap();
 
         assert_eq!(policy.authorized_peers().len(), 2);
-        let trusted_peers = policy.trusted_peers_config();
-        assert_eq!(trusted_peers.lock().trusted_devices.len(), 2);
+        assert_eq!(policy.inner.trusted_peers.lock().trusted_devices.len(), 2);
     }
 
     #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,11 +1,14 @@
 mod api;
 mod controls;
 mod daemon;
+mod devices;
 mod http_client;
 mod node_capabilities;
 mod recipes;
 pub mod runtime;
+mod service_access_manager;
 mod service_control;
+mod service_endpoints;
 mod service_state;
 
 /// Utilities for spawning ephemeral [`FungiDaemon`] instances in tests.
@@ -18,6 +21,7 @@ pub use api::{ServiceAccess, ServiceAccessEndpoint};
 use clap::Parser;
 pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;
+pub use devices::{DeviceHandle, DeviceKind, DeviceServices, Devices, ServiceHandle};
 pub use node_capabilities::{
     LocalRuntimeAvailability, LocalRuntimeStatus, NodeCapabilities, NodeRuntimeCapabilities,
     build_local_node_capabilities, build_local_runtime_status,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9,7 +9,7 @@ mod inbound_access;
 mod node_capabilities;
 mod recipes;
 pub mod runtime;
-mod service_access_manager;
+mod service_accesses;
 mod service_control;
 mod service_endpoints;
 mod service_state;
@@ -47,6 +47,7 @@ pub use runtime::{
     load_service_manifest_yaml_file, parse_service_manifest_yaml, peek_service_manifest_name,
     service_expose_endpoint_bindings, service_manifest_with_instance_name,
 };
+pub use service_accesses::ServiceAccesses;
 pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,
 };

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
+mod connectivity;
 mod control;
 mod controls;
 mod daemon;
@@ -21,6 +22,7 @@ pub mod test_support;
 
 pub use api::{ServiceAccess, ServiceAccessEndpoint};
 use clap::Parser;
+pub use connectivity::Connectivity;
 pub use control::FungiControl;
 pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
+mod control;
 mod controls;
 mod daemon;
 mod devices;
@@ -19,6 +20,7 @@ pub mod test_support;
 
 pub use api::{ServiceAccess, ServiceAccessEndpoint};
 use clap::Parser;
+pub use control::FungiControl;
 pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;
 pub use devices::{DeviceHandle, DeviceKind, DeviceServices, Devices, ServiceHandle};

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -11,6 +11,7 @@ mod service_access_manager;
 mod service_control;
 mod service_endpoints;
 mod service_state;
+mod services;
 
 /// Utilities for spawning ephemeral [`FungiDaemon`] instances in tests.
 ///
@@ -23,7 +24,7 @@ use clap::Parser;
 pub use control::FungiControl;
 pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;
-pub use devices::{DeviceHandle, DeviceKind, DeviceServices, Devices, ServiceHandle};
+pub use devices::{DeviceHandle, DeviceKind, Devices};
 pub use node_capabilities::{
     LocalRuntimeAvailability, LocalRuntimeStatus, NodeCapabilities, NodeRuntimeCapabilities,
     build_local_node_capabilities, build_local_runtime_status,
@@ -44,6 +45,7 @@ pub use runtime::{
 pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,
 };
+pub use services::{DeviceServices, ServiceHandle, Services};
 
 #[derive(Debug, Clone, Default, Parser)]
 pub struct DaemonArgs {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -14,6 +14,7 @@ mod service_control;
 mod service_endpoints;
 mod service_state;
 mod services;
+mod settings;
 
 /// Utilities for spawning ephemeral [`FungiDaemon`] instances in tests.
 ///
@@ -50,6 +51,7 @@ pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,
 };
 pub use services::{DeviceServices, ServiceHandle, ServiceKey, Services};
+pub use settings::Settings;
 
 #[derive(Debug, Clone, Default, Parser)]
 pub struct DaemonArgs {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -45,7 +45,7 @@ pub use runtime::{
 pub use service_control::{
     ServiceControlError, ServiceControlRequest, ServiceControlResponse, ServiceControlServiceRef,
 };
-pub use services::{DeviceServices, ServiceHandle, Services};
+pub use services::{DeviceServices, ServiceHandle, ServiceKey, Services};
 
 #[derive(Debug, Clone, Default, Parser)]
 pub struct DaemonArgs {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5,6 +5,7 @@ mod controls;
 mod daemon;
 mod devices;
 mod http_client;
+mod inbound_access;
 mod node_capabilities;
 mod recipes;
 pub mod runtime;
@@ -27,6 +28,7 @@ pub use control::FungiControl;
 pub use controls::{DEFAULT_REMOTE_SERVICE_LOG_TAIL, MAX_REMOTE_SERVICE_LOG_TAIL};
 pub use daemon::FungiDaemon;
 pub use devices::{DeviceHandle, DeviceKind, Devices};
+pub use inbound_access::InboundAccessPolicy;
 pub use node_capabilities::{
     LocalRuntimeAvailability, LocalRuntimeStatus, NodeCapabilities, NodeRuntimeCapabilities,
     build_local_node_capabilities, build_local_runtime_status,

--- a/crates/daemon/src/service_access_manager.rs
+++ b/crates/daemon/src/service_access_manager.rs
@@ -4,7 +4,6 @@ use std::{
     net::TcpListener as StdTcpListener,
     path::PathBuf,
     sync::Arc,
-    time::Duration,
 };
 
 use anyhow::{Result, bail};
@@ -18,11 +17,9 @@ use parking_lot::Mutex;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::{
-    DeviceService, DeviceServiceEndpoint, DeviceServiceSnapshot, ServiceAccess,
-    ServiceAccessEndpoint, Services, controls::TcpTunnelingControl,
+    DeviceService, DeviceServiceEndpoint, ServiceAccess, ServiceAccessEndpoint, Services,
+    controls::TcpTunnelingControl,
 };
-
-const STARTUP_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Default)]
 struct ServiceAccessRuntimeState {
@@ -636,24 +633,14 @@ pub(crate) async fn restore_saved_service_accesses(
 async fn refresh_devices<F, Fut>(
     peer_ids: impl IntoIterator<Item = PeerId>,
     refresh: F,
-) -> Vec<(PeerId, Result<DeviceServiceSnapshot>)>
+) -> Vec<(PeerId, Result<crate::DeviceServiceSnapshot>)>
 where
     F: Fn(PeerId) -> Fut,
-    Fut: Future<Output = Result<DeviceServiceSnapshot>>,
+    Fut: Future<Output = Result<crate::DeviceServiceSnapshot>>,
 {
     join_all(peer_ids.into_iter().map(|peer_id| {
         let refresh = &refresh;
-        async move {
-            let result = tokio::time::timeout(STARTUP_SERVICE_REFRESH_TIMEOUT, refresh(peer_id))
-                .await
-                .unwrap_or_else(|_| {
-                    Err(anyhow::anyhow!(
-                        "timed out after {} seconds",
-                        STARTUP_SERVICE_REFRESH_TIMEOUT.as_secs()
-                    ))
-                });
-            (peer_id, result)
-        }
+        async move { (peer_id, refresh(peer_id).await) }
     }))
     .await
 }
@@ -722,7 +709,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn startup_refresh_polls_all_devices_concurrently() {
+    async fn startup_refresh_polls_all_devices_concurrently_without_a_cap() {
         let device_count = 32;
         let started = Arc::new(AtomicUsize::new(0));
         let release = Arc::new(Semaphore::new(0));
@@ -731,21 +718,21 @@ mod tests {
             .collect::<Vec<_>>();
         let refresh_started = started.clone();
         let refresh_release = release.clone();
-        let refresh_task = tokio::spawn(refresh_devices(peer_ids, move |_| {
+        let refresh_task = tokio::spawn(refresh_devices(peer_ids, move |peer_id| {
             let started = refresh_started.clone();
             let release = refresh_release.clone();
             async move {
                 started.fetch_add(1, Ordering::SeqCst);
                 let _permit = release.acquire().await.unwrap();
-                Ok(DeviceServiceSnapshot {
-                    peer_id: PeerId::random().to_string(),
+                Ok(crate::DeviceServiceSnapshot {
+                    peer_id: peer_id.to_string(),
                     services: Vec::new(),
                     updated_at: std::time::SystemTime::now(),
                 })
             }
         }));
 
-        tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while started.load(Ordering::SeqCst) != device_count {
                 tokio::task::yield_now().await;
             }
@@ -756,16 +743,5 @@ mod tests {
         release.add_permits(device_count);
         let results = refresh_task.await.unwrap();
         assert_eq!(results.len(), device_count);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn startup_refresh_times_out_each_device_after_fifteen_seconds() {
-        let results = refresh_devices([PeerId::random()], |_| {
-            std::future::pending::<Result<DeviceServiceSnapshot>>()
-        })
-        .await;
-
-        let error = results.into_iter().next().unwrap().1.unwrap_err();
-        assert!(error.to_string().contains("timed out after 15 seconds"));
     }
 }

--- a/crates/daemon/src/service_access_manager.rs
+++ b/crates/daemon/src/service_access_manager.rs
@@ -1,0 +1,767 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    net::TcpListener as StdTcpListener,
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{Result, bail};
+use fungi_config::{
+    local_preferences::{LocalPortSource, LocalPreferenceCache, LocalServicePreference},
+    tcp_tunneling::ForwardingRule,
+};
+use futures::future::join_all;
+use libp2p::PeerId;
+use parking_lot::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::{
+    DeviceService, DeviceServiceEndpoint, DeviceServiceSnapshot, ServiceAccess,
+    ServiceAccessEndpoint, controls::TcpTunnelingControl, devices::Devices,
+};
+
+const STARTUP_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Default)]
+struct ServiceAccessRuntimeState {
+    /// Session-only overrides. Persistent preferences remain intact so a daemon restart restores
+    /// an explicitly detached access, matching the existing CLI behavior.
+    detached_services: BTreeSet<(String, String)>,
+}
+
+struct ServiceAccessManagerInner {
+    fungi_dir: PathBuf,
+    tcp_tunneling: TcpTunnelingControl,
+    /// Serializes preference read/modify/write sequences and listener replacement.
+    operations: AsyncMutex<()>,
+    runtime_state: Mutex<ServiceAccessRuntimeState>,
+}
+
+/// Owns local service-access preferences and their active forwarding listeners.
+#[derive(Clone)]
+pub(crate) struct ServiceAccessManager {
+    inner: Arc<ServiceAccessManagerInner>,
+}
+
+impl ServiceAccessManager {
+    pub(crate) fn new(fungi_dir: PathBuf, tcp_tunneling: TcpTunnelingControl) -> Self {
+        Self {
+            inner: Arc::new(ServiceAccessManagerInner {
+                fungi_dir,
+                tcp_tunneling,
+                operations: AsyncMutex::new(()),
+                runtime_state: Mutex::new(ServiceAccessRuntimeState::default()),
+            }),
+        }
+    }
+
+    pub(crate) fn forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
+        self.inner.tcp_tunneling.get_forwarding_rules()
+    }
+
+    pub(crate) async fn attach(
+        &self,
+        peer_id: PeerId,
+        service: DeviceService,
+        entry: Option<String>,
+        local_port: Option<u16>,
+    ) -> Result<ServiceAccess> {
+        if service.endpoints.is_empty() {
+            bail!(
+                "remote service exposes no named TCP endpoints: {}",
+                service.name
+            );
+        }
+
+        if local_port.is_some() && service.endpoints.len() > 1 && entry.is_none() {
+            bail!("choose a service entry before assigning a fixed local port");
+        }
+
+        let _operation = self.inner.operations.lock().await;
+        let peer_id_string = peer_id.to_string();
+        let mut local_preferences = self.local_preferences()?;
+        let mut active_rules = self.forwarding_rules();
+        let mut reserved_local_ports = local_preferences
+            .records
+            .iter()
+            .map(|record| record.local_port)
+            .chain(active_rules.iter().map(|(_, rule)| rule.local_port))
+            .collect::<BTreeSet<_>>();
+        let mut enabled_endpoints = Vec::new();
+        let endpoints = service
+            .endpoints
+            .into_iter()
+            .filter(|endpoint| {
+                entry
+                    .as_deref()
+                    .map(|entry| endpoint.name == entry)
+                    .unwrap_or(true)
+            })
+            .collect::<Vec<_>>();
+
+        if endpoints.is_empty() {
+            let entry = entry.unwrap_or_else(|| "default".to_string());
+            bail!("remote service entry not found: {entry}");
+        }
+
+        for endpoint in endpoints {
+            let existing_record = local_preferences
+                .find_record(&peer_id_string, &service.name, &endpoint.name)
+                .cloned();
+            let existing_active_rule = find_active_rule(
+                &active_rules,
+                &peer_id_string,
+                &service.name,
+                &endpoint.name,
+            );
+
+            if let Some(record) = &existing_record {
+                reserved_local_ports.remove(&record.local_port);
+            }
+            if let Some((_, rule)) = &existing_active_rule {
+                reserved_local_ports.remove(&rule.local_port);
+            }
+
+            let selected_local_port = match (local_port, existing_record.as_ref()) {
+                (Some(local_port), _) => local_port,
+                (None, Some(record)) => record.local_port,
+                (None, None) => allocate_free_local_port(&reserved_local_ports)?,
+            };
+            let local_port_source = if local_port.is_some() {
+                LocalPortSource::User
+            } else {
+                existing_record
+                    .as_ref()
+                    .map(|record| record.local_port_source)
+                    .unwrap_or_default()
+            };
+
+            let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
+                rule.local_host == "127.0.0.1"
+                    && rule.local_port == selected_local_port
+                    && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
+            });
+            let active_rule_owns_selected_port =
+                existing_active_rule.as_ref().is_some_and(|(_, rule)| {
+                    rule.local_host == "127.0.0.1" && rule.local_port == selected_local_port
+                });
+
+            if !active_rule_matches && !active_rule_owns_selected_port {
+                ensure_local_port_available(selected_local_port, &reserved_local_ports)?;
+            }
+
+            let record = LocalServicePreference {
+                remote_peer_id: peer_id_string.clone(),
+                remote_service_name: service.name.clone(),
+                remote_service_port_name: endpoint.name.clone(),
+                local_host: "127.0.0.1".to_string(),
+                local_port: selected_local_port,
+                local_port_source,
+            };
+            let updated_local_preferences =
+                local_preferences.with_upserted_record(record.clone())?;
+
+            let mut removed_active_rule = None;
+            let mut started_rule_id = None;
+            if !active_rule_matches {
+                if let Some((rule_id, rule)) = existing_active_rule {
+                    self.remove_forwarding_rule(&rule_id)?;
+                    removed_active_rule = Some(rule);
+                }
+
+                match self
+                    .start_forwarding_rule(&record, endpoint.protocol.clone())
+                    .await
+                {
+                    Ok(rule_id) => started_rule_id = Some(rule_id),
+                    Err(error) => {
+                        if let Some(rule) = removed_active_rule {
+                            self.restore_forwarding_rule_if_attached(rule).await;
+                        }
+                        return Err(error);
+                    }
+                }
+            }
+
+            if let Err(error) = updated_local_preferences.save_to_file() {
+                if let Some(rule_id) = started_rule_id
+                    && let Err(rollback_error) = self.remove_forwarding_rule(&rule_id)
+                {
+                    log::warn!(
+                        "Failed to roll back service access listener after save failure: {rollback_error}"
+                    );
+                }
+                if let Some(rule) = removed_active_rule {
+                    self.restore_forwarding_rule_if_attached(rule).await;
+                }
+                return Err(error);
+            }
+
+            local_preferences = updated_local_preferences;
+            if !active_rule_matches {
+                active_rules = self.forwarding_rules();
+            }
+            reserved_local_ports.insert(selected_local_port);
+            enabled_endpoints.push(ServiceAccessEndpoint {
+                name: endpoint.name,
+                protocol: endpoint.protocol,
+                local_host: record.local_host,
+                local_port: record.local_port,
+            });
+        }
+
+        enabled_endpoints.sort_by(|left, right| left.name.cmp(&right.name));
+        self.clear_detached(&peer_id_string, &service.name);
+        Ok(ServiceAccess {
+            peer_id: peer_id_string,
+            service_name: service.name,
+            endpoints: enabled_endpoints,
+        })
+    }
+
+    pub(crate) fn detach(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
+        let peer_id = peer_id.to_string();
+        self.inner
+            .runtime_state
+            .lock()
+            .detached_services
+            .insert((peer_id.clone(), service_name.to_string()));
+        self.remove_matching_rules(&peer_id, Some(service_name))
+    }
+
+    pub(crate) async fn forget_service(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
+        let _operation = self.inner.operations.lock().await;
+        let peer_id = peer_id.to_string();
+        self.inner
+            .runtime_state
+            .lock()
+            .detached_services
+            .insert((peer_id.clone(), service_name.to_string()));
+        self.remove_matching_rules(&peer_id, Some(service_name))?;
+        self.local_preferences()?
+            .remove_service_records(&peer_id, service_name)?;
+        Ok(())
+    }
+
+    pub(crate) async fn forget_device(&self, peer_id: PeerId) -> Result<()> {
+        let _operation = self.inner.operations.lock().await;
+        let peer_id = peer_id.to_string();
+        let preferences = self.local_preferences()?;
+        {
+            let mut state = self.inner.runtime_state.lock();
+            for record in &preferences.records {
+                if record.remote_peer_id == peer_id {
+                    state
+                        .detached_services
+                        .insert((peer_id.clone(), record.remote_service_name.clone()));
+                }
+            }
+        }
+        self.remove_matching_rules(&peer_id, None)?;
+        preferences.remove_device_records(&peer_id)?;
+        Ok(())
+    }
+
+    pub(crate) async fn saved_entries(
+        &self,
+        peer_id: PeerId,
+        service_name: &str,
+    ) -> Result<BTreeSet<String>> {
+        let _operation = self.inner.operations.lock().await;
+        let peer_id = peer_id.to_string();
+        Ok(self
+            .local_preferences()?
+            .records
+            .into_iter()
+            .filter(|record| {
+                record.remote_peer_id == peer_id && record.remote_service_name == service_name
+            })
+            .map(|record| record.remote_service_port_name)
+            .collect())
+    }
+
+    pub(crate) async fn list(&self, peer_id: Option<PeerId>) -> Result<Vec<ServiceAccess>> {
+        let _operation = self.inner.operations.lock().await;
+        let peer_filter = peer_id.map(|peer_id| peer_id.to_string());
+        let mut grouped = BTreeMap::<(String, String), Vec<ServiceAccessEndpoint>>::new();
+
+        for record in self.local_preferences()?.records {
+            if let Some(peer_filter) = &peer_filter
+                && &record.remote_peer_id != peer_filter
+            {
+                continue;
+            }
+
+            grouped
+                .entry((
+                    record.remote_peer_id.clone(),
+                    record.remote_service_name.clone(),
+                ))
+                .or_default()
+                .push(ServiceAccessEndpoint {
+                    name: record.remote_service_port_name,
+                    protocol: String::new(),
+                    local_host: record.local_host,
+                    local_port: record.local_port,
+                });
+        }
+
+        let mut services = grouped
+            .into_iter()
+            .map(|((peer_id, service_name), mut endpoints)| {
+                endpoints.sort_by(|left, right| left.name.cmp(&right.name));
+                ServiceAccess {
+                    peer_id,
+                    service_name,
+                    endpoints,
+                }
+            })
+            .collect::<Vec<_>>();
+        services.sort_by(|left, right| {
+            left.peer_id
+                .cmp(&right.peer_id)
+                .then(left.service_name.cmp(&right.service_name))
+        });
+        Ok(services)
+    }
+
+    pub(crate) async fn preference_records(&self) -> Result<Vec<LocalServicePreference>> {
+        let _operation = self.inner.operations.lock().await;
+        Ok(self.local_preferences()?.records)
+    }
+
+    async fn restore_from_cached_snapshots(&self, devices: &Devices) {
+        let records = match self.preference_records().await {
+            Ok(records) => records,
+            Err(error) => {
+                log::warn!("Failed to read local service access preferences: {error}");
+                return;
+            }
+        };
+
+        self.restore_records_from_cached_snapshots(&records, devices)
+            .await;
+    }
+
+    pub(crate) async fn restore_records_from_cached_snapshots(
+        &self,
+        records: &[LocalServicePreference],
+        devices: &Devices,
+    ) {
+        for candidate in records {
+            let peer_id = match candidate.remote_peer_id.parse::<PeerId>() {
+                Ok(peer_id) => peer_id,
+                Err(error) => {
+                    log::warn!(
+                        "Skipping service access restore for invalid peer id '{}': {error}",
+                        candidate.remote_peer_id
+                    );
+                    continue;
+                }
+            };
+            let snapshot = match devices.peer(peer_id).services().snapshot() {
+                Ok(Some(snapshot)) => snapshot,
+                Ok(None) => {
+                    log::debug!(
+                        "No cached device service snapshot for {}; skipping service access restore",
+                        candidate.remote_peer_id
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Failed to load cached device service snapshot for {}: {error}",
+                        candidate.remote_peer_id
+                    );
+                    continue;
+                }
+            };
+
+            let Some(endpoint) = snapshot
+                .services
+                .iter()
+                .find(|service| service.name == candidate.remote_service_name)
+                .and_then(|service| {
+                    service
+                        .endpoints
+                        .iter()
+                        .find(|endpoint| endpoint.name == candidate.remote_service_port_name)
+                })
+            else {
+                log::warn!(
+                    "Cached service metadata for {} does not include {} entry {}; skipping service access restore",
+                    candidate.remote_peer_id,
+                    candidate.remote_service_name,
+                    candidate.remote_service_port_name
+                );
+                continue;
+            };
+
+            if let Err(error) = self.restore_current_record(candidate, endpoint).await {
+                log::warn!(
+                    "Failed to restore local listener for {}@{} entry {} on {}:{}: {error}",
+                    candidate.remote_service_name,
+                    candidate.remote_peer_id,
+                    candidate.remote_service_port_name,
+                    candidate.local_host,
+                    candidate.local_port
+                );
+            }
+        }
+    }
+
+    async fn restore_current_record(
+        &self,
+        candidate: &LocalServicePreference,
+        endpoint: &DeviceServiceEndpoint,
+    ) -> Result<()> {
+        let _operation = self.inner.operations.lock().await;
+        if self.is_detached(&candidate.remote_peer_id, &candidate.remote_service_name) {
+            log::debug!(
+                "Skipping detached service access restore for {}@{}",
+                candidate.remote_service_name,
+                candidate.remote_peer_id
+            );
+            return Ok(());
+        }
+
+        let preferences = self.local_preferences()?;
+        let Some(current_record) = preferences
+            .find_record(
+                &candidate.remote_peer_id,
+                &candidate.remote_service_name,
+                &candidate.remote_service_port_name,
+            )
+            .cloned()
+        else {
+            log::debug!(
+                "Skipping stale service access restore for {}@{} entry {}",
+                candidate.remote_service_name,
+                candidate.remote_peer_id,
+                candidate.remote_service_port_name
+            );
+            return Ok(());
+        };
+
+        self.restore_forwarding_record(&current_record, endpoint)
+            .await
+    }
+
+    async fn restore_forwarding_record(
+        &self,
+        record: &LocalServicePreference,
+        endpoint: &DeviceServiceEndpoint,
+    ) -> Result<()> {
+        let existing_active_rule = find_active_rule(
+            &self.forwarding_rules(),
+            &record.remote_peer_id,
+            &record.remote_service_name,
+            &record.remote_service_port_name,
+        );
+        let active_rule_matches = existing_active_rule.as_ref().is_some_and(|(_, rule)| {
+            rule.local_host == record.local_host
+                && rule.local_port == record.local_port
+                && rule.remote_protocol.as_deref() == Some(endpoint.protocol.as_str())
+        });
+        if active_rule_matches {
+            return Ok(());
+        }
+
+        let mut removed_active_rule = None;
+        if let Some((rule_id, rule)) = existing_active_rule {
+            self.remove_forwarding_rule(&rule_id)?;
+            removed_active_rule = Some(rule);
+        }
+
+        match self
+            .start_forwarding_rule(record, endpoint.protocol.clone())
+            .await
+        {
+            Ok(rule_id) => {
+                // `detach` remains synchronous for Rust API compatibility and can race this
+                // background operation on another executor thread. Re-check after insertion so
+                // every ordering converges to a detached listener being absent.
+                if self.is_detached(&record.remote_peer_id, &record.remote_service_name) {
+                    let _ = self.remove_forwarding_rule(&rule_id);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if let Some(rule) = removed_active_rule {
+                    self.restore_forwarding_rule_if_attached(rule).await;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    async fn start_forwarding_rule(
+        &self,
+        record: &LocalServicePreference,
+        remote_protocol: String,
+    ) -> Result<String> {
+        let rule = ForwardingRule {
+            local_host: record.local_host.clone(),
+            local_port: record.local_port,
+            remote_peer_id: record.remote_peer_id.clone(),
+            remote_protocol: Some(remote_protocol),
+            remote_port: None,
+            remote_service_id: None,
+            remote_service_name: Some(record.remote_service_name.clone()),
+            remote_service_port_name: Some(record.remote_service_port_name.clone()),
+        };
+        ensure_service_access_rule(&rule)?;
+        self.inner.tcp_tunneling.add_forwarding_rule(rule).await
+    }
+
+    async fn restore_forwarding_rule_if_attached(&self, rule: ForwardingRule) {
+        let Some(service_name) = rule.remote_service_name.as_deref() else {
+            return;
+        };
+        if self.is_detached(&rule.remote_peer_id, service_name) {
+            return;
+        }
+
+        match self
+            .inner
+            .tcp_tunneling
+            .add_forwarding_rule(rule.clone())
+            .await
+        {
+            Ok(rule_id) => {
+                if self.is_detached(&rule.remote_peer_id, service_name) {
+                    let _ = self.remove_forwarding_rule(&rule_id);
+                }
+            }
+            Err(error) => log::warn!(
+                "Failed to restore previous service access listener after attach failure: {error}"
+            ),
+        }
+    }
+
+    fn remove_forwarding_rule(&self, rule_id: &str) -> Result<()> {
+        self.inner.tcp_tunneling.remove_forwarding_rule(rule_id)
+    }
+
+    fn remove_matching_rules(&self, peer_id: &str, service_name: Option<&str>) -> Result<()> {
+        let rules_to_remove = self
+            .forwarding_rules()
+            .into_iter()
+            .filter(|(_, rule)| {
+                rule.remote_peer_id == peer_id
+                    && service_name
+                        .is_none_or(|name| rule.remote_service_name.as_deref() == Some(name))
+            })
+            .map(|(rule_id, _)| rule_id)
+            .collect::<Vec<_>>();
+
+        for rule_id in rules_to_remove {
+            self.remove_forwarding_rule(&rule_id)?;
+        }
+        Ok(())
+    }
+
+    fn local_preferences(&self) -> Result<LocalPreferenceCache> {
+        LocalPreferenceCache::apply_from_dir(&self.inner.fungi_dir)
+    }
+
+    fn is_detached(&self, peer_id: &str, service_name: &str) -> bool {
+        self.inner
+            .runtime_state
+            .lock()
+            .detached_services
+            .contains(&(peer_id.to_string(), service_name.to_string()))
+    }
+
+    fn clear_detached(&self, peer_id: &str, service_name: &str) {
+        self.inner
+            .runtime_state
+            .lock()
+            .detached_services
+            .remove(&(peer_id.to_string(), service_name.to_string()));
+    }
+}
+
+pub(crate) async fn restore_saved_service_accesses(
+    service_access: ServiceAccessManager,
+    devices: Devices,
+) {
+    service_access.restore_from_cached_snapshots(&devices).await;
+
+    let records = match service_access.preference_records().await {
+        Ok(records) => records,
+        Err(error) => {
+            log::warn!(
+                "Failed to read local service access preferences before remote refresh: {error}"
+            );
+            return;
+        }
+    };
+    let peer_ids = records
+        .into_iter()
+        .filter_map(|record| match record.remote_peer_id.parse::<PeerId>() {
+            Ok(peer_id) => Some(peer_id),
+            Err(error) => {
+                log::warn!(
+                    "Skipping service access refresh for invalid peer id '{}': {error}",
+                    record.remote_peer_id
+                );
+                None
+            }
+        })
+        .collect::<BTreeSet<_>>();
+
+    for (peer_id, result) in refresh_devices(peer_ids, |peer_id| {
+        let services = devices.peer(peer_id).services();
+        async move { services.refresh().await }
+    })
+    .await
+    {
+        if let Err(error) = result {
+            log::warn!(
+                "Failed to refresh device service snapshot during startup restore for {peer_id}: {error}"
+            );
+        }
+    }
+
+    service_access.restore_from_cached_snapshots(&devices).await;
+}
+
+async fn refresh_devices<F, Fut>(
+    peer_ids: impl IntoIterator<Item = PeerId>,
+    refresh: F,
+) -> Vec<(PeerId, Result<DeviceServiceSnapshot>)>
+where
+    F: Fn(PeerId) -> Fut,
+    Fut: Future<Output = Result<DeviceServiceSnapshot>>,
+{
+    join_all(peer_ids.into_iter().map(|peer_id| {
+        let refresh = &refresh;
+        async move {
+            let result = tokio::time::timeout(STARTUP_SERVICE_REFRESH_TIMEOUT, refresh(peer_id))
+                .await
+                .unwrap_or_else(|_| {
+                    Err(anyhow::anyhow!(
+                        "timed out after {} seconds",
+                        STARTUP_SERVICE_REFRESH_TIMEOUT.as_secs()
+                    ))
+                });
+            (peer_id, result)
+        }
+    }))
+    .await
+}
+
+fn ensure_service_access_rule(rule: &ForwardingRule) -> Result<()> {
+    if rule
+        .remote_service_name
+        .as_deref()
+        .is_none_or(str::is_empty)
+        || rule
+            .remote_service_port_name
+            .as_deref()
+            .is_none_or(str::is_empty)
+    {
+        bail!("service access forwarding rules require remote service metadata");
+    }
+    Ok(())
+}
+
+fn find_active_rule(
+    active_rules: &[(String, ForwardingRule)],
+    remote_peer_id: &str,
+    remote_service_name: &str,
+    remote_service_port_name: &str,
+) -> Option<(String, ForwardingRule)> {
+    active_rules
+        .iter()
+        .find(|(_, rule)| {
+            rule.remote_peer_id == remote_peer_id
+                && rule.remote_service_name.as_deref() == Some(remote_service_name)
+                && rule.remote_service_port_name.as_deref() == Some(remote_service_port_name)
+        })
+        .cloned()
+}
+
+fn ensure_local_port_available(port: u16, reserved_ports: &BTreeSet<u16>) -> Result<()> {
+    if reserved_ports.contains(&port) {
+        bail!("local port is already reserved by another service access: {port}");
+    }
+    StdTcpListener::bind(("127.0.0.1", port))
+        .map(|_| ())
+        .map_err(|error| anyhow::anyhow!("local port {port} is not available: {error}"))
+}
+
+fn allocate_free_local_port(reserved_ports: &BTreeSet<u16>) -> Result<u16> {
+    for _ in 0..32 {
+        let listener = StdTcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        if !reserved_ports.contains(&port) {
+            return Ok(port);
+        }
+    }
+
+    bail!("failed to allocate a free local TCP port for remote service access")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use tokio::sync::Semaphore;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn startup_refresh_polls_all_devices_concurrently() {
+        let device_count = 32;
+        let started = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(Semaphore::new(0));
+        let peer_ids = (0..device_count)
+            .map(|_| PeerId::random())
+            .collect::<Vec<_>>();
+        let refresh_started = started.clone();
+        let refresh_release = release.clone();
+        let refresh_task = tokio::spawn(refresh_devices(peer_ids, move |_| {
+            let started = refresh_started.clone();
+            let release = refresh_release.clone();
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                let _permit = release.acquire().await.unwrap();
+                Ok(DeviceServiceSnapshot {
+                    peer_id: PeerId::random().to_string(),
+                    services: Vec::new(),
+                    updated_at: std::time::SystemTime::now(),
+                })
+            }
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while started.load(Ordering::SeqCst) != device_count {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("all device refreshes should be polled without a concurrency cap");
+
+        release.add_permits(device_count);
+        let results = refresh_task.await.unwrap();
+        assert_eq!(results.len(), device_count);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn startup_refresh_times_out_each_device_after_fifteen_seconds() {
+        let results = refresh_devices([PeerId::random()], |_| {
+            std::future::pending::<Result<DeviceServiceSnapshot>>()
+        })
+        .await;
+
+        let error = results.into_iter().next().unwrap().1.unwrap_err();
+        assert!(error.to_string().contains("timed out after 15 seconds"));
+    }
+}

--- a/crates/daemon/src/service_access_manager.rs
+++ b/crates/daemon/src/service_access_manager.rs
@@ -19,7 +19,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::{
     DeviceService, DeviceServiceEndpoint, DeviceServiceSnapshot, ServiceAccess,
-    ServiceAccessEndpoint, controls::TcpTunnelingControl, devices::Devices,
+    ServiceAccessEndpoint, Services, controls::TcpTunnelingControl,
 };
 
 const STARTUP_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
@@ -332,7 +332,7 @@ impl ServiceAccessManager {
         Ok(self.local_preferences()?.records)
     }
 
-    async fn restore_from_cached_snapshots(&self, devices: &Devices) {
+    async fn restore_from_cached_snapshots(&self, services: &Services) {
         let records = match self.preference_records().await {
             Ok(records) => records,
             Err(error) => {
@@ -341,14 +341,14 @@ impl ServiceAccessManager {
             }
         };
 
-        self.restore_records_from_cached_snapshots(&records, devices)
+        self.restore_records_from_cached_snapshots(&records, services)
             .await;
     }
 
     pub(crate) async fn restore_records_from_cached_snapshots(
         &self,
         records: &[LocalServicePreference],
-        devices: &Devices,
+        services: &Services,
     ) {
         for candidate in records {
             let peer_id = match candidate.remote_peer_id.parse::<PeerId>() {
@@ -361,7 +361,7 @@ impl ServiceAccessManager {
                     continue;
                 }
             };
-            let snapshot = match devices.peer(peer_id).services().snapshot() {
+            let snapshot = match services.for_device(peer_id).snapshot() {
                 Ok(Some(snapshot)) => snapshot,
                 Ok(None) => {
                     log::debug!(
@@ -586,9 +586,11 @@ impl ServiceAccessManager {
 
 pub(crate) async fn restore_saved_service_accesses(
     service_access: ServiceAccessManager,
-    devices: Devices,
+    services: Services,
 ) {
-    service_access.restore_from_cached_snapshots(&devices).await;
+    service_access
+        .restore_from_cached_snapshots(&services)
+        .await;
 
     let records = match service_access.preference_records().await {
         Ok(records) => records,
@@ -614,8 +616,8 @@ pub(crate) async fn restore_saved_service_accesses(
         .collect::<BTreeSet<_>>();
 
     for (peer_id, result) in refresh_devices(peer_ids, |peer_id| {
-        let services = devices.peer(peer_id).services();
-        async move { services.refresh().await }
+        let device_services = services.for_device(peer_id);
+        async move { device_services.refresh().await }
     })
     .await
     {
@@ -626,7 +628,9 @@ pub(crate) async fn restore_saved_service_accesses(
         }
     }
 
-    service_access.restore_from_cached_snapshots(&devices).await;
+    service_access
+        .restore_from_cached_snapshots(&services)
+        .await;
 }
 
 async fn refresh_devices<F, Fut>(

--- a/crates/daemon/src/service_accesses.rs
+++ b/crates/daemon/src/service_accesses.rs
@@ -37,6 +37,9 @@ struct ServiceAccessesInner {
 }
 
 /// Owns local service-access preferences and their active forwarding listeners.
+///
+/// Persisted preferences express user intent; listeners are a runtime projection that can be
+/// restored from cached service metadata without making startup depend on remote availability.
 #[derive(Clone)]
 pub struct ServiceAccesses {
     inner: Arc<ServiceAccessesInner>,

--- a/crates/daemon/src/service_accesses.rs
+++ b/crates/daemon/src/service_accesses.rs
@@ -28,7 +28,7 @@ struct ServiceAccessRuntimeState {
     detached_services: BTreeSet<(String, String)>,
 }
 
-struct ServiceAccessManagerInner {
+struct ServiceAccessesInner {
     fungi_dir: PathBuf,
     tcp_tunneling: TcpTunnelingControl,
     /// Serializes preference read/modify/write sequences and listener replacement.
@@ -38,14 +38,14 @@ struct ServiceAccessManagerInner {
 
 /// Owns local service-access preferences and their active forwarding listeners.
 #[derive(Clone)]
-pub(crate) struct ServiceAccessManager {
-    inner: Arc<ServiceAccessManagerInner>,
+pub struct ServiceAccesses {
+    inner: Arc<ServiceAccessesInner>,
 }
 
-impl ServiceAccessManager {
+impl ServiceAccesses {
     pub(crate) fn new(fungi_dir: PathBuf, tcp_tunneling: TcpTunnelingControl) -> Self {
         Self {
-            inner: Arc::new(ServiceAccessManagerInner {
+            inner: Arc::new(ServiceAccessesInner {
                 fungi_dir,
                 tcp_tunneling,
                 operations: AsyncMutex::new(()),
@@ -54,11 +54,11 @@ impl ServiceAccessManager {
         }
     }
 
-    pub(crate) fn forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
+    pub fn forwarding_rules(&self) -> Vec<(String, ForwardingRule)> {
         self.inner.tcp_tunneling.get_forwarding_rules()
     }
 
-    pub(crate) async fn attach(
+    pub async fn attach(
         &self,
         peer_id: PeerId,
         service: DeviceService,
@@ -218,7 +218,7 @@ impl ServiceAccessManager {
         })
     }
 
-    pub(crate) fn detach(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
+    pub fn detach(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
         let peer_id = peer_id.to_string();
         self.inner
             .runtime_state
@@ -228,7 +228,7 @@ impl ServiceAccessManager {
         self.remove_matching_rules(&peer_id, Some(service_name))
     }
 
-    pub(crate) async fn forget_service(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
+    pub async fn forget_service(&self, peer_id: PeerId, service_name: &str) -> Result<()> {
         let _operation = self.inner.operations.lock().await;
         let peer_id = peer_id.to_string();
         self.inner
@@ -242,7 +242,7 @@ impl ServiceAccessManager {
         Ok(())
     }
 
-    pub(crate) async fn forget_device(&self, peer_id: PeerId) -> Result<()> {
+    pub async fn forget_device(&self, peer_id: PeerId) -> Result<()> {
         let _operation = self.inner.operations.lock().await;
         let peer_id = peer_id.to_string();
         let preferences = self.local_preferences()?;
@@ -279,7 +279,7 @@ impl ServiceAccessManager {
             .collect())
     }
 
-    pub(crate) async fn list(&self, peer_id: Option<PeerId>) -> Result<Vec<ServiceAccess>> {
+    pub async fn list(&self, peer_id: Option<PeerId>) -> Result<Vec<ServiceAccess>> {
         let _operation = self.inner.operations.lock().await;
         let peer_filter = peer_id.map(|peer_id| peer_id.to_string());
         let mut grouped = BTreeMap::<(String, String), Vec<ServiceAccessEndpoint>>::new();
@@ -582,7 +582,7 @@ impl ServiceAccessManager {
 }
 
 pub(crate) async fn restore_saved_service_accesses(
-    service_access: ServiceAccessManager,
+    service_access: ServiceAccesses,
     services: Services,
 ) {
     service_access

--- a/crates/daemon/src/service_endpoints.rs
+++ b/crates/daemon/src/service_endpoints.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use fungi_config::tcp_tunneling::ListeningRule;
+
+use crate::{
+    RuntimeControl, ServiceManifest, controls::TcpTunnelingControl,
+    runtime::service_expose_endpoint_bindings,
+};
+
+pub(crate) async fn sync_service_endpoint_listeners_by_name(
+    runtime: &RuntimeControl,
+    tcp_tunneling: &TcpTunnelingControl,
+    name: &str,
+    enabled: bool,
+) -> Result<()> {
+    let manifest = runtime.get_service_manifest(name);
+    sync_service_endpoint_listeners_for_manifest(tcp_tunneling, manifest.as_ref(), enabled).await
+}
+
+pub(crate) async fn sync_service_endpoint_listeners_for_manifest(
+    tcp_tunneling: &TcpTunnelingControl,
+    manifest: Option<&ServiceManifest>,
+    enabled: bool,
+) -> Result<()> {
+    let Some(manifest) = manifest else {
+        return Ok(());
+    };
+
+    let listening_rules = tcp_tunneling.get_listening_rules();
+    for endpoint in service_expose_endpoint_bindings(manifest) {
+        let existing_rule_id = listening_rules
+            .iter()
+            .find(|(_, rule)| {
+                rule.port == endpoint.host_port
+                    && rule.protocol.as_deref() == Some(endpoint.protocol.as_str())
+            })
+            .map(|(rule_id, _)| rule_id.clone());
+
+        if enabled {
+            if existing_rule_id.is_none() {
+                tcp_tunneling
+                    .add_listening_rule(ListeningRule {
+                        host: "127.0.0.1".to_string(),
+                        port: endpoint.host_port,
+                        protocol: Some(endpoint.protocol),
+                    })
+                    .await?;
+            }
+        } else if let Some(rule_id) = existing_rule_id {
+            tcp_tunneling.remove_listening_rule(&rule_id)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     future::Future,
     path::PathBuf,
     sync::Arc,
@@ -10,6 +10,7 @@ use anyhow::{Context as _, Result};
 use fungi_config::runtime::Runtime as RuntimeConfig;
 use fungi_config::service_cache::DeviceServiceSnapshotCache;
 use libp2p::PeerId;
+use parking_lot::Mutex;
 
 use crate::{
     DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceInstance, ServiceLogs,
@@ -37,9 +38,76 @@ struct RemoteServiceBackend {
     control: ServiceControlProtocolControl,
 }
 
+struct DeviceServiceSnapshots {
+    fungi_dir: PathBuf,
+    epochs: Mutex<HashMap<PeerId, u64>>,
+}
+
+impl DeviceServiceSnapshots {
+    fn new(fungi_dir: PathBuf) -> Self {
+        Self {
+            fungi_dir,
+            epochs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn get(&self, peer_id: PeerId) -> Result<Option<DeviceServiceSnapshot>> {
+        let Some(snapshot_json) = self
+            .cache()?
+            .get_device_snapshot_json(&peer_id.to_string())?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_str(&snapshot_json)
+            .map(Some)
+            .map_err(|error| {
+                anyhow::anyhow!("failed to decode cached device service snapshot: {error}")
+            })
+    }
+
+    fn epoch(&self, peer_id: PeerId) -> u64 {
+        self.epochs
+            .lock()
+            .get(&peer_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn save_if_current(
+        &self,
+        peer_id: PeerId,
+        expected_epoch: u64,
+        snapshot: &DeviceServiceSnapshot,
+    ) -> Result<bool> {
+        let epochs = self.epochs.lock();
+        if epochs.get(&peer_id).copied().unwrap_or_default() != expected_epoch {
+            return Ok(false);
+        }
+
+        let snapshot_json = serde_json::to_string(snapshot)?;
+        self.cache()?
+            .set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
+        Ok(true)
+    }
+
+    fn remove(&self, peer_id: PeerId) -> Result<bool> {
+        let mut epochs = self.epochs.lock();
+        let epoch = epochs.entry(peer_id).or_default();
+        *epoch = epoch
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("device service snapshot epoch overflow"))?;
+        self.cache()?.remove_device_snapshot(&peer_id.to_string())
+    }
+
+    fn cache(&self) -> Result<DeviceServiceSnapshotCache> {
+        DeviceServiceSnapshotCache::apply_from_dir(&self.fungi_dir)
+    }
+}
+
 struct ServicesInner {
     local_device_id: PeerId,
     fungi_dir: PathBuf,
+    snapshots: DeviceServiceSnapshots,
     local: LocalServiceBackend,
     remote: RemoteServiceBackend,
 }
@@ -62,10 +130,12 @@ pub struct Services {
 
 impl Services {
     pub(crate) fn new(init: ServicesInit) -> Self {
+        let snapshots = DeviceServiceSnapshots::new(init.fungi_dir.clone());
         Self {
             inner: Arc::new(ServicesInner {
                 local_device_id: init.local_device_id,
                 fungi_dir: init.fungi_dir,
+                snapshots,
                 local: LocalServiceBackend {
                     runtime: init.runtime,
                     docker: init.docker,
@@ -110,23 +180,11 @@ impl Services {
         &self.inner.local.tcp_tunneling
     }
 
-    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        let snapshot_json = serde_json::to_string(snapshot)?;
-        self.snapshot_cache()?
-            .set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
-        Ok(())
-    }
-
     pub(crate) fn remove_snapshot(&self, peer_id: PeerId) -> Result<bool> {
         if peer_id == self.inner.local_device_id {
             return Ok(false);
         }
-        self.snapshot_cache()?
-            .remove_device_snapshot(&peer_id.to_string())
-    }
-
-    fn snapshot_cache(&self) -> Result<DeviceServiceSnapshotCache> {
-        DeviceServiceSnapshotCache::apply_from_dir(&self.inner.fungi_dir)
+        self.inner.snapshots.remove(peer_id)
     }
 }
 
@@ -169,22 +227,15 @@ impl DeviceServices {
             return Ok(None);
         }
 
-        let cache = self.services.snapshot_cache()?;
-        let Some(snapshot_json) = cache.get_device_snapshot_json(&self.device_id.to_string())?
-        else {
-            return Ok(None);
-        };
-        serde_json::from_str(&snapshot_json)
-            .map(Some)
-            .map_err(|error| {
-                anyhow::anyhow!("failed to decode cached device service snapshot: {error}")
-            })
+        self.services.inner.snapshots.get(self.device_id)
     }
 
     /// Observes this device now. Remote successes replace the persisted shadow; local
     /// observations are returned directly without creating a redundant cache.
     pub async fn refresh(&self) -> Result<DeviceServiceSnapshot> {
         let peer_id = self.device_id;
+        let snapshot_epoch =
+            (!self.is_local()).then(|| self.services.inner.snapshots.epoch(peer_id));
         let snapshot = if self.is_local() {
             let (managed, published) = tokio::try_join!(
                 self.services.inner.local.runtime.list_services(),
@@ -230,8 +281,11 @@ impl DeviceServices {
             merge_device_service_snapshot(peer_id, managed, published)
         };
 
-        if !self.is_local() {
-            self.services.save_snapshot(&snapshot)?;
+        if let Some(snapshot_epoch) = snapshot_epoch {
+            self.services
+                .inner
+                .snapshots
+                .save_if_current(peer_id, snapshot_epoch, &snapshot)?;
         }
         Ok(snapshot)
     }
@@ -321,11 +375,8 @@ impl DeviceServices {
         }
     }
 
-    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        self.services.save_snapshot(snapshot)
-    }
-
     pub(crate) fn remove_cached_service(&self, name: &str) -> Result<bool> {
+        let snapshot_epoch = self.services.inner.snapshots.epoch(self.device_id);
         let Some(mut snapshot) = self.snapshot()? else {
             return Ok(false);
         };
@@ -334,7 +385,10 @@ impl DeviceServices {
         if snapshot.services.len() == before {
             return Ok(false);
         }
-        self.save_snapshot(&snapshot)?;
+        self.services
+            .inner
+            .snapshots
+            .save_if_current(self.device_id, snapshot_epoch, &snapshot)?;
         Ok(true)
     }
 
@@ -594,5 +648,40 @@ mod tests {
                 .to_string()
                 .contains("timed out after 15 seconds")
         );
+    }
+
+    #[test]
+    fn snapshot_removal_rejects_only_writes_started_before_removal() {
+        let fungi_dir = tempfile::tempdir().unwrap();
+        let snapshots = DeviceServiceSnapshots::new(fungi_dir.path().to_path_buf());
+        let peer_id = PeerId::random();
+        let snapshot = DeviceServiceSnapshot {
+            peer_id: peer_id.to_string(),
+            services: Vec::new(),
+            updated_at: SystemTime::now(),
+        };
+        let stale_epoch = snapshots.epoch(peer_id);
+
+        assert!(
+            snapshots
+                .save_if_current(peer_id, stale_epoch, &snapshot)
+                .unwrap()
+        );
+        assert!(snapshots.remove(peer_id).unwrap());
+
+        assert!(
+            !snapshots
+                .save_if_current(peer_id, stale_epoch, &snapshot)
+                .unwrap()
+        );
+        assert!(snapshots.get(peer_id).unwrap().is_none());
+
+        let current_epoch = snapshots.epoch(peer_id);
+        assert!(
+            snapshots
+                .save_if_current(peer_id, current_epoch, &snapshot)
+                .unwrap()
+        );
+        assert!(snapshots.get(peer_id).unwrap().is_some());
     }
 }

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -1,15 +1,14 @@
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::SystemTime};
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Result};
 use fungi_config::service_cache::DeviceServiceSnapshotCache;
 use libp2p::PeerId;
 
 use crate::{
-    DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceAccess, ServiceInstance,
-    ServiceLogs, ServiceLogsOptions,
+    DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceInstance, ServiceLogs,
+    ServiceLogsOptions,
     controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
     runtime::RuntimeControl,
-    service_access_manager::ServiceAccessManager,
     service_endpoints::{
         sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
     },
@@ -31,11 +30,6 @@ struct ServicesInner {
     fungi_dir: PathBuf,
     local: LocalServiceBackend,
     remote: RemoteServiceBackend,
-
-    // Transitional dependency. Service access becomes an independent FungiControl module in the
-    // next refactor step; keeping the handle here preserves current ServiceHandle behavior without
-    // leaving it in Devices.
-    service_access: ServiceAccessManager,
 }
 
 pub(crate) struct ServicesInit {
@@ -45,7 +39,6 @@ pub(crate) struct ServicesInit {
     pub service_discovery: ServiceDiscoveryControl,
     pub service_control: ServiceControlProtocolControl,
     pub tcp_tunneling: TcpTunnelingControl,
-    pub service_access: ServiceAccessManager,
 }
 
 /// Shared service domain for local and remote devices.
@@ -68,7 +61,6 @@ impl Services {
                     discovery: init.service_discovery,
                     control: init.service_control,
                 },
-                service_access: init.service_access,
             }),
         }
     }
@@ -385,25 +377,15 @@ impl ServiceHandle {
             return Ok(());
         }
 
-        let response = self
-            .services
+        self.services
             .inner
             .remote
             .control
             .start_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
-        let service_name = response
-            .service
-            .as_ref()
-            .map(|service| service.name.clone())
-            .unwrap_or_else(|| self.key.service_name.clone());
-        self.restore_saved_access_after_start(&service_name)
-            .await
-            .with_context(|| {
-                format!(
-                    "remote service started, but failed to restore saved local access listeners for {service_name}"
-                )
-            })?;
+        self.device_services()
+            .refresh_or_keep_after_mutation()
+            .await;
         Ok(())
     }
 
@@ -425,25 +407,12 @@ impl ServiceHandle {
             return Ok(());
         }
 
-        let response = self
-            .services
+        self.services
             .inner
             .remote
             .control
             .stop_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
-        let service_name = response
-            .service
-            .as_ref()
-            .map(|service| service.name.as_str())
-            .unwrap_or(self.key.service_name.as_str());
-        self.services.inner.service_access
-            .detach(self.key.device_id, service_name)
-            .with_context(|| {
-                format!(
-                    "remote service stopped, but failed to disconnect local access listeners for {service_name}"
-                )
-            })?;
         self.device_services()
             .refresh_or_keep_after_mutation()
             .await;
@@ -473,26 +442,12 @@ impl ServiceHandle {
             return Ok(());
         }
 
-        let response = self
-            .services
+        self.services
             .inner
             .remote
             .control
             .remove_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
-        let service_name = response
-            .service
-            .as_ref()
-            .map(|service| service.name.as_str())
-            .unwrap_or(self.key.service_name.as_str());
-        self.services.inner.service_access
-            .forget_service(self.key.device_id, service_name)
-            .await
-            .with_context(|| {
-                format!(
-                    "remote service removed, but failed to forget local access records for {service_name}"
-                )
-            })?;
         self.device_services()
             .refresh_or_keep_after_mutation()
             .await;
@@ -534,88 +489,9 @@ impl ServiceHandle {
         })
     }
 
-    pub async fn attach_access(
-        &self,
-        entry: Option<String>,
-        local_port: Option<u16>,
-    ) -> Result<ServiceAccess> {
-        self.ensure_remote_access()?;
-        let snapshot = self.device_services().refresh().await.map_err(|error| {
-            anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
-        })?;
-        let service = find_service(snapshot, &self.key.service_name).ok_or_else(|| {
-            anyhow::anyhow!("remote service not found: {}", self.key.service_name)
-        })?;
-        self.services
-            .inner
-            .service_access
-            .attach(self.key.device_id, service, entry, local_port)
-            .await
-    }
-
-    pub fn detach_access(&self) -> Result<()> {
-        self.ensure_remote_access()?;
-        self.services
-            .inner
-            .service_access
-            .detach(self.key.device_id, &self.key.service_name)
-    }
-
-    pub async fn forget_access(&self) -> Result<()> {
-        self.ensure_remote_access()?;
-        self.services
-            .inner
-            .service_access
-            .forget_service(self.key.device_id, &self.key.service_name)
-            .await
-    }
-
-    pub async fn forget_cached_observation(&self) -> Result<bool> {
-        self.ensure_remote_access()?;
-        let removed = self
-            .device_services()
-            .remove_cached_service(&self.key.service_name)?;
-        if removed {
-            self.forget_access().await?;
-        }
-        Ok(removed)
-    }
-
-    async fn restore_saved_access_after_start(&self, service_name: &str) -> Result<()> {
-        let saved_entries = self
-            .services
-            .inner
-            .service_access
-            .saved_entries(self.key.device_id, service_name)
-            .await?;
-        let snapshot = self.device_services().refresh().await;
-        if saved_entries.is_empty() {
-            if let Err(error) = snapshot {
-                log::warn!(
-                    "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
-                    self.key.device_id
-                );
-            }
-            return Ok(());
-        }
-
-        let service = find_service(snapshot?, service_name)
-            .ok_or_else(|| anyhow::anyhow!("remote service not found: {service_name}"))?;
-        for entry in saved_entries {
-            self.services
-                .inner
-                .service_access
-                .attach(self.key.device_id, service.clone(), Some(entry), None)
-                .await?;
-        }
-        Ok(())
-    }
-
-    fn ensure_remote_access(&self) -> Result<()> {
-        if self.is_local() {
-            bail!("local services do not use remote service access listeners");
-        }
-        Ok(())
+    pub(crate) fn forget_cached_observation(&self) -> Result<bool> {
+        self.device_services()
+            .remove_cached_service(&self.key.service_name)
     }
 }
 

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -8,7 +8,6 @@ use crate::{
     DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceAccess, ServiceInstance,
     ServiceLogs, ServiceLogsOptions,
     controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
-    devices::DeviceHandle,
     runtime::RuntimeControl,
     service_access_manager::ServiceAccessManager,
     service_endpoints::{
@@ -74,10 +73,9 @@ impl Services {
         }
     }
 
-    pub(crate) fn for_device(&self, device: DeviceHandle) -> DeviceServices {
-        debug_assert_eq!(device.is_local(), device.id() == self.inner.local_device_id);
+    pub fn for_device(&self, device_id: PeerId) -> DeviceServices {
         DeviceServices {
-            device,
+            device_id,
             services: self.clone(),
         }
     }
@@ -118,28 +116,38 @@ impl Services {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ServiceKey {
+    pub device_id: PeerId,
+    pub service_name: String,
+}
+
 /// Collection and observation boundary for one device's services.
 #[derive(Clone)]
 pub struct DeviceServices {
-    device: DeviceHandle,
+    device_id: PeerId,
     services: Services,
 }
 
 impl DeviceServices {
-    pub fn device(&self) -> &DeviceHandle {
-        &self.device
+    pub fn device_id(&self) -> PeerId {
+        self.device_id
+    }
+
+    fn is_local(&self) -> bool {
+        self.device_id == self.services.inner.local_device_id
     }
 
     /// Reads the last successful remote observation without network access.
     ///
     /// Local services do not maintain a stale shadow, so this returns `None` for the local device.
     pub fn snapshot(&self) -> Result<Option<DeviceServiceSnapshot>> {
-        if self.device.is_local() {
+        if self.is_local() {
             return Ok(None);
         }
 
         let cache = self.services.snapshot_cache()?;
-        let Some(snapshot_json) = cache.get_device_snapshot_json(&self.device.id().to_string())?
+        let Some(snapshot_json) = cache.get_device_snapshot_json(&self.device_id.to_string())?
         else {
             return Ok(None);
         };
@@ -153,8 +161,8 @@ impl DeviceServices {
     /// Observes this device now. Remote successes replace the persisted shadow; local
     /// observations are returned directly without creating a redundant cache.
     pub async fn refresh(&self) -> Result<DeviceServiceSnapshot> {
-        let peer_id = self.device.id();
-        let snapshot = if self.device.is_local() {
+        let peer_id = self.device_id;
+        let snapshot = if self.is_local() {
             let (managed, published) = tokio::try_join!(
                 self.services.inner.local.runtime.list_services(),
                 self.services
@@ -196,7 +204,7 @@ impl DeviceServices {
             merge_device_service_snapshot(peer_id, managed, published)
         };
 
-        if !self.device.is_local() {
+        if !self.is_local() {
             self.services.save_snapshot(&snapshot)?;
         }
         Ok(snapshot)
@@ -208,7 +216,7 @@ impl DeviceServices {
 
     /// Lists only endpoints published for connection, without the managed-service merge.
     pub async fn published(&self) -> Result<Vec<DeviceService>> {
-        if self.device.is_local() {
+        if self.is_local() {
             self.services
                 .inner
                 .local
@@ -220,16 +228,18 @@ impl DeviceServices {
                 .inner
                 .remote
                 .discovery
-                .list_peer_services(self.device.id())
+                .list_peer_services(self.device_id)
                 .await
         }
     }
 
     pub fn service(&self, name: impl Into<String>) -> ServiceHandle {
         ServiceHandle {
-            device: self.device.clone(),
+            key: ServiceKey {
+                device_id: self.device_id,
+                service_name: name.into(),
+            },
             services: self.services.clone(),
-            name: name.into(),
         }
     }
 
@@ -238,7 +248,7 @@ impl DeviceServices {
         manifest_yaml: String,
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceHandle> {
-        if self.device.is_local() {
+        if self.is_local() {
             let fungi_home = self.services.inner.fungi_dir.clone();
             let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
             let applied = self
@@ -275,7 +285,7 @@ impl DeviceServices {
                 .inner
                 .remote
                 .control
-                .pull_peer_service(self.device.id(), manifest_yaml)
+                .pull_peer_service(self.device_id, manifest_yaml)
                 .await?;
             self.refresh_or_keep_after_mutation().await;
             let service_name = response
@@ -309,7 +319,7 @@ impl DeviceServices {
         if let Err(error) = self.refresh().await {
             log::warn!(
                 "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
-                self.device.id()
+                self.device_id
             );
         }
     }
@@ -319,49 +329,56 @@ impl DeviceServices {
 /// become stale; observation and mutation always go through the owning `DeviceServices`.
 #[derive(Clone)]
 pub struct ServiceHandle {
-    device: DeviceHandle,
+    key: ServiceKey,
     services: Services,
-    name: String,
 }
 
 impl ServiceHandle {
-    pub fn device(&self) -> &DeviceHandle {
-        &self.device
+    pub fn key(&self) -> &ServiceKey {
+        &self.key
+    }
+
+    pub fn device_id(&self) -> PeerId {
+        self.key.device_id
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        &self.key.service_name
     }
 
     fn device_services(&self) -> DeviceServices {
-        self.services.for_device(self.device.clone())
+        self.services.for_device(self.key.device_id)
+    }
+
+    fn is_local(&self) -> bool {
+        self.key.device_id == self.services.inner.local_device_id
     }
 
     pub fn observation(&self) -> Result<Option<DeviceService>> {
         Ok(self
             .device_services()
             .snapshot()?
-            .and_then(|snapshot| find_service(snapshot, &self.name)))
+            .and_then(|snapshot| find_service(snapshot, &self.key.service_name)))
     }
 
     pub async fn inspect(&self) -> Result<DeviceService> {
         let snapshot = self.device_services().refresh().await?;
-        find_service(snapshot, &self.name)
-            .ok_or_else(|| anyhow::anyhow!("service not found: {}", self.name))
+        find_service(snapshot, &self.key.service_name)
+            .ok_or_else(|| anyhow::anyhow!("service not found: {}", self.key.service_name))
     }
 
     pub async fn start(&self) -> Result<()> {
-        if self.device.is_local() {
+        if self.is_local() {
             self.services
                 .inner
                 .local
                 .runtime
-                .start_by_name(&self.name)
+                .start_by_name(&self.key.service_name)
                 .await?;
             sync_service_endpoint_listeners_by_name(
                 &self.services.inner.local.runtime,
                 &self.services.inner.local.tcp_tunneling,
-                &self.name,
+                &self.key.service_name,
                 true,
             )
             .await?;
@@ -373,13 +390,13 @@ impl ServiceHandle {
             .inner
             .remote
             .control
-            .start_peer_service(self.device.id(), self.name.clone())
+            .start_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
         let service_name = response
             .service
             .as_ref()
             .map(|service| service.name.clone())
-            .unwrap_or_else(|| self.name.clone());
+            .unwrap_or_else(|| self.key.service_name.clone());
         self.restore_saved_access_after_start(&service_name)
             .await
             .with_context(|| {
@@ -391,17 +408,17 @@ impl ServiceHandle {
     }
 
     pub async fn stop(&self) -> Result<()> {
-        if self.device.is_local() {
+        if self.is_local() {
             self.services
                 .inner
                 .local
                 .runtime
-                .stop_by_name(&self.name)
+                .stop_by_name(&self.key.service_name)
                 .await?;
             sync_service_endpoint_listeners_by_name(
                 &self.services.inner.local.runtime,
                 &self.services.inner.local.tcp_tunneling,
-                &self.name,
+                &self.key.service_name,
                 false,
             )
             .await?;
@@ -413,15 +430,15 @@ impl ServiceHandle {
             .inner
             .remote
             .control
-            .stop_peer_service(self.device.id(), self.name.clone())
+            .stop_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
         let service_name = response
             .service
             .as_ref()
             .map(|service| service.name.as_str())
-            .unwrap_or(self.name.as_str());
+            .unwrap_or(self.key.service_name.as_str());
         self.services.inner.service_access
-            .detach(self.device.id(), service_name)
+            .detach(self.key.device_id, service_name)
             .with_context(|| {
                 format!(
                     "remote service stopped, but failed to disconnect local access listeners for {service_name}"
@@ -434,18 +451,18 @@ impl ServiceHandle {
     }
 
     pub async fn remove(&self) -> Result<()> {
-        if self.device.is_local() {
+        if self.is_local() {
             let manifest = self
                 .services
                 .inner
                 .local
                 .runtime
-                .get_service_manifest(&self.name);
+                .get_service_manifest(&self.key.service_name);
             self.services
                 .inner
                 .local
                 .runtime
-                .remove_by_name(&self.name)
+                .remove_by_name(&self.key.service_name)
                 .await?;
             sync_service_endpoint_listeners_for_manifest(
                 &self.services.inner.local.tcp_tunneling,
@@ -461,15 +478,15 @@ impl ServiceHandle {
             .inner
             .remote
             .control
-            .remove_peer_service(self.device.id(), self.name.clone())
+            .remove_peer_service(self.key.device_id, self.key.service_name.clone())
             .await?;
         let service_name = response
             .service
             .as_ref()
             .map(|service| service.name.as_str())
-            .unwrap_or(self.name.as_str());
+            .unwrap_or(self.key.service_name.as_str());
         self.services.inner.service_access
-            .forget_service(self.device.id(), service_name)
+            .forget_service(self.key.device_id, service_name)
             .await
             .with_context(|| {
                 format!(
@@ -483,14 +500,14 @@ impl ServiceHandle {
     }
 
     pub async fn logs(&self, tail: Option<usize>) -> Result<ServiceLogs> {
-        if self.device.is_local() {
+        if self.is_local() {
             return self
                 .services
                 .inner
                 .local
                 .runtime
                 .logs_by_name(
-                    &self.name,
+                    &self.key.service_name,
                     &ServiceLogsOptions {
                         tail: tail.map(|tail| tail.to_string()),
                     },
@@ -506,7 +523,7 @@ impl ServiceHandle {
             .inner
             .remote
             .control
-            .get_peer_service_logs(self.device.id(), self.name.clone(), tail)
+            .get_peer_service_logs(self.key.device_id, self.key.service_name.clone(), tail)
             .await?;
         let text = response
             .logs_text
@@ -526,12 +543,13 @@ impl ServiceHandle {
         let snapshot = self.device_services().refresh().await.map_err(|error| {
             anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
         })?;
-        let service = find_service(snapshot, &self.name)
-            .ok_or_else(|| anyhow::anyhow!("remote service not found: {}", self.name))?;
+        let service = find_service(snapshot, &self.key.service_name).ok_or_else(|| {
+            anyhow::anyhow!("remote service not found: {}", self.key.service_name)
+        })?;
         self.services
             .inner
             .service_access
-            .attach(self.device.id(), service, entry, local_port)
+            .attach(self.key.device_id, service, entry, local_port)
             .await
     }
 
@@ -540,7 +558,7 @@ impl ServiceHandle {
         self.services
             .inner
             .service_access
-            .detach(self.device.id(), &self.name)
+            .detach(self.key.device_id, &self.key.service_name)
     }
 
     pub async fn forget_access(&self) -> Result<()> {
@@ -548,13 +566,15 @@ impl ServiceHandle {
         self.services
             .inner
             .service_access
-            .forget_service(self.device.id(), &self.name)
+            .forget_service(self.key.device_id, &self.key.service_name)
             .await
     }
 
     pub async fn forget_cached_observation(&self) -> Result<bool> {
         self.ensure_remote_access()?;
-        let removed = self.device_services().remove_cached_service(&self.name)?;
+        let removed = self
+            .device_services()
+            .remove_cached_service(&self.key.service_name)?;
         if removed {
             self.forget_access().await?;
         }
@@ -566,14 +586,14 @@ impl ServiceHandle {
             .services
             .inner
             .service_access
-            .saved_entries(self.device.id(), service_name)
+            .saved_entries(self.key.device_id, service_name)
             .await?;
         let snapshot = self.device_services().refresh().await;
         if saved_entries.is_empty() {
             if let Err(error) = snapshot {
                 log::warn!(
                     "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
-                    self.device.id()
+                    self.key.device_id
                 );
             }
             return Ok(());
@@ -585,14 +605,14 @@ impl ServiceHandle {
             self.services
                 .inner
                 .service_access
-                .attach(self.device.id(), service.clone(), Some(entry), None)
+                .attach(self.key.device_id, service.clone(), Some(entry), None)
                 .await?;
         }
         Ok(())
     }
 
     fn ensure_remote_access(&self) -> Result<()> {
-        if self.device.is_local() {
+        if self.is_local() {
             bail!("local services do not use remote service access listeners");
         }
         Ok(())

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::SystemTime};
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use anyhow::{Context as _, Result};
 use fungi_config::service_cache::DeviceServiceSnapshotCache;
@@ -14,6 +20,8 @@ use crate::{
     },
     service_state::DesiredServiceState,
 };
+
+const REMOTE_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
 
 struct LocalServiceBackend {
     runtime: RuntimeControl,
@@ -167,21 +175,24 @@ impl DeviceServices {
         } else {
             let control = self.services.inner.remote.control.clone();
             let discovery = self.services.inner.remote.discovery.clone();
-            let (managed_response, published) = tokio::try_join!(
-                async move {
-                    control.list_peer_services(peer_id).await.with_context(|| {
-                        format!("failed to refresh managed services for device {peer_id}")
-                    })
-                },
-                async move {
-                    discovery
-                        .list_peer_services(peer_id)
-                        .await
-                        .with_context(|| {
-                            format!("failed to refresh published services for device {peer_id}")
+            let (managed_response, published) = with_remote_refresh_timeout(async move {
+                tokio::try_join!(
+                    async move {
+                        control.list_peer_services(peer_id).await.with_context(|| {
+                            format!("failed to refresh managed services for device {peer_id}")
                         })
-                },
-            )?;
+                    },
+                    async move {
+                        discovery
+                            .list_peer_services(peer_id)
+                            .await
+                            .with_context(|| {
+                                format!("failed to refresh published services for device {peer_id}")
+                            })
+                    },
+                )
+            })
+            .await?;
             let managed = managed_response
                 .services_json
                 .as_deref()
@@ -536,4 +547,32 @@ fn find_service(snapshot: DeviceServiceSnapshot, name: &str) -> Option<DeviceSer
         .services
         .into_iter()
         .find(|service| service.name == name)
+}
+
+async fn with_remote_refresh_timeout<T>(refresh: impl Future<Output = Result<T>>) -> Result<T> {
+    tokio::time::timeout(REMOTE_SERVICE_REFRESH_TIMEOUT, refresh)
+        .await
+        .unwrap_or_else(|_| {
+            Err(anyhow::anyhow!(
+                "remote service refresh timed out after {} seconds",
+                REMOTE_SERVICE_REFRESH_TIMEOUT.as_secs()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn remote_refresh_times_out_after_fifteen_seconds() {
+        let result = with_remote_refresh_timeout(std::future::pending::<Result<()>>()).await;
+
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("timed out after 15 seconds")
+        );
+    }
 }

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -101,11 +101,8 @@ impl Services {
         Ok(())
     }
 
-    pub(crate) fn service_discovery(&self) -> &ServiceDiscoveryControl {
-        &self.inner.remote.discovery
-    }
-
-    pub(crate) fn service_control(&self) -> &ServiceControlProtocolControl {
+    /// Low-level protocol handle for focused integration tests.
+    pub fn service_control(&self) -> &ServiceControlProtocolControl {
         &self.inner.remote.control
     }
 

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -38,6 +38,10 @@ struct RemoteServiceBackend {
     control: ServiceControlProtocolControl,
 }
 
+/// Stores best-effort remote observations independently from device-directory membership.
+///
+/// Per-peer epochs let removal invalidate an older in-flight write without holding a lock during
+/// remote I/O. A later refresh may still create a new observation for an addressable peer.
 struct DeviceServiceSnapshots {
     fungi_dir: PathBuf,
     epochs: Mutex<HashMap<PeerId, u64>>,
@@ -123,6 +127,9 @@ pub(crate) struct ServicesInit {
 }
 
 /// Shared service domain for local and remote devices.
+///
+/// The same handles route local operations to runtime backends and remote operations to libp2p
+/// protocols. Remote status is a cached observation rather than authoritative state.
 #[derive(Clone)]
 pub struct Services {
     inner: Arc<ServicesInner>,

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -7,13 +7,16 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
+use fungi_config::runtime::Runtime as RuntimeConfig;
 use fungi_config::service_cache::DeviceServiceSnapshotCache;
 use libp2p::PeerId;
 
 use crate::{
     DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceInstance, ServiceLogs,
     ServiceLogsOptions,
-    controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
+    controls::{
+        DockerControl, ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl,
+    },
     runtime::RuntimeControl,
     service_endpoints::{
         sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
@@ -25,6 +28,7 @@ const REMOTE_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
 
 struct LocalServiceBackend {
     runtime: RuntimeControl,
+    docker: Option<DockerControl>,
     tcp_tunneling: TcpTunnelingControl,
 }
 
@@ -44,6 +48,7 @@ pub(crate) struct ServicesInit {
     pub local_device_id: PeerId,
     pub fungi_dir: PathBuf,
     pub runtime: RuntimeControl,
+    pub docker: Option<DockerControl>,
     pub service_discovery: ServiceDiscoveryControl,
     pub service_control: ServiceControlProtocolControl,
     pub tcp_tunneling: TcpTunnelingControl,
@@ -63,6 +68,7 @@ impl Services {
                 fungi_dir: init.fungi_dir,
                 local: LocalServiceBackend {
                     runtime: init.runtime,
+                    docker: init.docker,
                     tcp_tunneling: init.tcp_tunneling,
                 },
                 remote: RemoteServiceBackend {
@@ -82,6 +88,17 @@ impl Services {
 
     pub(crate) fn runtime(&self) -> &RuntimeControl {
         &self.inner.local.runtime
+    }
+
+    pub(crate) fn apply_runtime_config(&self, config: &RuntimeConfig) -> Result<()> {
+        if let Some(docker) = &self.inner.local.docker {
+            docker.update_runtime_config(config)?;
+        }
+        self.inner
+            .local
+            .runtime
+            .update_allowed_host_paths(config.allowed_host_paths.clone());
+        Ok(())
     }
 
     pub(crate) fn service_discovery(&self) -> &ServiceDiscoveryControl {
@@ -120,6 +137,15 @@ impl Services {
 pub struct ServiceKey {
     pub device_id: PeerId,
     pub service_name: String,
+}
+
+impl ServiceKey {
+    pub fn new(device_id: PeerId, service_name: impl Into<String>) -> Self {
+        Self {
+            device_id,
+            service_name: service_name.into(),
+        }
+    }
 }
 
 /// Collection and observation boundary for one device's services.
@@ -238,10 +264,7 @@ impl DeviceServices {
 
     pub fn service(&self, name: impl Into<String>) -> ServiceHandle {
         ServiceHandle {
-            key: ServiceKey {
-                device_id: self.device_id,
-                service_name: name.into(),
-            },
+            key: ServiceKey::new(self.device_id, name),
             services: self.services.clone(),
         }
     }

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -1,23 +1,128 @@
-use std::{collections::BTreeMap, path::PathBuf, time::SystemTime};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::SystemTime};
 
 use anyhow::{Context as _, Result, bail};
+use fungi_config::service_cache::DeviceServiceSnapshotCache;
 use libp2p::PeerId;
 
 use crate::{
     DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceAccess, ServiceInstance,
     ServiceLogs, ServiceLogsOptions,
+    controls::{ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl},
+    devices::DeviceHandle,
+    runtime::RuntimeControl,
+    service_access_manager::ServiceAccessManager,
     service_endpoints::{
         sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
     },
     service_state::DesiredServiceState,
 };
 
-use super::DeviceHandle;
+struct LocalServiceBackend {
+    runtime: RuntimeControl,
+    tcp_tunneling: TcpTunnelingControl,
+}
+
+struct RemoteServiceBackend {
+    discovery: ServiceDiscoveryControl,
+    control: ServiceControlProtocolControl,
+}
+
+struct ServicesInner {
+    local_device_id: PeerId,
+    fungi_dir: PathBuf,
+    local: LocalServiceBackend,
+    remote: RemoteServiceBackend,
+
+    // Transitional dependency. Service access becomes an independent FungiControl module in the
+    // next refactor step; keeping the handle here preserves current ServiceHandle behavior without
+    // leaving it in Devices.
+    service_access: ServiceAccessManager,
+}
+
+pub(crate) struct ServicesInit {
+    pub local_device_id: PeerId,
+    pub fungi_dir: PathBuf,
+    pub runtime: RuntimeControl,
+    pub service_discovery: ServiceDiscoveryControl,
+    pub service_control: ServiceControlProtocolControl,
+    pub tcp_tunneling: TcpTunnelingControl,
+    pub service_access: ServiceAccessManager,
+}
+
+/// Shared service domain for local and remote devices.
+#[derive(Clone)]
+pub struct Services {
+    inner: Arc<ServicesInner>,
+}
+
+impl Services {
+    pub(crate) fn new(init: ServicesInit) -> Self {
+        Self {
+            inner: Arc::new(ServicesInner {
+                local_device_id: init.local_device_id,
+                fungi_dir: init.fungi_dir,
+                local: LocalServiceBackend {
+                    runtime: init.runtime,
+                    tcp_tunneling: init.tcp_tunneling,
+                },
+                remote: RemoteServiceBackend {
+                    discovery: init.service_discovery,
+                    control: init.service_control,
+                },
+                service_access: init.service_access,
+            }),
+        }
+    }
+
+    pub(crate) fn for_device(&self, device: DeviceHandle) -> DeviceServices {
+        debug_assert_eq!(device.is_local(), device.id() == self.inner.local_device_id);
+        DeviceServices {
+            device,
+            services: self.clone(),
+        }
+    }
+
+    pub(crate) fn runtime(&self) -> &RuntimeControl {
+        &self.inner.local.runtime
+    }
+
+    pub(crate) fn service_discovery(&self) -> &ServiceDiscoveryControl {
+        &self.inner.remote.discovery
+    }
+
+    pub(crate) fn service_control(&self) -> &ServiceControlProtocolControl {
+        &self.inner.remote.control
+    }
+
+    pub(crate) fn tcp_tunneling(&self) -> &TcpTunnelingControl {
+        &self.inner.local.tcp_tunneling
+    }
+
+    pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
+        let snapshot_json = serde_json::to_string(snapshot)?;
+        self.snapshot_cache()?
+            .set_device_snapshot_json(snapshot.peer_id.clone(), snapshot_json)?;
+        Ok(())
+    }
+
+    pub(crate) fn remove_snapshot(&self, peer_id: PeerId) -> Result<bool> {
+        if peer_id == self.inner.local_device_id {
+            return Ok(false);
+        }
+        self.snapshot_cache()?
+            .remove_device_snapshot(&peer_id.to_string())
+    }
+
+    fn snapshot_cache(&self) -> Result<DeviceServiceSnapshotCache> {
+        DeviceServiceSnapshotCache::apply_from_dir(&self.inner.fungi_dir)
+    }
+}
 
 /// Collection and observation boundary for one device's services.
 #[derive(Clone)]
 pub struct DeviceServices {
-    pub(super) device: DeviceHandle,
+    device: DeviceHandle,
+    services: Services,
 }
 
 impl DeviceServices {
@@ -33,9 +138,8 @@ impl DeviceServices {
             return Ok(None);
         }
 
-        let cache = self.device.devices.snapshot_cache()?;
-        let Some(snapshot_json) =
-            cache.get_device_snapshot_json(&self.device.peer_id.to_string())?
+        let cache = self.services.snapshot_cache()?;
+        let Some(snapshot_json) = cache.get_device_snapshot_json(&self.device.id().to_string())?
         else {
             return Ok(None);
         };
@@ -49,20 +153,20 @@ impl DeviceServices {
     /// Observes this device now. Remote successes replace the persisted shadow; local
     /// observations are returned directly without creating a redundant cache.
     pub async fn refresh(&self) -> Result<DeviceServiceSnapshot> {
-        let peer_id = self.device.peer_id;
+        let peer_id = self.device.id();
         let snapshot = if self.device.is_local() {
             let (managed, published) = tokio::try_join!(
-                self.device.devices.inner.runtime.list_services(),
-                self.device
-                    .devices
+                self.services.inner.local.runtime.list_services(),
+                self.services
                     .inner
+                    .local
                     .runtime
                     .list_published_device_services(),
             )?;
             merge_device_service_snapshot(peer_id, managed, published)
         } else {
-            let control = self.device.devices.inner.service_control.clone();
-            let discovery = self.device.devices.inner.service_discovery.clone();
+            let control = self.services.inner.remote.control.clone();
+            let discovery = self.services.inner.remote.discovery.clone();
             let (managed_response, published) = tokio::try_join!(
                 async move {
                     control.list_peer_services(peer_id).await.with_context(|| {
@@ -93,7 +197,7 @@ impl DeviceServices {
         };
 
         if !self.device.is_local() {
-            self.device.devices.save_snapshot(&snapshot)?;
+            self.services.save_snapshot(&snapshot)?;
         }
         Ok(snapshot)
     }
@@ -105,18 +209,18 @@ impl DeviceServices {
     /// Lists only endpoints published for connection, without the managed-service merge.
     pub async fn published(&self) -> Result<Vec<DeviceService>> {
         if self.device.is_local() {
-            self.device
-                .devices
+            self.services
                 .inner
+                .local
                 .runtime
                 .list_published_device_services()
                 .await
         } else {
-            self.device
-                .devices
+            self.services
                 .inner
-                .service_discovery
-                .list_peer_services(self.device.peer_id)
+                .remote
+                .discovery
+                .list_peer_services(self.device.id())
                 .await
         }
     }
@@ -124,6 +228,7 @@ impl DeviceServices {
     pub fn service(&self, name: impl Into<String>) -> ServiceHandle {
         ServiceHandle {
             device: self.device.clone(),
+            services: self.services.clone(),
             name: name.into(),
         }
     }
@@ -134,12 +239,12 @@ impl DeviceServices {
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceHandle> {
         if self.device.is_local() {
-            let fungi_home = self.device.devices.inner.fungi_dir.clone();
+            let fungi_home = self.services.inner.fungi_dir.clone();
             let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
             let applied = self
-                .device
-                .devices
+                .services
                 .inner
+                .local
                 .runtime
                 .apply_manifest_yaml(
                     &manifest_yaml,
@@ -150,14 +255,14 @@ impl DeviceServices {
                 .await?;
             if applied.desired_state == DesiredServiceState::Running {
                 sync_service_endpoint_listeners_for_manifest(
-                    &self.device.devices.inner.tcp_tunneling,
+                    &self.services.inner.local.tcp_tunneling,
                     applied.previous_manifest.as_ref(),
                     false,
                 )
                 .await?;
                 sync_service_endpoint_listeners_by_name(
-                    &self.device.devices.inner.runtime,
-                    &self.device.devices.inner.tcp_tunneling,
+                    &self.services.inner.local.runtime,
+                    &self.services.inner.local.tcp_tunneling,
                     &applied.instance.name,
                     true,
                 )
@@ -166,11 +271,11 @@ impl DeviceServices {
             Ok(self.service(applied.instance.name))
         } else {
             let response = self
-                .device
-                .devices
+                .services
                 .inner
-                .service_control
-                .pull_peer_service(self.device.peer_id, manifest_yaml)
+                .remote
+                .control
+                .pull_peer_service(self.device.id(), manifest_yaml)
                 .await?;
             self.refresh_or_keep_after_mutation().await;
             let service_name = response
@@ -184,17 +289,7 @@ impl DeviceServices {
     }
 
     pub(crate) fn save_snapshot(&self, snapshot: &DeviceServiceSnapshot) -> Result<()> {
-        self.device.devices.save_snapshot(snapshot)
-    }
-
-    pub(crate) fn remove_snapshot(&self) -> Result<bool> {
-        if self.device.is_local() {
-            return Ok(false);
-        }
-        self.device
-            .devices
-            .snapshot_cache()?
-            .remove_device_snapshot(&self.device.peer_id.to_string())
+        self.services.save_snapshot(snapshot)
     }
 
     pub(crate) fn remove_cached_service(&self, name: &str) -> Result<bool> {
@@ -214,7 +309,7 @@ impl DeviceServices {
         if let Err(error) = self.refresh().await {
             log::warn!(
                 "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
-                self.device.peer_id
+                self.device.id()
             );
         }
     }
@@ -225,6 +320,7 @@ impl DeviceServices {
 #[derive(Clone)]
 pub struct ServiceHandle {
     device: DeviceHandle,
+    services: Services,
     name: String,
 }
 
@@ -237,31 +333,34 @@ impl ServiceHandle {
         &self.name
     }
 
+    fn device_services(&self) -> DeviceServices {
+        self.services.for_device(self.device.clone())
+    }
+
     pub fn observation(&self) -> Result<Option<DeviceService>> {
         Ok(self
-            .device
-            .services()
+            .device_services()
             .snapshot()?
             .and_then(|snapshot| find_service(snapshot, &self.name)))
     }
 
     pub async fn inspect(&self) -> Result<DeviceService> {
-        let snapshot = self.device.services().refresh().await?;
+        let snapshot = self.device_services().refresh().await?;
         find_service(snapshot, &self.name)
             .ok_or_else(|| anyhow::anyhow!("service not found: {}", self.name))
     }
 
     pub async fn start(&self) -> Result<()> {
         if self.device.is_local() {
-            self.device
-                .devices
+            self.services
                 .inner
+                .local
                 .runtime
                 .start_by_name(&self.name)
                 .await?;
             sync_service_endpoint_listeners_by_name(
-                &self.device.devices.inner.runtime,
-                &self.device.devices.inner.tcp_tunneling,
+                &self.services.inner.local.runtime,
+                &self.services.inner.local.tcp_tunneling,
                 &self.name,
                 true,
             )
@@ -270,11 +369,11 @@ impl ServiceHandle {
         }
 
         let response = self
-            .device
-            .devices
+            .services
             .inner
-            .service_control
-            .start_peer_service(self.device.peer_id, self.name.clone())
+            .remote
+            .control
+            .start_peer_service(self.device.id(), self.name.clone())
             .await?;
         let service_name = response
             .service
@@ -293,15 +392,15 @@ impl ServiceHandle {
 
     pub async fn stop(&self) -> Result<()> {
         if self.device.is_local() {
-            self.device
-                .devices
+            self.services
                 .inner
+                .local
                 .runtime
                 .stop_by_name(&self.name)
                 .await?;
             sync_service_endpoint_listeners_by_name(
-                &self.device.devices.inner.runtime,
-                &self.device.devices.inner.tcp_tunneling,
+                &self.services.inner.local.runtime,
+                &self.services.inner.local.tcp_tunneling,
                 &self.name,
                 false,
             )
@@ -310,29 +409,25 @@ impl ServiceHandle {
         }
 
         let response = self
-            .device
-            .devices
+            .services
             .inner
-            .service_control
-            .stop_peer_service(self.device.peer_id, self.name.clone())
+            .remote
+            .control
+            .stop_peer_service(self.device.id(), self.name.clone())
             .await?;
         let service_name = response
             .service
             .as_ref()
             .map(|service| service.name.as_str())
             .unwrap_or(self.name.as_str());
-        self.device
-            .devices
-            .inner
-            .service_access
-            .detach(self.device.peer_id, service_name)
+        self.services.inner.service_access
+            .detach(self.device.id(), service_name)
             .with_context(|| {
                 format!(
                     "remote service stopped, but failed to disconnect local access listeners for {service_name}"
                 )
             })?;
-        self.device
-            .services()
+        self.device_services()
             .refresh_or_keep_after_mutation()
             .await;
         Ok(())
@@ -341,19 +436,19 @@ impl ServiceHandle {
     pub async fn remove(&self) -> Result<()> {
         if self.device.is_local() {
             let manifest = self
-                .device
-                .devices
+                .services
                 .inner
+                .local
                 .runtime
                 .get_service_manifest(&self.name);
-            self.device
-                .devices
+            self.services
                 .inner
+                .local
                 .runtime
                 .remove_by_name(&self.name)
                 .await?;
             sync_service_endpoint_listeners_for_manifest(
-                &self.device.devices.inner.tcp_tunneling,
+                &self.services.inner.local.tcp_tunneling,
                 manifest.as_ref(),
                 false,
             )
@@ -362,30 +457,26 @@ impl ServiceHandle {
         }
 
         let response = self
-            .device
-            .devices
+            .services
             .inner
-            .service_control
-            .remove_peer_service(self.device.peer_id, self.name.clone())
+            .remote
+            .control
+            .remove_peer_service(self.device.id(), self.name.clone())
             .await?;
         let service_name = response
             .service
             .as_ref()
             .map(|service| service.name.as_str())
             .unwrap_or(self.name.as_str());
-        self.device
-            .devices
-            .inner
-            .service_access
-            .forget_service(self.device.peer_id, service_name)
+        self.services.inner.service_access
+            .forget_service(self.device.id(), service_name)
             .await
             .with_context(|| {
                 format!(
                     "remote service removed, but failed to forget local access records for {service_name}"
                 )
             })?;
-        self.device
-            .services()
+        self.device_services()
             .refresh_or_keep_after_mutation()
             .await;
         Ok(())
@@ -394,9 +485,9 @@ impl ServiceHandle {
     pub async fn logs(&self, tail: Option<usize>) -> Result<ServiceLogs> {
         if self.device.is_local() {
             return self
-                .device
-                .devices
+                .services
                 .inner
+                .local
                 .runtime
                 .logs_by_name(
                     &self.name,
@@ -411,11 +502,11 @@ impl ServiceHandle {
             .unwrap_or(crate::DEFAULT_REMOTE_SERVICE_LOG_TAIL)
             .clamp(1, crate::MAX_REMOTE_SERVICE_LOG_TAIL);
         let response = self
-            .device
-            .devices
+            .services
             .inner
-            .service_control
-            .get_peer_service_logs(self.device.peer_id, self.name.clone(), tail)
+            .remote
+            .control
+            .get_peer_service_logs(self.device.id(), self.name.clone(), tail)
             .await?;
         let text = response
             .logs_text
@@ -432,41 +523,38 @@ impl ServiceHandle {
         local_port: Option<u16>,
     ) -> Result<ServiceAccess> {
         self.ensure_remote_access()?;
-        let snapshot = self.device.services().refresh().await.map_err(|error| {
+        let snapshot = self.device_services().refresh().await.map_err(|error| {
             anyhow::anyhow!("failed to refresh remote service before attaching access: {error}")
         })?;
         let service = find_service(snapshot, &self.name)
             .ok_or_else(|| anyhow::anyhow!("remote service not found: {}", self.name))?;
-        self.device
-            .devices
+        self.services
             .inner
             .service_access
-            .attach(self.device.peer_id, service, entry, local_port)
+            .attach(self.device.id(), service, entry, local_port)
             .await
     }
 
     pub fn detach_access(&self) -> Result<()> {
         self.ensure_remote_access()?;
-        self.device
-            .devices
+        self.services
             .inner
             .service_access
-            .detach(self.device.peer_id, &self.name)
+            .detach(self.device.id(), &self.name)
     }
 
     pub async fn forget_access(&self) -> Result<()> {
         self.ensure_remote_access()?;
-        self.device
-            .devices
+        self.services
             .inner
             .service_access
-            .forget_service(self.device.peer_id, &self.name)
+            .forget_service(self.device.id(), &self.name)
             .await
     }
 
     pub async fn forget_cached_observation(&self) -> Result<bool> {
         self.ensure_remote_access()?;
-        let removed = self.device.services().remove_cached_service(&self.name)?;
+        let removed = self.device_services().remove_cached_service(&self.name)?;
         if removed {
             self.forget_access().await?;
         }
@@ -475,18 +563,17 @@ impl ServiceHandle {
 
     async fn restore_saved_access_after_start(&self, service_name: &str) -> Result<()> {
         let saved_entries = self
-            .device
-            .devices
+            .services
             .inner
             .service_access
-            .saved_entries(self.device.peer_id, service_name)
+            .saved_entries(self.device.id(), service_name)
             .await?;
-        let snapshot = self.device.services().refresh().await;
+        let snapshot = self.device_services().refresh().await;
         if saved_entries.is_empty() {
             if let Err(error) = snapshot {
                 log::warn!(
                     "Failed to refresh device service snapshot for device {} after remote mutation: {error}",
-                    self.device.peer_id
+                    self.device.id()
                 );
             }
             return Ok(());
@@ -495,11 +582,10 @@ impl ServiceHandle {
         let service = find_service(snapshot?, service_name)
             .ok_or_else(|| anyhow::anyhow!("remote service not found: {service_name}"))?;
         for entry in saved_entries {
-            self.device
-                .devices
+            self.services
                 .inner
                 .service_access
-                .attach(self.device.peer_id, service.clone(), Some(entry), None)
+                .attach(self.device.id(), service.clone(), Some(entry), None)
                 .await?;
         }
         Ok(())

--- a/crates/daemon/src/settings.rs
+++ b/crates/daemon/src/settings.rs
@@ -1,0 +1,148 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::Result;
+use fungi_config::{EffectiveRelayAddress, FungiConfig, runtime::Runtime as RuntimeConfig};
+use libp2p::Multiaddr;
+use parking_lot::Mutex;
+
+struct SettingsInner {
+    config: Arc<Mutex<FungiConfig>>,
+}
+
+/// Shared daemon settings and their persisted updates.
+#[derive(Clone)]
+pub struct Settings {
+    inner: Arc<SettingsInner>,
+}
+
+impl Settings {
+    pub(crate) fn new(config: FungiConfig) -> Self {
+        Self {
+            inner: Arc::new(SettingsInner {
+                config: Arc::new(Mutex::new(config)),
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> FungiConfig {
+        self.inner.config.lock().clone()
+    }
+
+    pub fn hostname(&self) -> Option<String> {
+        self.inner.config.lock().get_hostname()
+    }
+
+    pub fn config_file_path(&self) -> PathBuf {
+        self.inner.config.lock().config_file_path().to_path_buf()
+    }
+
+    pub fn fungi_dir(&self) -> Result<PathBuf> {
+        self.inner
+            .config
+            .lock()
+            .config_file_path()
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .ok_or_else(|| anyhow::anyhow!("config file has no parent directory"))
+    }
+
+    pub fn runtime(&self) -> RuntimeConfig {
+        self.inner.config.lock().get_runtime_config()
+    }
+
+    pub fn relay_enabled(&self) -> bool {
+        self.inner.config.lock().network.relay_enabled
+    }
+
+    pub fn use_community_relays(&self) -> bool {
+        self.inner.config.lock().network.use_community_relays
+    }
+
+    pub fn custom_relay_addresses(&self) -> Vec<Multiaddr> {
+        self.inner
+            .config
+            .lock()
+            .network
+            .custom_relay_addresses
+            .clone()
+    }
+
+    pub fn effective_relay_addresses(&self) -> Vec<EffectiveRelayAddress> {
+        self.inner
+            .config
+            .lock()
+            .network
+            .effective_relay_addresses(&fungi_swarm::get_default_relay_addrs())
+    }
+
+    pub fn set_relay_enabled(&self, enabled: bool) -> Result<()> {
+        self.update(|config| config.set_relay_enabled(enabled))?;
+        Ok(())
+    }
+
+    pub fn set_use_community_relays(&self, enabled: bool) -> Result<()> {
+        self.update(|config| config.set_use_community_relays(enabled))?;
+        Ok(())
+    }
+
+    pub fn add_custom_relay_address(&self, address: Multiaddr) -> Result<()> {
+        self.update(|config| config.add_custom_relay_address(address))?;
+        Ok(())
+    }
+
+    pub fn remove_custom_relay_address(&self, address: &Multiaddr) -> Result<()> {
+        self.update(|config| config.remove_custom_relay_address(address))?;
+        Ok(())
+    }
+
+    pub(crate) fn add_runtime_allowed_host_path(&self, path: PathBuf) -> Result<FungiConfig> {
+        self.update(|config| config.add_runtime_allowed_host_path(path))
+    }
+
+    pub(crate) fn remove_runtime_allowed_host_path(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<FungiConfig> {
+        self.update(|config| config.remove_runtime_allowed_host_path(path))
+    }
+
+    pub(crate) fn config_handle(&self) -> Arc<Mutex<FungiConfig>> {
+        self.inner.config.clone()
+    }
+
+    fn update(
+        &self,
+        update: impl FnOnce(&FungiConfig) -> Result<FungiConfig>,
+    ) -> Result<FungiConfig> {
+        let mut config = self.inner.config.lock();
+        let updated = update(&config)?;
+        *config = updated.clone();
+        Ok(updated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concurrent_updates_share_one_serialized_config_state() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let settings = Settings::new(FungiConfig::apply_from_dir(temp_dir.path()).unwrap());
+        let first = Multiaddr::empty().with(libp2p::multiaddr::Protocol::Memory(1));
+        let second = Multiaddr::empty().with(libp2p::multiaddr::Protocol::Memory(2));
+
+        let first_task = {
+            let settings = settings.clone();
+            std::thread::spawn(move || settings.add_custom_relay_address(first).unwrap())
+        };
+        let second_task = {
+            let settings = settings.clone();
+            std::thread::spawn(move || settings.add_custom_relay_address(second).unwrap())
+        };
+        first_task.join().unwrap();
+        second_task.join().unwrap();
+
+        assert_eq!(settings.custom_relay_addresses().len(), 2);
+    }
+}

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -51,7 +51,7 @@ use fungi_config::{
 use libp2p::{Multiaddr, PeerId, identity::Keypair, multiaddr::Protocol};
 use tempfile::TempDir;
 
-use crate::{DaemonArgs, FungiDaemon};
+use crate::{DaemonArgs, FungiControl, FungiDaemon};
 
 type ConfigMutator = Box<dyn Fn(&mut FungiConfig) + Send + Sync + 'static>;
 
@@ -207,7 +207,7 @@ impl TestDaemon {
 
     /// The [`PeerId`] of this daemon.
     pub fn peer_id(&self) -> PeerId {
-        self.inner.swarm_control().local_peer_id()
+        self.inner.control_ref().swarm_control().local_peer_id()
     }
 
     /// A `Multiaddr` that can be dialled by another daemon on the same host.
@@ -221,9 +221,12 @@ impl TestDaemon {
             .with(Protocol::P2p(peer_id))
     }
 
-    /// Borrow the inner daemon for calling any daemon API directly.
-    pub fn daemon(&self) -> &FungiDaemon {
-        &self.inner
+    /// Borrow the daemon's application API.
+    ///
+    /// The method name remains `daemon()` so existing test scenarios stay readable while the
+    /// production API separates daemon lifecycle ownership from the cloneable control facade.
+    pub fn daemon(&self) -> &FungiControl {
+        self.inner.control_ref()
     }
 
     /// Return the isolated Fungi home used by this daemon.
@@ -233,7 +236,7 @@ impl TestDaemon {
 
     /// Borrow the underlying [`fungi_swarm::SwarmControl`].
     pub fn swarm_control(&self) -> &fungi_swarm::SwarmControl {
-        self.inner.swarm_control()
+        self.inner.control_ref().swarm_control()
     }
 
     // ── Connection helpers ────────────────────────────────────────────────

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -207,7 +207,11 @@ impl TestDaemon {
 
     /// The [`PeerId`] of this daemon.
     pub fn peer_id(&self) -> PeerId {
-        self.inner.control_ref().swarm_control().local_peer_id()
+        self.inner
+            .control_ref()
+            .connectivity()
+            .swarm_control()
+            .local_peer_id()
     }
 
     /// A `Multiaddr` that can be dialled by another daemon on the same host.
@@ -236,7 +240,7 @@ impl TestDaemon {
 
     /// Borrow the underlying [`fungi_swarm::SwarmControl`].
     pub fn swarm_control(&self) -> &fungi_swarm::SwarmControl {
-        self.inner.control_ref().swarm_control()
+        self.inner.control_ref().connectivity().swarm_control()
     }
 
     // ── Connection helpers ────────────────────────────────────────────────
@@ -371,11 +375,10 @@ mod tests {
         assert_ne!(client.peer_id(), server.peer_id());
 
         // Server's trusted devices should include the client.
-        let trusted_devices = server.daemon().trusted_devices();
-        let client_in_list = trusted_devices
-            .lock()
-            .trusted_devices
-            .contains(&client.peer_id());
+        let client_in_list = server
+            .daemon()
+            .inbound_access()
+            .is_authorized(client.peer_id());
         assert!(client_in_list, "server should trust client device");
     }
 
@@ -389,7 +392,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(d.daemon().config().lock().network.relay_enabled);
+        assert!(d.daemon().settings().snapshot().network.relay_enabled);
     }
 
     #[tokio::test]
@@ -404,8 +407,7 @@ mod tests {
             .await
             .unwrap();
 
-        let config_handle = d.daemon().config();
-        let config = config_handle.lock();
+        let config = d.daemon().settings().snapshot();
         assert!(config.network.relay_enabled);
         assert!(!config.network.use_community_relays);
         assert_eq!(config.network.custom_relay_addresses, vec![relay_addr]);
@@ -433,10 +435,8 @@ mod tests {
         assert!(
             !victim
                 .daemon()
-                .trusted_devices()
-                .lock()
-                .trusted_devices
-                .contains(&attacker_peer_id),
+                .inbound_access()
+                .is_authorized(attacker_peer_id),
             "victim must not trust attacker device"
         );
 

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -159,7 +159,7 @@ impl TestDaemonBuilder {
             DaemonArgs::default(),
             cfg,
             keypair,
-            DevicesConfig::default(),
+            DevicesConfig::apply_from_dir(dir.path())?,
             trusted_devices,
             DirectAddressCache::apply_from_dir(dir.path())?,
         )

--- a/crates/daemon/tests/allowlist_protocol_tests.rs
+++ b/crates/daemon/tests/allowlist_protocol_tests.rs
@@ -73,7 +73,8 @@ async fn untrusted_device_cannot_use_service_control_over_existing_inbound_conne
 
     let result = attacker
         .daemon()
-        .service_control_protocol_control()
+        .services()
+        .service_control()
         .list_peer_services(victim.peer_id())
         .await;
 
@@ -92,7 +93,8 @@ async fn untrusted_device_cannot_use_node_capabilities_over_existing_inbound_con
 
     let result = attacker
         .daemon()
-        .node_capabilities_control()
+        .devices()
+        .node_capabilities()
         .discover_peer_capabilities(victim.peer_id())
         .await;
 

--- a/crates/daemon/tests/probe_smoke_tests.rs
+++ b/crates/daemon/tests/probe_smoke_tests.rs
@@ -63,6 +63,7 @@ async fn active_probe_ping_returns_rtt_and_updates_connection_state() -> Result<
 
     let rtt = client
         .daemon()
+        .connectivity()
         .swarm_control()
         .ping_connection(connection_id, Duration::from_secs(2))
         .await?;
@@ -159,6 +160,7 @@ async fn active_probe_ping_can_use_inbound_connection_id() -> Result<()> {
 
     let rtt = client
         .daemon()
+        .connectivity()
         .swarm_control()
         .ping_connection(connection_id, Duration::from_secs(2))
         .await?;

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -22,6 +22,7 @@ use fungi_daemon_grpc::{
         ServiceNameRequest,
     },
 };
+use futures::future::join_all;
 use serde::Serialize;
 
 use crate::commands::CommonArgs;
@@ -1325,24 +1326,18 @@ async fn print_service_overview(client: &mut RpcClient, verbose: bool, refresh: 
     );
 
     let devices = list_saved_devices(client).await;
-    if refresh {
-        for device in devices {
-            let saved_accesses = list_accesses(client, &device.peer_id).await;
-            let snapshot = fetch_device_service_snapshot(client, &device.peer_id, true).await;
-            add_remote_service_overview_rows(
-                &mut rows,
-                &device,
-                &saved_accesses,
-                snapshot,
-                verbose,
-            );
+    let device_rows = join_all(devices.into_iter().map(|device| {
+        let mut client = client.clone();
+        async move {
+            let saved_accesses = list_accesses(&mut client, &device.peer_id).await;
+            let snapshot =
+                fetch_device_service_snapshot(&mut client, &device.peer_id, refresh).await;
+            (device, saved_accesses, snapshot)
         }
-    } else {
-        for device in devices {
-            let accesses = list_accesses(client, &device.peer_id).await;
-            let snapshot = fetch_device_service_snapshot(client, &device.peer_id, false).await;
-            add_remote_service_overview_rows(&mut rows, &device, &accesses, snapshot, verbose);
-        }
+    }))
+    .await;
+    for (device, saved_accesses, snapshot) in device_rows {
+        add_remote_service_overview_rows(&mut rows, &device, &saved_accesses, snapshot, verbose);
     }
 
     rows.sort_by(|left, right| left.reference.cmp(&right.reference));

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -48,15 +48,16 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
 
     log::info!("Starting Fungi daemon...");
 
-    let daemon = match FungiDaemon::start(fungi_dir.clone(), args.clone()).await {
+    let mut daemon = match FungiDaemon::start(fungi_dir.clone(), args.clone()).await {
         Ok(daemon) => daemon,
         Err(error) => {
             print_startup_error("Failed to start Fungi daemon", &error);
             return Err(error);
         }
     };
+    let control = daemon.control();
 
-    let swarm_control = daemon.swarm_control().clone();
+    let swarm_control = control.swarm_control().clone();
     log::info!("Local Peer ID: {}", swarm_control.local_peer_id());
 
     let network_info = swarm_control
@@ -65,7 +66,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
         .unwrap();
     log::info!("Network info: {network_info:?}");
 
-    let rpc_listen_address = daemon.config().lock().rpc.listen_address.clone();
+    let rpc_listen_address = control.config().lock().rpc.listen_address.clone();
     let rpc_listener = match bind_rpc_listener(&rpc_listen_address).await {
         Ok(listener) => listener,
         Err(error) => {
@@ -79,8 +80,8 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     let _published_endpoint =
         fungi_config::PublishedDaemonEndpoint::publish(&fungi_dir, rpc_socket_addr)?;
     log::info!("Daemon RPC endpoint: http://{rpc_socket_addr}");
-    let saved_service_access_restore = daemon.spawn_saved_service_access_restore();
-    let server_fut = start_grpc_server(daemon, rpc_listener);
+    let saved_service_access_restore = control.spawn_saved_service_access_restore();
+    let server_fut = start_grpc_server(control, rpc_listener);
 
     let stdin_monitor = if args.exit_on_stdin_close {
         Some(tokio::spawn(stdin_monitor()))
@@ -89,6 +90,10 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     };
 
     let run_result = tokio::select! {
+        result = daemon.wait() => {
+            log::error!("Fungi daemon core stopped: {result:?}");
+            result
+        },
         signal = termination_signal() => {
             match signal {
                 Ok(signal) => {
@@ -120,6 +125,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     };
 
     saved_service_access_restore.abort();
+    daemon.shutdown().await;
     run_result
 }
 

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -57,7 +57,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     };
     let control = daemon.control();
 
-    let swarm_control = control.swarm_control().clone();
+    let swarm_control = control.connectivity().swarm_control().clone();
     log::info!("Local Peer ID: {}", swarm_control.local_peer_id());
 
     let network_info = swarm_control
@@ -66,7 +66,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
         .unwrap();
     log::info!("Network info: {network_info:?}");
 
-    let rpc_listen_address = control.config().lock().rpc.listen_address.clone();
+    let rpc_listen_address = control.settings().snapshot().rpc.listen_address;
     let rpc_listener = match bind_rpc_listener(&rpc_listen_address).await {
         Ok(listener) => listener,
         Err(error) => {

--- a/fungi/src/commands/fungi_daemon.rs
+++ b/fungi/src/commands/fungi_daemon.rs
@@ -79,6 +79,7 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
     let _published_endpoint =
         fungi_config::PublishedDaemonEndpoint::publish(&fungi_dir, rpc_socket_addr)?;
     log::info!("Daemon RPC endpoint: http://{rpc_socket_addr}");
+    let saved_service_access_restore = daemon.spawn_saved_service_access_restore();
     let server_fut = start_grpc_server(daemon, rpc_listener);
 
     let stdin_monitor = if args.exit_on_stdin_close {
@@ -87,16 +88,23 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
         None
     };
 
-    tokio::select! {
+    let run_result = tokio::select! {
         signal = termination_signal() => {
-            let signal = signal.context("Failed to wait for daemon termination signal")?;
-            log::info!("Received {signal}, shutting down Fungi daemon...");
+            match signal {
+                Ok(signal) => {
+                    log::info!("Received {signal}, shutting down Fungi daemon...");
+                    Ok(())
+                }
+                Err(error) => Err(error).context("Failed to wait for daemon termination signal"),
+            }
         },
         res = server_fut => {
             if let Err(error) = res {
                 print_grpc_startup_error(&rpc_listen_address, &error);
                 log::error!("Error occurred while serving: {}", error);
-                return Err(error);
+                Err(error)
+            } else {
+                Ok(())
             }
         },
         _ = async {
@@ -107,10 +115,12 @@ pub async fn run(common: CommonArgs, args: fungi_daemon::DaemonArgs) -> Result<(
             }
         } => {
             log::info!("Shutting down Fungi daemon...");
+            Ok(())
         },
-    }
+    };
 
-    Ok(())
+    saved_service_access_restore.abort();
+    run_result
 }
 
 async fn bind_rpc_listener(listen_address: &str) -> Result<tokio::net::TcpListener> {

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -6,7 +6,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use fungi_config::FungiConfig;
+use fungi_config::{
+    FungiConfig,
+    devices::{DeviceInfo, DevicesConfig},
+    local_preferences::{LocalPortSource, LocalPreferenceCache, LocalServicePreference},
+};
 use tempfile::TempDir;
 
 struct DaemonChild {
@@ -77,6 +81,57 @@ fn daemon_publishes_dynamic_endpoint_and_enforces_one_instance_per_fungi_dir() {
     let recovered_endpoint = fungi_config::read_daemon_endpoint(home.path()).unwrap();
     assert!(recovered_endpoint.starts_with("http://127.0.0.1:"));
     recovered.stop_gracefully();
+}
+
+#[test]
+fn daemon_publishes_endpoint_before_saved_service_access_refresh_finishes() {
+    let home = TempDir::new().unwrap();
+    let swarm = reserve_port();
+    init_fungi_dir(home.path(), 0, swarm);
+
+    let blackhole = TcpListener::bind("127.0.0.1:0").unwrap();
+    let blackhole_port = blackhole.local_addr().unwrap().port();
+    thread::spawn(move || {
+        if let Ok((_stream, _)) = blackhole.accept() {
+            thread::sleep(Duration::from_secs(20));
+        }
+    });
+
+    let peer_id = libp2p::PeerId::random();
+    let mut device = DeviceInfo::new_unknown(peer_id);
+    device.name = Some("slow-device".to_string());
+    device.multiaddrs = vec![format!("/ip4/127.0.0.1/tcp/{blackhole_port}/p2p/{peer_id}")];
+    DevicesConfig::apply_from_dir(home.path())
+        .unwrap()
+        .add_or_update_device(device)
+        .unwrap();
+    LocalPreferenceCache::apply_from_dir(home.path())
+        .unwrap()
+        .upsert_record(LocalServicePreference {
+            remote_peer_id: peer_id.to_string(),
+            remote_service_name: "slow-service".to_string(),
+            remote_service_port_name: "main".to_string(),
+            local_host: "127.0.0.1".to_string(),
+            local_port: reserve_port(),
+            local_port_source: LocalPortSource::Auto,
+        })
+        .unwrap();
+
+    let daemon = start_daemon(home.path());
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(3);
+    while !fungi_config::daemon_endpoint_path(home.path()).exists() {
+        assert!(
+            Instant::now() < deadline,
+            "daemon endpoint publication waited for background service access refresh"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let output = run_cli(home.path(), ["info", "version"]);
+    assert!(!output.stdout.trim().is_empty());
+    assert!(started.elapsed() < Duration::from_secs(3));
+    daemon.stop_gracefully();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- separate the unique `FungiDaemon` lifecycle from the cloneable `FungiControl` API facade
- organize daemon capabilities into `Settings`, `Devices`, `Services`, `ServiceAccesses`, `InboundAccessPolicy`, and `Connectivity`
- move gRPC away from `Arc<FungiDaemon>` and scope low-level controls under their owning domains
- move saved remote service-access restoration out of daemon startup
- share one per-device service refresh path with a 15-second timeout
- refresh saved devices concurrently without an artificial concurrency cap
- separate inbound peer authorization from actively managed devices

## Why

Saved remote service-access restoration was part of the daemon startup path. Remote service state refresh could therefore delay local RPC readiness, especially just after system login while the network or remote devices were unavailable.

The daemon root object also mixed lifecycle ownership, API routing, persisted state, service orchestration, and low-level libp2p/runtime controls. That made it difficult to move restoration into the background without exposing or cloning the entire daemon.

This refactor gives lifecycle ownership and business capabilities explicit boundaries. The one-shot restore task now owns only the `Services` and `ServiceAccesses` handles it needs.

## Behavior and compatibility

- the RPC endpoint becomes ready without waiting for remote devices
- failed remote refresh keeps cached service observations and saved access intent
- startup restoration refreshes only devices referenced by saved bindings
- `fungi service list --refresh` uses the same `DeviceServices::refresh()` path and refreshes devices concurrently
- each remote device refresh has a 15-second timeout
- existing gRPC messages and persisted configuration formats remain unchanged
- legacy device removal still composes access cleanup and untrust at the compatibility API layer

## Design notes

The public service-access DTO already uses the name `ServiceAccess`, so the host-level domain handle is named `ServiceAccesses` to avoid a breaking DTO rename.

Uniform `DaemonUnavailable` semantics are intentionally deferred. Mapping only closed swarm channels would not cover local runtime operations held by a cloned in-process control. A future long-lived FFI/control use case should introduce one lifecycle boundary across all realtime backends rather than a partial error wrapper.

Durable binding schema changes, listener validation/readiness state, and capability-level authorization remain follow-up work.

## Validation

- `cargo test --workspace`
- `cargo clippy -p fungi-daemon -p fungi-daemon-grpc -p fungi -- -D warnings`
- `git diff --check enbop/master...HEAD`

The two release-binary migration tests remain intentionally ignored.