### PR TITLE
chore(release): prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1] - 2026-08-29
+
+### Added
+
+- Trusted devices can read bounded remote service logs with `fungi service logs <service>@<device> [--tail N]`. Remote requests default to 200 lines, accept up to 2,000 lines, and cap responses at 512 KiB ([#65](https://github.com/enbop/fungi/pull/65)).
+- `fungi ping` now supports explicit `--count` and `--watch` modes and finishes after four rounds by default ([#69](https://github.com/enbop/fungi/pull/69)).
+
+### Changed
+
+- Saved remote service access is restored after the local RPC endpoint becomes ready, so unavailable devices no longer delay daemon startup ([#74](https://github.com/enbop/fungi/pull/74)).
+- Startup restoration and `fungi service list --refresh` now share one per-device refresh path, refresh devices concurrently, and use a 15-second timeout per device while retaining cached observations after refresh failures ([#74](https://github.com/enbop/fungi/pull/74)).
+- Recipe output now shows catalog release information once with clearer labels ([#68](https://github.com/enbop/fungi/pull/68)).
+- Daemon lifecycle ownership is separated from the cloneable control facade and its domain handles. Existing gRPC messages and persisted configuration formats remain compatible ([#74](https://github.com/enbop/fungi/pull/74)).
+
+### Fixed
+
+- New remote service access now requires a successful live refresh, preventing stale cached metadata from opening or returning unusable local endpoints when a device is offline or does not trust the current device ([#64](https://github.com/enbop/fungi/pull/64)).
+- CLI-to-daemon RPC requests now have bounded timeouts, and ping stream failures are reported instead of being treated as successful completion ([#69](https://github.com/enbop/fungi/pull/69)).
+
 ## [0.7.0] - 2026-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fungi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "fungi-config-migrate",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-config-migrate"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-daemon"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-daemon-grpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "fungi-config",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-docker-agent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytes",
  "clap",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-lab"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-stream"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-swarm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-result",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-tests"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "env_logger 0.11.11",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "fungi-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary

- prepare the core v0.7.1 release from the current v0.7.0 tag through master
- document user-facing changes from #64, #65, #68, #69, and #74
- bump the workspace package version and lockfile packages from 0.7.0 to 0.7.1

## Release highlights

- add bounded remote service log retrieval for trusted devices
- make ping finite by default and bound CLI-to-daemon RPC requests
- reject new remote access when only stale cached service metadata is available
- restore saved remote service access after RPC readiness and refresh devices concurrently
- clarify recipe catalog output
- separate daemon lifecycle ownership from the cloneable domain control facade without changing persisted formats or existing gRPC messages

## Validation

- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy -p fungi-daemon -p fungi-daemon-grpc -p fungi -- -D warnings
- cargo run -q -p fungi -- --version (fungi 0.7.1)