### PR TITLE
fix(service): make apply --start idempotent

### DIFF
--- a/crates/daemon-grpc/proto/fungi_daemon.proto
+++ b/crates/daemon-grpc/proto/fungi_daemon.proto
@@ -436,7 +436,10 @@ message GetServiceLogsRequest {
   string             tail    = 3;
 }
 
-message ServiceInstanceResponse { string instance_json = 1; }
+message ServiceInstanceResponse {
+  string instance_json       = 1;
+  string apply_outcome_json  = 2;
+}
 
 message ServiceLogsResponse {
   bytes  raw  = 1;
@@ -534,6 +537,7 @@ message RemotePeerRequest { string peer_id = 1; }
 message RemoteServiceControlResponse {
   string service_name      = 1;
   bool   forgotten_locally = 2;
+  string apply_outcome_json = 3;
 }
 
 message AttachServiceAccessRequest {

--- a/crates/daemon-grpc/src/generated/fungi_daemon.rs
+++ b/crates/daemon-grpc/src/generated/fungi_daemon.rs
@@ -423,6 +423,8 @@ pub struct GetServiceLogsRequest {
 pub struct ServiceInstanceResponse {
     #[prost(string, tag = "1")]
     pub instance_json: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub apply_outcome_json: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ServiceLogsResponse {
@@ -576,6 +578,8 @@ pub struct RemoteServiceControlResponse {
     pub service_name: ::prost::alloc::string::String,
     #[prost(bool, tag = "2")]
     pub forgotten_locally: bool,
+    #[prost(string, tag = "3")]
+    pub apply_outcome_json: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AttachServiceAccessRequest {

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -26,6 +26,38 @@ pub use tonic::{Request, Response, Status};
 
 type PingEventSendError = mpsc::error::SendError<Result<PingPeerEvent, Status>>;
 
+fn service_apply_failure_status(
+    service_name: String,
+    outcome: fungi_daemon::ServiceApplyOutcome,
+) -> Status {
+    let response = fungi_daemon::ServiceControlResponse::applied(None, service_name, outcome);
+    let message = response
+        .error
+        .as_ref()
+        .map(|error| error.message.clone())
+        .unwrap_or_else(|| "service apply completed partially".to_string());
+    match serde_json::to_vec(&response) {
+        Ok(details) => Status::with_details(tonic::Code::Internal, message, details.into()),
+        Err(error) => Status::internal(format!(
+            "{message}; failed to serialize partial apply details: {error}"
+        )),
+    }
+}
+
+pub fn decode_service_apply_failure_status(
+    status: &Status,
+) -> Option<fungi_daemon::ServiceControlResponse> {
+    serde_json::from_slice::<fungi_daemon::ServiceControlResponse>(status.details())
+        .ok()
+        .filter(|response| {
+            !response.ok
+                && response
+                    .apply_outcome
+                    .as_ref()
+                    .is_some_and(|outcome| outcome.failure.is_some())
+        })
+}
+
 fn now_unix_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -849,6 +881,13 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to pull service: {e}")))?;
 
+        if applied.outcome.failure.is_some() {
+            return Err(service_apply_failure_status(
+                applied.instance.name,
+                applied.outcome,
+            ));
+        }
+
         let instance_json = serde_json::to_string(&applied.instance)
             .map_err(|e| Status::internal(format!("Failed to serialize service instance: {e}")))?;
         let apply_outcome_json = serde_json::to_string(&applied.outcome)
@@ -1110,6 +1149,19 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to pull remote service: {e}")))?;
 
+        let service_name = response
+            .service
+            .as_ref()
+            .map(|service| service.name.clone())
+            .unwrap_or_default();
+        if let Some(outcome) = response
+            .apply_outcome
+            .as_ref()
+            .filter(|outcome| outcome.failure.is_some())
+        {
+            return Err(service_apply_failure_status(service_name, outcome.clone()));
+        }
+
         let apply_outcome_json = response
             .apply_outcome
             .as_ref()
@@ -1119,10 +1171,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             .unwrap_or_default();
 
         Ok(Response::new(RemoteServiceControlResponse {
-            service_name: response
-                .service
-                .map(|service| service.name)
-                .unwrap_or_default(),
+            service_name,
             forgotten_locally: response.forgotten_locally,
             apply_outcome_json,
         }))
@@ -1489,5 +1538,25 @@ mod tests {
             system_time_to_i64(i64_to_system_time(1_752_299_892).unwrap()),
             1_752_299_892
         );
+    }
+
+    #[test]
+    fn partial_apply_status_preserves_structured_failure_details() {
+        let outcome = fungi_daemon::ServiceApplyOutcome {
+            manifest_change: fungi_daemon::ServiceManifestChange::Changed,
+            workload_action: fungi_daemon::ServiceWorkloadAction::None,
+            final_status: fungi_daemon::ServiceStatus::stopped(),
+            failure: Some(fungi_daemon::ServiceApplyFailure {
+                stage: fungi_daemon::ServiceApplyFailureStage::Restart,
+                message: "launcher failed".to_string(),
+            }),
+        };
+
+        let status = service_apply_failure_status("demo".to_string(), outcome.clone());
+        let decoded = decode_service_apply_failure_status(&status).unwrap();
+
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert_eq!(decoded.service.unwrap().name, "demo");
+        assert_eq!(decoded.apply_outcome.unwrap(), outcome);
     }
 }

--- a/crates/daemon-grpc/src/lib.rs
+++ b/crates/daemon-grpc/src/lib.rs
@@ -836,9 +836,9 @@ impl FungiDaemon for FungiDaemonRpcImpl {
         request: Request<PullServiceRequest>,
     ) -> Result<Response<ServiceInstanceResponse>, Status> {
         let req = request.into_inner();
-        let instance = self
+        let applied = self
             .inner
-            .pull_service_from_manifest_yaml(
+            .apply_service_from_manifest_yaml(
                 req.manifest_yaml,
                 if req.manifest_base_dir.trim().is_empty() {
                     None
@@ -849,9 +849,14 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to pull service: {e}")))?;
 
-        let instance_json = serde_json::to_string(&instance)
+        let instance_json = serde_json::to_string(&applied.instance)
             .map_err(|e| Status::internal(format!("Failed to serialize service instance: {e}")))?;
-        Ok(Response::new(ServiceInstanceResponse { instance_json }))
+        let apply_outcome_json = serde_json::to_string(&applied.outcome)
+            .map_err(|e| Status::internal(format!("Failed to serialize apply outcome: {e}")))?;
+        Ok(Response::new(ServiceInstanceResponse {
+            instance_json,
+            apply_outcome_json,
+        }))
     }
 
     async fn start_service(
@@ -937,7 +942,10 @@ impl FungiDaemon for FungiDaemonRpcImpl {
         };
         let instance_json = serde_json::to_string(&instance)
             .map_err(|e| Status::internal(format!("Failed to serialize service instance: {e}")))?;
-        Ok(Response::new(ServiceInstanceResponse { instance_json }))
+        Ok(Response::new(ServiceInstanceResponse {
+            instance_json,
+            apply_outcome_json: String::new(),
+        }))
     }
 
     async fn get_service_logs(
@@ -1102,12 +1110,21 @@ impl FungiDaemon for FungiDaemonRpcImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to pull remote service: {e}")))?;
 
+        let apply_outcome_json = response
+            .apply_outcome
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| Status::internal(format!("Failed to serialize apply outcome: {e}")))?
+            .unwrap_or_default();
+
         Ok(Response::new(RemoteServiceControlResponse {
             service_name: response
                 .service
                 .map(|service| service.name)
                 .unwrap_or_default(),
             forgotten_locally: response.forgotten_locally,
+            apply_outcome_json,
         }))
     }
 
@@ -1131,6 +1148,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                 .map(|service| service.name)
                 .unwrap_or_default(),
             forgotten_locally: response.forgotten_locally,
+            apply_outcome_json: String::new(),
         }))
     }
 
@@ -1174,6 +1192,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                 .map(|service| service.name)
                 .unwrap_or_default(),
             forgotten_locally: response.forgotten_locally,
+            apply_outcome_json: String::new(),
         }))
     }
 
@@ -1197,6 +1216,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                 .map(|service| service.name)
                 .unwrap_or_default(),
             forgotten_locally: response.forgotten_locally,
+            apply_outcome_json: String::new(),
         }))
     }
 
@@ -1220,6 +1240,7 @@ impl FungiDaemon for FungiDaemonRpcImpl {
                 .map(|service| service.name)
                 .unwrap_or_default(),
             forgotten_locally: response.forgotten_locally,
+            apply_outcome_json: String::new(),
         }))
     }
 

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -12,9 +12,9 @@ use crate::runtime::{
     ServiceLogs, ServiceLogsOptions, ServiceManifest,
 };
 use crate::service_endpoints::{
-    sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
+    sync_applied_service_endpoint_listeners, sync_service_endpoint_listeners_by_name,
+    sync_service_endpoint_listeners_for_manifest,
 };
-use crate::service_state::DesiredServiceState;
 use crate::{
     FungiControl, LocalRuntimeStatus, ManifestResolutionPolicy, NodeCapabilities,
     ResolvedServiceRecipe, ServiceControlResponse, ServiceRecipeDetail, ServiceRecipeRuntime,
@@ -109,27 +109,11 @@ impl FungiControl {
     }
 
     pub async fn pull_service(&self, manifest: ServiceManifest) -> Result<ServiceInstance> {
-        let applied = self.services().runtime().apply(&manifest).await?;
-        if applied.desired_state == DesiredServiceState::Running {
-            self.sync_service_endpoint_listeners_for_manifest(
-                applied.previous_manifest.as_ref(),
-                false,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "service manifest applied, but failed to update endpoint listeners; final phase: {}",
-                    applied.outcome.final_status.phase
-                )
-            })?;
-            self.sync_service_endpoint_listeners_by_name(&applied.instance.name, true)
-                .await
-                .with_context(|| {
-                    format!(
-                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
-                        applied.outcome.final_status.phase
-                    )
-                })?;
+        let mut applied = self.services().runtime().apply(&manifest).await?;
+        self.record_applied_service_listener_failure(&mut applied)
+            .await;
+        if let Some(message) = applied.outcome.failure_summary() {
+            anyhow::bail!(message);
         }
         Ok(applied.instance)
     }
@@ -139,10 +123,13 @@ impl FungiControl {
         manifest_yaml: String,
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceInstance> {
-        Ok(self
+        let applied = self
             .apply_service_from_manifest_yaml(manifest_yaml, manifest_base_dir)
-            .await?
-            .instance)
+            .await?;
+        if let Some(message) = applied.outcome.failure_summary() {
+            anyhow::bail!(message);
+        }
+        Ok(applied.instance)
     }
 
     pub async fn apply_service_from_manifest_yaml(
@@ -153,33 +140,23 @@ impl FungiControl {
         let fungi_home = self.fungi_home_dir();
         let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
         let policy = self.manifest_resolution_policy();
-        let applied = self
+        let mut applied = self
             .services()
             .runtime()
             .apply_manifest_yaml(&manifest_yaml, &base_dir, &fungi_home, &policy)
             .await?;
-        if applied.desired_state == DesiredServiceState::Running {
-            self.sync_service_endpoint_listeners_for_manifest(
-                applied.previous_manifest.as_ref(),
-                false,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "service manifest applied, but failed to update endpoint listeners; final phase: {}",
-                    applied.outcome.final_status.phase
-                )
-            })?;
-            self.sync_service_endpoint_listeners_by_name(&applied.instance.name, true)
-                .await
-                .with_context(|| {
-                    format!(
-                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
-                        applied.outcome.final_status.phase
-                    )
-                })?;
-        }
+        self.record_applied_service_listener_failure(&mut applied)
+            .await;
         Ok(applied)
+    }
+
+    async fn record_applied_service_listener_failure(&self, applied: &mut AppliedService) {
+        sync_applied_service_endpoint_listeners(
+            self.services().runtime(),
+            self.services().tcp_tunneling(),
+            applied,
+        )
+        .await;
     }
 
     pub async fn start_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
@@ -476,7 +453,7 @@ impl FungiControl {
             .await?;
         let service_name = applied.service.name().to_string();
         Ok(match applied.outcome {
-            Some(outcome) => ServiceControlResponse::success_applied(None, service_name, outcome),
+            Some(outcome) => ServiceControlResponse::applied(None, service_name, outcome),
             None => ServiceControlResponse::success(None, service_name),
         })
     }

--- a/crates/daemon/src/api/runtime.rs
+++ b/crates/daemon/src/api/runtime.rs
@@ -8,8 +8,8 @@ use fungi_config::runtime::Runtime as RuntimeConfig;
 use libp2p::PeerId;
 
 use crate::runtime::{
-    DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceInstance, ServiceLogs,
-    ServiceLogsOptions, ServiceManifest,
+    AppliedService, DeviceService, DeviceServiceSnapshot, RuntimeKind, ServiceInstance,
+    ServiceLogs, ServiceLogsOptions, ServiceManifest,
 };
 use crate::service_endpoints::{
     sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
@@ -115,9 +115,21 @@ impl FungiControl {
                 applied.previous_manifest.as_ref(),
                 false,
             )
-            .await?;
+            .await
+            .with_context(|| {
+                format!(
+                    "service manifest applied, but failed to update endpoint listeners; final phase: {}",
+                    applied.outcome.final_status.phase
+                )
+            })?;
             self.sync_service_endpoint_listeners_by_name(&applied.instance.name, true)
-                .await?;
+                .await
+                .with_context(|| {
+                    format!(
+                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
+                        applied.outcome.final_status.phase
+                    )
+                })?;
         }
         Ok(applied.instance)
     }
@@ -127,6 +139,17 @@ impl FungiControl {
         manifest_yaml: String,
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceInstance> {
+        Ok(self
+            .apply_service_from_manifest_yaml(manifest_yaml, manifest_base_dir)
+            .await?
+            .instance)
+    }
+
+    pub async fn apply_service_from_manifest_yaml(
+        &self,
+        manifest_yaml: String,
+        manifest_base_dir: Option<PathBuf>,
+    ) -> Result<AppliedService> {
         let fungi_home = self.fungi_home_dir();
         let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
         let policy = self.manifest_resolution_policy();
@@ -140,11 +163,23 @@ impl FungiControl {
                 applied.previous_manifest.as_ref(),
                 false,
             )
-            .await?;
+            .await
+            .with_context(|| {
+                format!(
+                    "service manifest applied, but failed to update endpoint listeners; final phase: {}",
+                    applied.outcome.final_status.phase
+                )
+            })?;
             self.sync_service_endpoint_listeners_by_name(&applied.instance.name, true)
-                .await?;
+                .await
+                .with_context(|| {
+                    format!(
+                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
+                        applied.outcome.final_status.phase
+                    )
+                })?;
         }
-        Ok(applied.instance)
+        Ok(applied)
     }
 
     pub async fn start_service(&self, runtime: RuntimeKind, name: String) -> Result<()> {
@@ -433,16 +468,17 @@ impl FungiControl {
         peer_id: PeerId,
         manifest_yaml: String,
     ) -> Result<ServiceControlResponse> {
-        let service = self
+        let applied = self
             .devices()
             .peer(peer_id)
             .services()
-            .apply_manifest_yaml(manifest_yaml, None)
+            .apply_manifest_yaml_with_outcome(manifest_yaml, None)
             .await?;
-        Ok(ServiceControlResponse::success(
-            None,
-            service.name().to_string(),
-        ))
+        let service_name = applied.service.name().to_string();
+        Ok(match applied.outcome {
+            Some(outcome) => ServiceControlResponse::success_applied(None, service_name, outcome),
+            None => ServiceControlResponse::success(None, service_name),
+        })
     }
 
     pub async fn remote_start_service(

--- a/crates/daemon/src/controls/service_control.rs
+++ b/crates/daemon/src/controls/service_control.rs
@@ -238,8 +238,11 @@ impl ServiceControlProtocolControl {
                                 Err(error) => {
                                     return ServiceControlResponse::error(
                                         request_id.clone(),
-                                        "execution_failed",
-                                        error.to_string(),
+                                        "partial_apply",
+                                        format!(
+                                            "Service manifest applied, but failed to update endpoint listeners: {error}. Final phase: {}",
+                                            applied.outcome.final_status.phase
+                                        ),
                                     );
                                 }
                             }
@@ -254,13 +257,20 @@ impl ServiceControlProtocolControl {
                                 Err(error) => {
                                     return ServiceControlResponse::error(
                                         request_id.clone(),
-                                        "execution_failed",
-                                        error.to_string(),
+                                        "partial_apply",
+                                        format!(
+                                            "Service manifest applied, but failed to publish endpoint listeners: {error}. Final phase: {}",
+                                            applied.outcome.final_status.phase
+                                        ),
                                     );
                                 }
                             }
                         }
-                        Ok(applied.instance.name)
+                        return ServiceControlResponse::success_applied(
+                            request_id,
+                            applied.instance.name,
+                            applied.outcome,
+                        );
                     }
                     Err(error) => Err(error),
                 }

--- a/crates/daemon/src/controls/service_control.rs
+++ b/crates/daemon/src/controls/service_control.rs
@@ -17,9 +17,9 @@ use crate::{
     ManifestResolutionPolicy, RuntimeControl, ServiceControlRequest, ServiceControlResponse,
     ServiceManifest,
     service_endpoints::{
-        sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
+        sync_applied_service_endpoint_listeners, sync_service_endpoint_listeners_by_name,
+        sync_service_endpoint_listeners_for_manifest,
     },
-    service_state::DesiredServiceState,
 };
 
 const MAX_CONTROL_FRAME_LEN: usize = 2 * 1024 * 1024;
@@ -68,14 +68,15 @@ impl ServiceControlProtocolControl {
         peer_id: PeerId,
         manifest_yaml: String,
     ) -> Result<ServiceControlResponse> {
-        self.send_request(
+        self.send_request_raw(
             peer_id,
             ServiceControlRequest::PullService {
                 request_id: None,
                 manifest_yaml,
             },
         )
-        .await
+        .await?
+        .into_apply_result()
     }
 
     pub async fn start_peer_service(
@@ -153,6 +154,14 @@ impl ServiceControlProtocolControl {
         peer_id: PeerId,
         request: ServiceControlRequest,
     ) -> Result<ServiceControlResponse> {
+        self.send_request_raw(peer_id, request).await?.into_result()
+    }
+
+    async fn send_request_raw(
+        &self,
+        peer_id: PeerId,
+        request: ServiceControlRequest,
+    ) -> Result<ServiceControlResponse> {
         let (mut stream, _handle, _connection_id) = self
             .swarm_control
             .open_stream(peer_id, FUNGI_SERVICE_CONTROL_PROTOCOL)
@@ -169,8 +178,7 @@ impl ServiceControlProtocolControl {
             .await
             .map_err(|e| {
                 anyhow::anyhow!("Failed to read service-control response from peer {peer_id}: {e}")
-            })?
-            .into_result()
+            })
     }
 
     async fn listen_from_incoming_streams(self, mut incoming_streams: IncomingStreams) {
@@ -225,48 +233,14 @@ impl ServiceControlProtocolControl {
                     )
                     .await
                 {
-                    Ok(applied) => {
-                        if applied.desired_state == DesiredServiceState::Running {
-                            match self
-                                .sync_service_endpoint_listeners_for_manifest(
-                                    applied.previous_manifest.as_ref(),
-                                    false,
-                                )
-                                .await
-                            {
-                                Ok(()) => {}
-                                Err(error) => {
-                                    return ServiceControlResponse::error(
-                                        request_id.clone(),
-                                        "partial_apply",
-                                        format!(
-                                            "Service manifest applied, but failed to update endpoint listeners: {error}. Final phase: {}",
-                                            applied.outcome.final_status.phase
-                                        ),
-                                    );
-                                }
-                            }
-                            match self
-                                .sync_service_endpoint_listeners_by_name(
-                                    &applied.instance.name,
-                                    true,
-                                )
-                                .await
-                            {
-                                Ok(()) => {}
-                                Err(error) => {
-                                    return ServiceControlResponse::error(
-                                        request_id.clone(),
-                                        "partial_apply",
-                                        format!(
-                                            "Service manifest applied, but failed to publish endpoint listeners: {error}. Final phase: {}",
-                                            applied.outcome.final_status.phase
-                                        ),
-                                    );
-                                }
-                            }
-                        }
-                        return ServiceControlResponse::success_applied(
+                    Ok(mut applied) => {
+                        sync_applied_service_endpoint_listeners(
+                            &self.runtime_control,
+                            &self.tcp_tunneling_control,
+                            &mut applied,
+                        )
+                        .await;
+                        return ServiceControlResponse::applied(
                             request_id,
                             applied.instance.name,
                             applied.outcome,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -40,12 +40,13 @@ pub use recipes::{
 pub use runtime::{
     AppliedService, DeviceService, DeviceServiceEndpoint, DeviceServiceMetadata,
     DeviceServiceSnapshot, ManifestResolutionPolicy, RuntimeControl, RuntimeKind,
-    ServiceApplyOutcome, ServiceExpose, ServiceExposeEndpointBinding, ServiceExposeTransport,
-    ServiceExposeTransportKind, ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance,
-    ServiceLogs, ServiceLogsOptions, ServiceManifest, ServiceManifestChange, ServiceMount,
-    ServicePhase, ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceRunMode,
-    ServiceSource, ServiceStatus, ServiceWorkloadAction, load_service_manifest_yaml_file,
-    parse_service_manifest_yaml, peek_service_manifest_name, service_expose_endpoint_bindings,
+    ServiceApplyFailure, ServiceApplyFailureStage, ServiceApplyOutcome, ServiceExpose,
+    ServiceExposeEndpointBinding, ServiceExposeTransport, ServiceExposeTransportKind,
+    ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance, ServiceLogs, ServiceLogsOptions,
+    ServiceManifest, ServiceManifestChange, ServiceMount, ServicePhase, ServicePort,
+    ServicePortAllocation, ServicePortProtocol, ServiceRunMode, ServiceSource, ServiceStatus,
+    ServiceWorkloadAction, load_service_manifest_yaml_file, parse_service_manifest_yaml,
+    peek_service_manifest_name, service_expose_endpoint_bindings,
     service_manifest_with_instance_name,
 };
 pub use service_accesses::ServiceAccesses;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -38,14 +38,15 @@ pub use recipes::{
     ResolvedServiceRecipe, ServiceRecipeDetail, ServiceRecipeRuntime, ServiceRecipeSummary,
 };
 pub use runtime::{
-    DeviceService, DeviceServiceEndpoint, DeviceServiceMetadata, DeviceServiceSnapshot,
-    ManifestResolutionPolicy, RuntimeControl, RuntimeKind, ServiceExpose,
-    ServiceExposeEndpointBinding, ServiceExposeTransport, ServiceExposeTransportKind,
-    ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance, ServiceLogs, ServiceLogsOptions,
-    ServiceManifest, ServiceMount, ServicePhase, ServicePort, ServicePortAllocation,
-    ServicePortProtocol, ServiceRunMode, ServiceSource, ServiceStatus,
-    load_service_manifest_yaml_file, parse_service_manifest_yaml, peek_service_manifest_name,
-    service_expose_endpoint_bindings, service_manifest_with_instance_name,
+    AppliedService, DeviceService, DeviceServiceEndpoint, DeviceServiceMetadata,
+    DeviceServiceSnapshot, ManifestResolutionPolicy, RuntimeControl, RuntimeKind,
+    ServiceApplyOutcome, ServiceExpose, ServiceExposeEndpointBinding, ServiceExposeTransport,
+    ServiceExposeTransportKind, ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance,
+    ServiceLogs, ServiceLogsOptions, ServiceManifest, ServiceManifestChange, ServiceMount,
+    ServicePhase, ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceRunMode,
+    ServiceSource, ServiceStatus, ServiceWorkloadAction, load_service_manifest_yaml_file,
+    parse_service_manifest_yaml, peek_service_manifest_name, service_expose_endpoint_bindings,
+    service_manifest_with_instance_name,
 };
 pub use service_accesses::ServiceAccesses;
 pub use service_control::{

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -99,10 +99,11 @@ impl RuntimeControl {
     }
 
     pub async fn pull(&self, manifest: &ServiceManifest) -> Result<ServiceInstance> {
-        Ok(self
-            .apply_with_local_service_id(manifest, None)
-            .await?
-            .instance)
+        let applied = self.apply_with_local_service_id(manifest, None).await?;
+        if let Some(message) = applied.outcome.failure_summary() {
+            bail!(message);
+        }
+        Ok(applied.instance)
     }
 
     pub async fn apply(&self, manifest: &ServiceManifest) -> Result<AppliedService> {
@@ -213,22 +214,57 @@ impl RuntimeControl {
         self.persist_service(manifest, desired_state, Some(&resolved_local_service_id))?;
 
         let mut instance = enrich_instance_from_manifest(instance, manifest);
+        let mut workload_action = ServiceWorkloadAction::None;
+        let mut failure = None;
         if desired_state == DesiredServiceState::Running {
-            self.start(manifest.runtime, &manifest.name).await?;
-            instance = self.inspect(manifest.runtime, &manifest.name).await?;
+            match self.start(manifest.runtime, &manifest.name).await {
+                Ok(()) => {
+                    if manifest.runtime != RuntimeKind::External {
+                        workload_action = ServiceWorkloadAction::Restarted;
+                    }
+                    match self.inspect(manifest.runtime, &manifest.name).await {
+                        Ok(inspected) => instance = inspected,
+                        Err(error) => {
+                            instance.status = ServiceStatus::unknown();
+                            failure = Some(ServiceApplyFailure {
+                                stage: ServiceApplyFailureStage::FinalInspection,
+                                message: error.to_string(),
+                            });
+                        }
+                    }
+                }
+                Err(error) => {
+                    let mut message = error.to_string();
+                    match self.inspect(manifest.runtime, &manifest.name).await {
+                        Ok(inspected) => {
+                            if inspected.status.is_running()
+                                && manifest.runtime != RuntimeKind::External
+                            {
+                                workload_action = ServiceWorkloadAction::Restarted;
+                            }
+                            instance = inspected;
+                        }
+                        Err(inspect_error) => {
+                            instance.status = ServiceStatus::unknown();
+                            message.push_str(&format!(
+                                "; failed to inspect final service state: {inspect_error}"
+                            ));
+                        }
+                    }
+                    failure = Some(ServiceApplyFailure {
+                        stage: ServiceApplyFailureStage::Restart,
+                        message,
+                    });
+                }
+            }
         }
 
         Ok(AppliedService {
             outcome: ServiceApplyOutcome {
                 manifest_change,
-                workload_action: if desired_state == DesiredServiceState::Running
-                    && manifest.runtime != RuntimeKind::External
-                {
-                    ServiceWorkloadAction::Restarted
-                } else {
-                    ServiceWorkloadAction::None
-                },
+                workload_action,
                 final_status: instance.status.clone(),
+                failure,
             },
             instance,
             previous_manifest,

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -41,6 +41,7 @@ pub struct AppliedService {
     pub instance: ServiceInstance,
     pub previous_manifest: Option<ServiceManifest>,
     pub desired_state: DesiredServiceState,
+    pub outcome: ServiceApplyOutcome,
 }
 
 impl RuntimeControl {
@@ -142,6 +143,11 @@ impl RuntimeControl {
             .or(in_memory_runtime);
         let replacing_existing =
             previous_service.is_some() || previous_manifest.is_some() || previous_runtime.is_some();
+        let manifest_change = match previous_manifest.as_ref() {
+            None => ServiceManifestChange::Created,
+            Some(previous) if previous == manifest => ServiceManifestChange::Unchanged,
+            Some(_) => ServiceManifestChange::Changed,
+        };
 
         if let Some(previous_manifest) = previous_manifest.as_ref() {
             ensure_definition_id_compatible(previous_manifest, manifest)?;
@@ -213,6 +219,17 @@ impl RuntimeControl {
         }
 
         Ok(AppliedService {
+            outcome: ServiceApplyOutcome {
+                manifest_change,
+                workload_action: if desired_state == DesiredServiceState::Running
+                    && manifest.runtime != RuntimeKind::External
+                {
+                    ServiceWorkloadAction::Restarted
+                } else {
+                    ServiceWorkloadAction::None
+                },
+                final_status: instance.status.clone(),
+            },
             instance,
             previous_manifest,
             desired_state,

--- a/crates/daemon/src/runtime/mod.rs
+++ b/crates/daemon/src/runtime/mod.rs
@@ -7,7 +7,7 @@ mod providers;
 #[cfg(test)]
 mod tests;
 
-pub use control::RuntimeControl;
+pub use control::{AppliedService, RuntimeControl};
 pub use manifest::{
     load_service_manifest_yaml_file, parse_service_manifest_yaml,
     parse_service_manifest_yaml_with_policy, peek_service_manifest_name,

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -10,7 +10,7 @@ pub enum RuntimeKind {
     External,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceManifest {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -37,7 +37,7 @@ pub enum ServiceRunMode {
     Http,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ServiceSource {
     Docker { image: String },
     WasmtimeFile { component: PathBuf },
@@ -45,14 +45,14 @@ pub enum ServiceSource {
     ExistingTcp { host: String, port: u16 },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceExpose {
     pub transport: ServiceExposeTransport,
     pub usage: Option<ServiceExposeUsage>,
     pub icon_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceExposeTransport {
     pub kind: ServiceExposeTransportKind,
 }
@@ -64,7 +64,7 @@ pub enum ServiceExposeTransportKind {
     Raw,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceExposeUsage {
     pub kind: ServiceExposeUsageKind,
     pub path: Option<String>,
@@ -78,13 +78,13 @@ pub enum ServiceExposeUsageKind {
     Raw,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceMount {
     pub host_path: PathBuf,
     pub runtime_path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServicePort {
     pub name: Option<String>,
     pub host_port: u16,
@@ -158,11 +158,62 @@ impl fmt::Display for ServicePhase {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceStatus {
     pub phase: ServicePhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceManifestChange {
+    Created,
+    Changed,
+    Unchanged,
+    Unknown,
+}
+
+impl fmt::Display for ServiceManifestChange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Created => "created",
+            Self::Changed => "changed",
+            Self::Unchanged => "unchanged",
+            Self::Unknown => "unknown",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceWorkloadAction {
+    None,
+    Started,
+    Restarted,
+    Reloaded,
+    Unknown,
+}
+
+impl fmt::Display for ServiceWorkloadAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::None => "none",
+            Self::Started => "started",
+            Self::Restarted => "restarted",
+            Self::Reloaded => "reloaded",
+            Self::Unknown => "unknown",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceApplyOutcome {
+    pub manifest_change: ServiceManifestChange,
+    pub workload_action: ServiceWorkloadAction,
+    pub final_status: ServiceStatus,
 }
 
 impl ServiceStatus {

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -209,11 +209,62 @@ impl fmt::Display for ServiceWorkloadAction {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceApplyFailureStage {
+    Restart,
+    FinalInspection,
+    EndpointListeners,
+}
+
+impl fmt::Display for ServiceApplyFailureStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Restart => "restart",
+            Self::FinalInspection => "final inspection",
+            Self::EndpointListeners => "endpoint listener synchronization",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceApplyFailure {
+    pub stage: ServiceApplyFailureStage,
+    pub message: String,
+}
+
+impl fmt::Display for ServiceApplyFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} failed: {}", self.stage, self.message)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceApplyOutcome {
     pub manifest_change: ServiceManifestChange,
     pub workload_action: ServiceWorkloadAction,
     pub final_status: ServiceStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ServiceApplyFailure>,
+}
+
+impl ServiceApplyOutcome {
+    pub fn record_failure(&mut self, stage: ServiceApplyFailureStage, message: impl Into<String>) {
+        self.failure = Some(ServiceApplyFailure {
+            stage,
+            message: message.into(),
+        });
+    }
+
+    pub fn failure_summary(&self) -> Option<String> {
+        self.failure.as_ref().map(|failure| {
+            format!(
+                "service manifest applied, but {failure}; final phase: {}",
+                self.final_status.phase
+            )
+        })
+    }
 }
 
 impl ServiceStatus {

--- a/crates/daemon/src/runtime/providers.rs
+++ b/crates/daemon/src/runtime/providers.rs
@@ -472,7 +472,7 @@ impl RuntimeProvider for WasmtimeRuntimeProvider {
 
         refresh_child_state(state)?;
         if state.child.is_some() {
-            bail!("wasmtime service is already running: {handle}");
+            return Ok(());
         }
 
         let mut command = build_wasmtime_command(&self.launcher_path, &self.fungi_home, state)?;

--- a/crates/daemon/src/runtime/tests.rs
+++ b/crates/daemon/src/runtime/tests.rs
@@ -1002,6 +1002,15 @@ publish:
         .await
         .unwrap();
     assert_eq!(applied_v1.instance.name, "demo");
+    assert_eq!(
+        applied_v1.outcome.manifest_change,
+        ServiceManifestChange::Created
+    );
+    assert_eq!(
+        applied_v1.outcome.workload_action,
+        ServiceWorkloadAction::None
+    );
+    assert_eq!(applied_v1.outcome.final_status.phase, ServicePhase::Stopped);
 
     let local_service_id = fs::read_dir(fungi_home.join("services"))
         .unwrap()
@@ -1017,6 +1026,7 @@ publish:
         .join("component.wasm");
     assert_eq!(fs::read(&staged_component).unwrap(), b"wasm-v1");
 
+    control.start_by_name("demo").await.unwrap();
     control.start_by_name("demo").await.unwrap();
 
     let manifest_v2 = format!(
@@ -1057,6 +1067,37 @@ publish:
     );
     assert_eq!(fs::read(&staged_component).unwrap(), b"wasm-v2");
     assert!(applied_v2.instance.status.is_running());
+    assert_eq!(
+        applied_v2.outcome.manifest_change,
+        ServiceManifestChange::Changed
+    );
+    assert_eq!(
+        applied_v2.outcome.workload_action,
+        ServiceWorkloadAction::Restarted
+    );
+    assert_eq!(applied_v2.outcome.final_status.phase, ServicePhase::Running);
+
+    let reapplied_v2 = control
+        .apply_manifest_yaml(
+            &manifest_v2,
+            temp_dir.path(),
+            &fungi_home,
+            &ManifestResolutionPolicy,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        reapplied_v2.outcome.manifest_change,
+        ServiceManifestChange::Unchanged
+    );
+    assert_eq!(
+        reapplied_v2.outcome.workload_action,
+        ServiceWorkloadAction::Restarted
+    );
+    assert_eq!(
+        reapplied_v2.outcome.final_status.phase,
+        ServicePhase::Running
+    );
 }
 
 #[tokio::test]

--- a/crates/daemon/src/runtime/tests.rs
+++ b/crates/daemon/src/runtime/tests.rs
@@ -1100,6 +1100,78 @@ publish:
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn runtime_control_apply_reports_restart_failure_after_persisting_manifest() {
+    let temp_dir = TempDir::new().unwrap();
+    let fungi_home = temp_dir.path().join("fungi-home");
+    let component_v1 = temp_dir.path().join("component-v1.wasm");
+    let component_v2 = temp_dir.path().join("component-v2.wasm");
+    fs::write(&component_v1, b"wasm-v1").unwrap();
+    fs::write(&component_v2, b"wasm-v2").unwrap();
+    let launcher = create_fake_launcher(temp_dir.path()).unwrap();
+
+    let control = RuntimeControl::new(
+        fungi_home.join("runtime"),
+        launcher.clone(),
+        fungi_home.clone(),
+        None,
+        fungi_home.join("services"),
+        vec![temp_dir.path().to_path_buf()],
+        true,
+    )
+    .unwrap();
+
+    let manifest_v1 = wasmtime_manifest_yaml("demo", &component_v1, 19110);
+    control
+        .apply_manifest_yaml(
+            &manifest_v1,
+            temp_dir.path(),
+            &fungi_home,
+            &ManifestResolutionPolicy,
+        )
+        .await
+        .unwrap();
+    control.start_by_name("demo").await.unwrap();
+
+    let mut permissions = fs::metadata(&launcher).unwrap().permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&launcher, permissions).unwrap();
+
+    let manifest_v2 = wasmtime_manifest_yaml("demo", &component_v2, 19110);
+    let applied = control
+        .apply_manifest_yaml(
+            &manifest_v2,
+            temp_dir.path(),
+            &fungi_home,
+            &ManifestResolutionPolicy,
+        )
+        .await
+        .expect("post-persist restart failure should return an apply outcome");
+
+    assert_eq!(
+        applied.outcome.manifest_change,
+        ServiceManifestChange::Changed
+    );
+    assert_eq!(applied.outcome.workload_action, ServiceWorkloadAction::None);
+    assert_eq!(applied.outcome.final_status.phase, ServicePhase::Stopped);
+    let failure = applied.outcome.failure.unwrap();
+    assert_eq!(failure.stage, ServiceApplyFailureStage::Restart);
+    assert!(
+        failure
+            .message
+            .contains("Failed to spawn fungi WASI process")
+    );
+    assert!(matches!(
+        control.get_service_manifest("demo").unwrap().source,
+        ServiceSource::WasmtimeFile { component } if component == component_v2
+    ));
+    assert_eq!(
+        control.inspect_by_name("demo").await.unwrap().status.phase,
+        ServicePhase::Stopped
+    );
+}
+
 #[tokio::test]
 async fn runtime_control_apply_uses_in_memory_manifest_when_persisted_state_is_missing() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/daemon/src/service_control.rs
+++ b/crates/daemon/src/service_control.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::ServiceApplyOutcome;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum ServiceControlRequest {
@@ -65,6 +67,8 @@ pub struct ServiceControlResponse {
     pub services_json: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logs_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apply_outcome: Option<ServiceApplyOutcome>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ServiceControlError>,
 }
@@ -78,6 +82,24 @@ impl ServiceControlResponse {
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
             logs_text: None,
+            apply_outcome: None,
+            error: None,
+        }
+    }
+
+    pub fn success_applied(
+        request_id: Option<String>,
+        service_name: String,
+        apply_outcome: ServiceApplyOutcome,
+    ) -> Self {
+        Self {
+            request_id,
+            ok: true,
+            forgotten_locally: false,
+            service: Some(ServiceControlServiceRef { name: service_name }),
+            services_json: None,
+            logs_text: None,
+            apply_outcome: Some(apply_outcome),
             error: None,
         }
     }
@@ -90,6 +112,7 @@ impl ServiceControlResponse {
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
             logs_text: None,
+            apply_outcome: None,
             error: None,
         }
     }
@@ -102,6 +125,7 @@ impl ServiceControlResponse {
             service: None,
             services_json: Some(services_json),
             logs_text: None,
+            apply_outcome: None,
             error: None,
         }
     }
@@ -114,6 +138,7 @@ impl ServiceControlResponse {
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
             logs_text: Some(text),
+            apply_outcome: None,
             error: None,
         }
     }
@@ -126,6 +151,7 @@ impl ServiceControlResponse {
             service: None,
             services_json: None,
             logs_text: None,
+            apply_outcome: None,
             error: Some(ServiceControlError {
                 code: code.to_string(),
                 message,
@@ -155,4 +181,36 @@ pub struct ServiceControlServiceRef {
 pub struct ServiceControlError {
     pub code: String,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ServiceManifestChange, ServicePhase, ServiceStatus, ServiceWorkloadAction};
+
+    #[test]
+    fn legacy_response_without_apply_outcome_remains_compatible() {
+        let response: ServiceControlResponse =
+            serde_json::from_str(r#"{"request_id":null,"ok":true,"service":{"name":"demo"}}"#)
+                .unwrap();
+
+        assert!(response.apply_outcome.is_none());
+    }
+
+    #[test]
+    fn applied_response_round_trips_structured_outcome() {
+        let response = ServiceControlResponse::success_applied(
+            None,
+            "demo".to_string(),
+            ServiceApplyOutcome {
+                manifest_change: ServiceManifestChange::Unchanged,
+                workload_action: ServiceWorkloadAction::Restarted,
+                final_status: ServiceStatus::new(ServicePhase::Running),
+            },
+        );
+
+        let encoded = serde_json::to_string(&response).unwrap();
+        let decoded: ServiceControlResponse = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.apply_outcome, response.apply_outcome);
+    }
 }

--- a/crates/daemon/src/service_control.rs
+++ b/crates/daemon/src/service_control.rs
@@ -87,20 +87,26 @@ impl ServiceControlResponse {
         }
     }
 
-    pub fn success_applied(
+    pub fn applied(
         request_id: Option<String>,
         service_name: String,
         apply_outcome: ServiceApplyOutcome,
     ) -> Self {
+        let error = apply_outcome
+            .failure_summary()
+            .map(|message| ServiceControlError {
+                code: "partial_apply".to_string(),
+                message,
+            });
         Self {
             request_id,
-            ok: true,
+            ok: error.is_none(),
             forgotten_locally: false,
             service: Some(ServiceControlServiceRef { name: service_name }),
             services_json: None,
             logs_text: None,
             apply_outcome: Some(apply_outcome),
-            error: None,
+            error,
         }
     }
 
@@ -170,6 +176,19 @@ impl ServiceControlResponse {
             anyhow::bail!("{}: {}", error.code, error.message)
         }
     }
+
+    pub fn into_apply_result(self) -> anyhow::Result<Self> {
+        if self.ok
+            || self
+                .apply_outcome
+                .as_ref()
+                .is_some_and(|outcome| outcome.failure.is_some())
+        {
+            Ok(self)
+        } else {
+            self.into_result()
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,18 +218,47 @@ mod tests {
 
     #[test]
     fn applied_response_round_trips_structured_outcome() {
-        let response = ServiceControlResponse::success_applied(
+        let response = ServiceControlResponse::applied(
             None,
             "demo".to_string(),
             ServiceApplyOutcome {
                 manifest_change: ServiceManifestChange::Unchanged,
                 workload_action: ServiceWorkloadAction::Restarted,
                 final_status: ServiceStatus::new(ServicePhase::Running),
+                failure: None,
             },
         );
 
         let encoded = serde_json::to_string(&response).unwrap();
         let decoded: ServiceControlResponse = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded.apply_outcome, response.apply_outcome);
+    }
+
+    #[test]
+    fn partial_apply_response_preserves_remote_failure_details() {
+        let response = ServiceControlResponse::applied(
+            None,
+            "demo".to_string(),
+            ServiceApplyOutcome {
+                manifest_change: ServiceManifestChange::Changed,
+                workload_action: ServiceWorkloadAction::None,
+                final_status: ServiceStatus::stopped(),
+                failure: Some(crate::ServiceApplyFailure {
+                    stage: crate::ServiceApplyFailureStage::Restart,
+                    message: "launcher failed".to_string(),
+                }),
+            },
+        );
+
+        assert!(!response.ok);
+        assert_eq!(response.error.as_ref().unwrap().code, "partial_apply");
+
+        let encoded = serde_json::to_string(&response).unwrap();
+        let decoded: ServiceControlResponse = serde_json::from_str(&encoded).unwrap();
+        let preserved = decoded.into_apply_result().unwrap();
+        assert_eq!(
+            preserved.apply_outcome.unwrap().failure.unwrap().message,
+            "launcher failed"
+        );
     }
 }

--- a/crates/daemon/src/service_endpoints.rs
+++ b/crates/daemon/src/service_endpoints.rs
@@ -2,9 +2,48 @@ use anyhow::Result;
 use fungi_config::tcp_tunneling::ListeningRule;
 
 use crate::{
-    RuntimeControl, ServiceManifest, controls::TcpTunnelingControl,
-    runtime::service_expose_endpoint_bindings,
+    AppliedService, RuntimeControl, ServiceApplyFailureStage, ServiceManifest,
+    controls::TcpTunnelingControl, runtime::service_expose_endpoint_bindings,
+    service_state::DesiredServiceState,
 };
+
+pub(crate) async fn sync_applied_service_endpoint_listeners(
+    runtime: &RuntimeControl,
+    tcp_tunneling: &TcpTunnelingControl,
+    applied: &mut AppliedService,
+) {
+    if applied.desired_state != DesiredServiceState::Running || applied.outcome.failure.is_some() {
+        return;
+    }
+
+    if let Err(error) = sync_service_endpoint_listeners_for_manifest(
+        tcp_tunneling,
+        applied.previous_manifest.as_ref(),
+        false,
+    )
+    .await
+    {
+        applied.outcome.record_failure(
+            ServiceApplyFailureStage::EndpointListeners,
+            format!("failed to update endpoint listeners: {error}"),
+        );
+        return;
+    }
+
+    if let Err(error) = sync_service_endpoint_listeners_by_name(
+        runtime,
+        tcp_tunneling,
+        &applied.instance.name,
+        true,
+    )
+    .await
+    {
+        applied.outcome.record_failure(
+            ServiceApplyFailureStage::EndpointListeners,
+            format!("failed to publish endpoint listeners: {error}"),
+        );
+    }
+}
 
 pub(crate) async fn sync_service_endpoint_listeners_by_name(
     runtime: &RuntimeControl,

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -20,9 +20,9 @@ use crate::{
     },
     runtime::RuntimeControl,
     service_endpoints::{
-        sync_service_endpoint_listeners_by_name, sync_service_endpoint_listeners_for_manifest,
+        sync_applied_service_endpoint_listeners, sync_service_endpoint_listeners_by_name,
+        sync_service_endpoint_listeners_for_manifest,
     },
-    service_state::DesiredServiceState,
 };
 
 const REMOTE_SERVICE_REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
@@ -337,10 +337,17 @@ impl DeviceServices {
         manifest_yaml: String,
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceHandle> {
-        Ok(self
+        let applied = self
             .apply_manifest_yaml_with_outcome(manifest_yaml, manifest_base_dir)
-            .await?
-            .service)
+            .await?;
+        if let Some(message) = applied
+            .outcome
+            .as_ref()
+            .and_then(ServiceApplyOutcome::failure_summary)
+        {
+            anyhow::bail!(message);
+        }
+        Ok(applied.service)
     }
 
     pub(crate) async fn apply_manifest_yaml_with_outcome(
@@ -351,7 +358,7 @@ impl DeviceServices {
         if self.is_local() {
             let fungi_home = self.services.inner.fungi_dir.clone();
             let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
-            let applied = self
+            let mut applied = self
                 .services
                 .inner
                 .local
@@ -363,33 +370,12 @@ impl DeviceServices {
                     &ManifestResolutionPolicy,
                 )
                 .await?;
-            if applied.desired_state == DesiredServiceState::Running {
-                sync_service_endpoint_listeners_for_manifest(
-                    &self.services.inner.local.tcp_tunneling,
-                    applied.previous_manifest.as_ref(),
-                    false,
-                )
-                .await
-                .with_context(|| {
-                    format!(
-                        "service manifest applied, but failed to update endpoint listeners; final phase: {}",
-                        applied.outcome.final_status.phase
-                    )
-                })?;
-                sync_service_endpoint_listeners_by_name(
-                    &self.services.inner.local.runtime,
-                    &self.services.inner.local.tcp_tunneling,
-                    &applied.instance.name,
-                    true,
-                )
-                .await
-                .with_context(|| {
-                    format!(
-                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
-                        applied.outcome.final_status.phase
-                    )
-                })?;
-            }
+            sync_applied_service_endpoint_listeners(
+                &self.services.inner.local.runtime,
+                &self.services.inner.local.tcp_tunneling,
+                &mut applied,
+            )
+            .await;
             Ok(AppliedServiceHandle {
                 service: self.service(applied.instance.name),
                 outcome: Some(applied.outcome),

--- a/crates/daemon/src/services.rs
+++ b/crates/daemon/src/services.rs
@@ -13,8 +13,8 @@ use libp2p::PeerId;
 use parking_lot::Mutex;
 
 use crate::{
-    DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceInstance, ServiceLogs,
-    ServiceLogsOptions,
+    DeviceService, DeviceServiceSnapshot, ManifestResolutionPolicy, ServiceApplyOutcome,
+    ServiceInstance, ServiceLogs, ServiceLogsOptions,
     controls::{
         DockerControl, ServiceControlProtocolControl, ServiceDiscoveryControl, TcpTunnelingControl,
     },
@@ -217,6 +217,11 @@ pub struct DeviceServices {
     services: Services,
 }
 
+pub(crate) struct AppliedServiceHandle {
+    pub service: ServiceHandle,
+    pub outcome: Option<ServiceApplyOutcome>,
+}
+
 impl DeviceServices {
     pub fn device_id(&self) -> PeerId {
         self.device_id
@@ -332,6 +337,17 @@ impl DeviceServices {
         manifest_yaml: String,
         manifest_base_dir: Option<PathBuf>,
     ) -> Result<ServiceHandle> {
+        Ok(self
+            .apply_manifest_yaml_with_outcome(manifest_yaml, manifest_base_dir)
+            .await?
+            .service)
+    }
+
+    pub(crate) async fn apply_manifest_yaml_with_outcome(
+        &self,
+        manifest_yaml: String,
+        manifest_base_dir: Option<PathBuf>,
+    ) -> Result<AppliedServiceHandle> {
         if self.is_local() {
             let fungi_home = self.services.inner.fungi_dir.clone();
             let base_dir = manifest_base_dir.unwrap_or_else(|| fungi_home.clone());
@@ -353,16 +369,31 @@ impl DeviceServices {
                     applied.previous_manifest.as_ref(),
                     false,
                 )
-                .await?;
+                .await
+                .with_context(|| {
+                    format!(
+                        "service manifest applied, but failed to update endpoint listeners; final phase: {}",
+                        applied.outcome.final_status.phase
+                    )
+                })?;
                 sync_service_endpoint_listeners_by_name(
                     &self.services.inner.local.runtime,
                     &self.services.inner.local.tcp_tunneling,
                     &applied.instance.name,
                     true,
                 )
-                .await?;
+                .await
+                .with_context(|| {
+                    format!(
+                        "service manifest applied, but failed to publish endpoint listeners; final phase: {}",
+                        applied.outcome.final_status.phase
+                    )
+                })?;
             }
-            Ok(self.service(applied.instance.name))
+            Ok(AppliedServiceHandle {
+                service: self.service(applied.instance.name),
+                outcome: Some(applied.outcome),
+            })
         } else {
             let response = self
                 .services
@@ -378,7 +409,10 @@ impl DeviceServices {
                 .ok_or_else(|| {
                     anyhow::anyhow!("service apply response did not include a service")
                 })?;
-            Ok(self.service(service_name))
+            Ok(AppliedServiceHandle {
+                service: self.service(service_name),
+                outcome: response.apply_outcome,
+            })
         }
     }
 

--- a/crates/tests/src/bin/test_service_apply_cli.rs
+++ b/crates/tests/src/bin/test_service_apply_cli.rs
@@ -289,7 +289,7 @@ fn apply_service(fungi_bin: &Path, fungi_dir: &Path, target: &str, manifest: &Pa
     args.extend(["apply", name, "--yes"]);
     args.push(manifest);
     let output = run_cli(fungi_bin, fungi_dir, args)?;
-    if !output.contains("Remote service applied:") && !output.contains("\"name\":") {
+    if !output.contains("Remote service applied:") && !output.contains("Service applied:") {
         bail!("unexpected apply output:\n{output}");
     }
     Ok(())

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -6,8 +6,9 @@ use clap::{Args, Subcommand};
 use fungi_config::{FungiDir, devices::LOCAL_DEVICE_NAME, paths::FungiPaths};
 use fungi_daemon::{
     DEFAULT_REMOTE_SERVICE_LOG_TAIL, DeviceService, DeviceServiceSnapshot,
-    MAX_REMOTE_SERVICE_LOG_TAIL, RuntimeKind, ServiceAccess, ServiceExposeUsageKind,
-    ServiceInstance, ServicePhase, ServicePortProtocol, ServiceStatus, parse_service_manifest_yaml,
+    MAX_REMOTE_SERVICE_LOG_TAIL, RuntimeKind, ServiceAccess, ServiceApplyOutcome,
+    ServiceExposeUsageKind, ServiceInstance, ServiceManifestChange, ServicePhase,
+    ServicePortProtocol, ServiceStatus, ServiceWorkloadAction, parse_service_manifest_yaml,
     service_manifest_with_instance_name,
 };
 use fungi_daemon_grpc::{
@@ -70,7 +71,10 @@ pub enum ServiceCommands {
         #[arg(long, default_value_t = false)]
         refresh: bool,
     },
-    /// Apply a service file
+    /// Apply a service definition
+    #[command(
+        after_long_help = "State behavior:\n  First deployment: add --start to finish in the running phase.\n  Running service update: apply preserves running state and restarts the workload.\n  Stopped service update: apply preserves stopped state; add --start to finish running."
+    )]
     Apply {
         /// Service instance target to create or update
         #[arg(value_name = "NAME[@DEVICE]")]
@@ -90,7 +94,7 @@ pub enum ServiceCommands {
         /// Preview parsing, validation, and runtime intent without changing state
         #[arg(long, default_value_t = false)]
         dry_run: bool,
-        /// Start the service after applying it
+        /// Ensure the service is running after applying it
         #[arg(long, default_value_t = false)]
         start: bool,
         /// Skip service apply confirmation prompts
@@ -873,21 +877,7 @@ async fn apply_service_from_recipe(
         };
         match client.remote_pull_service(Request::new(req)).await {
             Ok(resp) => {
-                let response = resp.into_inner();
-                let service_name = response_service_name(&response);
-                print_remote_service_applied(response);
-                if start {
-                    let req = RemoteServiceNameRequest {
-                        peer_id: device.peer_id.clone(),
-                        name: service_name.clone(),
-                    };
-                    match client.remote_start_service(Request::new(req)).await {
-                        Ok(resp) => print_remote_service_result("started", resp.into_inner()),
-                        Err(error) => fatal_remote_device_grpc(error),
-                    }
-                }
-                refresh_remote_device_services(client, &device.peer_id).await;
-                print_remote_apply_next_steps(&service_name, &device, start);
+                finish_remote_apply(client, &device, resp.into_inner(), start).await;
             }
             Err(error) => fatal_remote_device_grpc(error),
         }
@@ -899,16 +889,7 @@ async fn apply_service_from_recipe(
         };
         match client.pull_service(Request::new(req)).await {
             Ok(resp) => {
-                let instance = decode_service_instance(resp.into_inner());
-                let name = instance.name.clone();
-                print_service_instance_value(instance, false);
-                if start {
-                    let req = ServiceNameRequest { runtime: 0, name };
-                    match client.start_service(Request::new(req)).await {
-                        Ok(_) => println!("Service started"),
-                        Err(error) => fatal_grpc(error),
-                    }
-                }
+                finish_local_apply(client, resp.into_inner(), start).await;
             }
             Err(error) => fatal_grpc(error),
         }
@@ -1082,6 +1063,196 @@ fn print_remote_apply_next_steps(
     }
 }
 
+fn decode_apply_outcome(value: &str) -> Option<ServiceApplyOutcome> {
+    if value.trim().is_empty() {
+        return None;
+    }
+    Some(
+        serde_json::from_str(value).unwrap_or_else(|error| {
+            fatal(format!("Failed to decode service apply outcome: {error}"))
+        }),
+    )
+}
+
+fn fallback_apply_outcome(status: ServiceStatus) -> ServiceApplyOutcome {
+    ServiceApplyOutcome {
+        manifest_change: ServiceManifestChange::Unknown,
+        workload_action: ServiceWorkloadAction::Unknown,
+        final_status: status,
+    }
+}
+
+fn print_service_apply_outcome(
+    service_name: &str,
+    device_name: Option<&str>,
+    outcome: &ServiceApplyOutcome,
+) {
+    match device_name {
+        Some(device_name) => println!("Remote service applied: {service_name}@{device_name}"),
+        None => println!("Service applied: {service_name}"),
+    }
+    println!("Manifest: {}", outcome.manifest_change);
+    println!("Workload: {}", outcome.workload_action);
+    println!("Final phase: {}", outcome.final_status.phase);
+    if let Some(detail) = outcome.final_status.detail.as_deref() {
+        println!("Final detail: {detail}");
+    }
+}
+
+fn fatal_partial_apply(
+    service_name: &str,
+    requested_phase: Option<ServicePhase>,
+    final_status: Option<&ServiceStatus>,
+    action_error: Option<&str>,
+    inspect_error: Option<&str>,
+) -> ! {
+    fatal(partial_apply_message(
+        service_name,
+        requested_phase,
+        final_status,
+        action_error,
+        inspect_error,
+    ))
+}
+
+fn partial_apply_message(
+    service_name: &str,
+    requested_phase: Option<ServicePhase>,
+    final_status: Option<&ServiceStatus>,
+    action_error: Option<&str>,
+    inspect_error: Option<&str>,
+) -> String {
+    let final_state = final_status
+        .map(|status| status.state_label())
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut message = match requested_phase {
+        Some(requested_phase) => format!(
+            "Service manifest applied for {service_name}, but the requested final phase `{requested_phase}` was not verified. Final state: {final_state}."
+        ),
+        None => format!(
+            "Service manifest applied for {service_name}, but its final state could not be verified. Final state: {final_state}."
+        ),
+    };
+    if let Some(error) = action_error {
+        message.push_str(&format!(" Start error: {error}."));
+    }
+    if let Some(error) = inspect_error {
+        message.push_str(&format!(" Inspect error: {error}."));
+    }
+    message
+}
+
+async fn finish_local_apply(
+    client: &mut RpcClient,
+    response: ServiceInstanceResponse,
+    start_requested: bool,
+) {
+    let decoded_outcome = decode_apply_outcome(&response.apply_outcome_json);
+    let instance = decode_service_instance(response);
+    let service_name = instance.name.clone();
+    let has_managed_workload = instance.runtime != RuntimeKind::External;
+    let mut outcome =
+        decoded_outcome.unwrap_or_else(|| fallback_apply_outcome(instance.status.clone()));
+
+    if start_requested {
+        let was_running = outcome.final_status.is_running();
+        let start_error = client
+            .start_service(Request::new(ServiceNameRequest {
+                runtime: 0,
+                name: service_name.clone(),
+            }))
+            .await
+            .err()
+            .map(|error| error.message().to_string());
+        let inspected = try_inspect_local_service(client, service_name.clone()).await;
+        match inspected {
+            Ok(instance) if instance.status.is_running() => {
+                outcome.final_status = instance.status;
+                if !was_running && has_managed_workload {
+                    outcome.workload_action = ServiceWorkloadAction::Started;
+                }
+            }
+            Ok(instance) => fatal_partial_apply(
+                &service_name,
+                Some(ServicePhase::Running),
+                Some(&instance.status),
+                start_error.as_deref(),
+                None,
+            ),
+            Err(inspect_error) => fatal_partial_apply(
+                &service_name,
+                Some(ServicePhase::Running),
+                None,
+                start_error.as_deref(),
+                Some(&inspect_error),
+            ),
+        }
+    }
+
+    print_service_apply_outcome(&service_name, None, &outcome);
+}
+
+async fn finish_remote_apply(
+    client: &mut RpcClient,
+    device: &super::shared::ResolvedPeerTarget,
+    response: RemoteServiceControlResponse,
+    start_requested: bool,
+) {
+    let service_name = response_service_name(&response);
+    let mut outcome = match decode_apply_outcome(&response.apply_outcome_json) {
+        Some(outcome) => outcome,
+        None => match try_inspect_remote_service(client, &device.peer_id, &service_name).await {
+            Ok(service) => fallback_apply_outcome(service.status),
+            Err(error) => fatal_partial_apply(
+                &service_name,
+                start_requested.then_some(ServicePhase::Running),
+                None,
+                None,
+                Some(&error),
+            ),
+        },
+    };
+
+    if start_requested {
+        let was_running = outcome.final_status.is_running();
+        let start_error = client
+            .remote_start_service(Request::new(RemoteServiceNameRequest {
+                peer_id: device.peer_id.clone(),
+                name: service_name.clone(),
+            }))
+            .await
+            .err()
+            .map(|error| error.message().to_string());
+        let inspected = try_inspect_remote_service(client, &device.peer_id, &service_name).await;
+        match inspected {
+            Ok(service) if service.status.is_running() => {
+                outcome.final_status = service.status;
+                if !was_running && service.runtime != RuntimeKind::External {
+                    outcome.workload_action = ServiceWorkloadAction::Started;
+                }
+            }
+            Ok(service) => fatal_partial_apply(
+                &service_name,
+                Some(ServicePhase::Running),
+                Some(&service.status),
+                start_error.as_deref(),
+                None,
+            ),
+            Err(inspect_error) => fatal_partial_apply(
+                &service_name,
+                Some(ServicePhase::Running),
+                None,
+                start_error.as_deref(),
+                Some(&inspect_error),
+            ),
+        }
+    }
+
+    let device_name = resolved_device_display_name(device);
+    print_service_apply_outcome(&service_name, Some(&device_name), &outcome);
+    print_remote_apply_next_steps(&service_name, device, start_requested);
+}
+
 async fn apply_created_service(
     client: &mut RpcClient,
     args: &CommonArgs,
@@ -1098,21 +1269,7 @@ async fn apply_created_service(
         };
         match client.remote_pull_service(Request::new(req)).await {
             Ok(resp) => {
-                let response = resp.into_inner();
-                let applied_service_name = response_service_name(&response);
-                print_remote_service_applied(response);
-                if created.start_now {
-                    let req = RemoteServiceNameRequest {
-                        peer_id: device.peer_id.clone(),
-                        name: applied_service_name.clone(),
-                    };
-                    match client.remote_start_service(Request::new(req)).await {
-                        Ok(resp) => print_remote_service_result("started", resp.into_inner()),
-                        Err(error) => fatal_remote_device_grpc(error),
-                    }
-                }
-                refresh_remote_device_services(client, &device.peer_id).await;
-                print_remote_apply_next_steps(&applied_service_name, &device, created.start_now);
+                finish_remote_apply(client, &device, resp.into_inner(), created.start_now).await;
             }
             Err(error) => fatal_remote_device_grpc(error),
         }
@@ -1123,16 +1280,7 @@ async fn apply_created_service(
         };
         match client.pull_service(Request::new(req)).await {
             Ok(resp) => {
-                let instance = decode_service_instance(resp.into_inner());
-                let name = instance.name.clone();
-                print_service_instance_value(instance, false);
-                if created.start_now {
-                    let req = ServiceNameRequest { runtime: 0, name };
-                    match client.start_service(Request::new(req)).await {
-                        Ok(_) => println!("Service started"),
-                        Err(error) => fatal_grpc(error),
-                    }
-                }
+                finish_local_apply(client, resp.into_inner(), created.start_now).await;
             }
             Err(error) => fatal_grpc(error),
         }
@@ -1212,11 +1360,6 @@ fn response_service_name(resp: &RemoteServiceControlResponse) -> String {
     service_name.to_string()
 }
 
-fn print_remote_service_applied(resp: RemoteServiceControlResponse) {
-    let service_name = response_service_name(&resp);
-    println!("Remote service applied: {service_name}");
-}
-
 fn print_remote_service_result(action: &str, resp: RemoteServiceControlResponse) {
     let service_name = response_service_name(&resp);
     if resp.forgotten_locally {
@@ -1275,14 +1418,23 @@ async fn refresh_remote_device_services(client: &mut RpcClient, peer_id: &str) {
 }
 
 async fn inspect_local_service(client: &mut RpcClient, name: String) -> ServiceInstance {
+    try_inspect_local_service(client, name)
+        .await
+        .unwrap_or_else(|error| fatal(error))
+}
+
+async fn try_inspect_local_service(
+    client: &mut RpcClient,
+    name: String,
+) -> Result<ServiceInstance, String> {
     let req = ServiceNameRequest { runtime: 0, name };
     match client.inspect_service(Request::new(req)).await {
         Ok(resp) => match serde_json::from_str::<ServiceInstance>(&resp.into_inner().instance_json)
         {
-            Ok(instance) => instance,
-            Err(error) => fatal(format!("Failed to decode service instance: {error}")),
+            Ok(instance) => Ok(instance),
+            Err(error) => Err(format!("Failed to decode service instance: {error}")),
         },
-        Err(error) => fatal_grpc(error),
+        Err(error) => Err(error.message().to_string()),
     }
 }
 
@@ -1468,19 +1620,29 @@ async fn inspect_remote_service(
     peer_id: &str,
     name: String,
 ) -> RemoteService {
+    try_inspect_remote_service(client, peer_id, &name)
+        .await
+        .unwrap_or_else(|error| fatal_remote_device_message(&error))
+}
+
+async fn try_inspect_remote_service(
+    client: &mut RpcClient,
+    peer_id: &str,
+    name: &str,
+) -> Result<RemoteService, String> {
     match fetch_device_service_snapshot(client, peer_id, true).await {
         Ok(snapshot) => {
             if snapshot.error.is_some() {
-                fatal(REMOTE_DEVICE_CONNECTION_MESSAGE);
+                return Err(REMOTE_DEVICE_CONNECTION_MESSAGE.to_string());
             }
             snapshot
                 .snapshot
                 .services
                 .into_iter()
                 .find(|service| service.name == name)
-                .unwrap_or_else(|| fatal(format!("Remote service not found: {name}")))
+                .ok_or_else(|| format!("Remote service not found: {name}"))
         }
-        Err(error) => fatal_remote_device_message(&error),
+        Err(error) => Err(error),
     }
 }
 
@@ -2009,7 +2171,7 @@ fn print_service_apply_dry_run(created: &CreatedServiceManifest, args: &CommonAr
         }
     }
     if created.start_now {
-        println!("After apply: start service");
+        println!("After apply: ensure service is running");
     } else {
         println!("After apply: leave service stopped unless it was already running");
     }
@@ -2917,6 +3079,23 @@ mod tests {
         };
 
         assert_eq!(service_request_timeout(&list), DEFAULT_RPC_REQUEST_TIMEOUT);
+    }
+
+    #[test]
+    fn partial_apply_message_reports_applied_manifest_and_final_state() {
+        let status = ServiceStatus::stopped();
+        let message = partial_apply_message(
+            "demo",
+            Some(ServicePhase::Running),
+            Some(&status),
+            Some("launcher failed"),
+            None,
+        );
+
+        assert!(message.contains("Service manifest applied for demo"));
+        assert!(message.contains("requested final phase `running`"));
+        assert!(message.contains("Final state: stopped"));
+        assert!(message.contains("Start error: launcher failed"));
     }
 
     #[test]

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -1142,6 +1142,10 @@ fn partial_apply_message(
     message
 }
 
+fn running_phase_verified(status: &ServiceStatus, start_error: Option<&str>) -> bool {
+    status.is_running() && start_error.is_none()
+}
+
 async fn finish_local_apply(
     client: &mut RpcClient,
     response: ServiceInstanceResponse,
@@ -1166,7 +1170,7 @@ async fn finish_local_apply(
             .map(|error| error.message().to_string());
         let inspected = try_inspect_local_service(client, service_name.clone()).await;
         match inspected {
-            Ok(instance) if instance.status.is_running() => {
+            Ok(instance) if running_phase_verified(&instance.status, start_error.as_deref()) => {
                 outcome.final_status = instance.status;
                 if !was_running && has_managed_workload {
                     outcome.workload_action = ServiceWorkloadAction::Started;
@@ -1225,7 +1229,7 @@ async fn finish_remote_apply(
             .map(|error| error.message().to_string());
         let inspected = try_inspect_remote_service(client, &device.peer_id, &service_name).await;
         match inspected {
-            Ok(service) if service.status.is_running() => {
+            Ok(service) if running_phase_verified(&service.status, start_error.as_deref()) => {
                 outcome.final_status = service.status;
                 if !was_running && service.runtime != RuntimeKind::External {
                     outcome.workload_action = ServiceWorkloadAction::Started;
@@ -3096,6 +3100,17 @@ mod tests {
         assert!(message.contains("requested final phase `running`"));
         assert!(message.contains("Final state: stopped"));
         assert!(message.contains("Start error: launcher failed"));
+    }
+
+    #[test]
+    fn running_phase_is_not_verified_when_start_reports_an_error() {
+        let status = ServiceStatus::running();
+
+        assert!(running_phase_verified(&status, None));
+        assert!(!running_phase_verified(
+            &status,
+            Some("listener synchronization failed")
+        ));
     }
 
     #[test]

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -12,7 +12,7 @@ use fungi_daemon::{
     service_manifest_with_instance_name,
 };
 use fungi_daemon_grpc::{
-    Request,
+    Request, decode_service_apply_failure_status,
     fungi_daemon_grpc::{
         AttachServiceAccessRequest, DetachServiceAccessRequest, DeviceInfo,
         DeviceServiceSnapshotRequest, Empty, GetRecipeRequest, GetServiceLogsRequest,
@@ -296,7 +296,7 @@ pub async fn execute_service(args: CommonArgs, service_args: ServiceArgs) {
             };
             match client.pull_service(Request::new(req)).await {
                 Ok(resp) => print_service_instance(resp.into_inner(), false),
-                Err(e) => fatal_grpc(e),
+                Err(error) => fatal_apply_grpc(error, None),
             }
         }
         ServiceCommands::Start { name } => {
@@ -879,7 +879,7 @@ async fn apply_service_from_recipe(
             Ok(resp) => {
                 finish_remote_apply(client, &device, resp.into_inner(), start).await;
             }
-            Err(error) => fatal_remote_device_grpc(error),
+            Err(error) => fatal_apply_grpc(error, Some(&device)),
         }
     } else {
         print_recipe_runtime_wait_notice(&detail);
@@ -891,7 +891,7 @@ async fn apply_service_from_recipe(
             Ok(resp) => {
                 finish_local_apply(client, resp.into_inner(), start).await;
             }
-            Err(error) => fatal_grpc(error),
+            Err(error) => fatal_apply_grpc(error, None),
         }
     }
 }
@@ -1079,6 +1079,7 @@ fn fallback_apply_outcome(status: ServiceStatus) -> ServiceApplyOutcome {
         manifest_change: ServiceManifestChange::Unknown,
         workload_action: ServiceWorkloadAction::Unknown,
         final_status: status,
+        failure: None,
     }
 }
 
@@ -1096,6 +1097,49 @@ fn print_service_apply_outcome(
     println!("Final phase: {}", outcome.final_status.phase);
     if let Some(detail) = outcome.final_status.detail.as_deref() {
         println!("Final detail: {detail}");
+    }
+}
+
+fn apply_failure_message(service_name: &str, outcome: &ServiceApplyOutcome) -> String {
+    let failure = outcome
+        .failure
+        .as_ref()
+        .expect("apply failure message requires a failed outcome");
+    format!(
+        "Service manifest applied for {service_name}, but {failure}. Final state: {}.",
+        outcome.final_status.state_label()
+    )
+}
+
+fn fatal_failed_apply(
+    service_name: &str,
+    device_name: Option<&str>,
+    outcome: &ServiceApplyOutcome,
+) -> ! {
+    print_service_apply_outcome(service_name, device_name, outcome);
+    let target = match device_name {
+        Some(device_name) => format!("{service_name}@{device_name}"),
+        None => service_name.to_string(),
+    };
+    fatal(apply_failure_message(&target, outcome))
+}
+
+fn fatal_apply_grpc(error: tonic::Status, device: Option<&super::shared::ResolvedPeerTarget>) -> ! {
+    if let Some(response) = decode_service_apply_failure_status(&error) {
+        let service_name = response
+            .service
+            .map(|service| service.name)
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let outcome = response
+            .apply_outcome
+            .expect("decoded partial apply status requires an outcome");
+        let device_name = device.map(resolved_device_display_name);
+        fatal_failed_apply(&service_name, device_name.as_deref(), &outcome);
+    }
+
+    match device {
+        Some(_) => fatal_remote_device_grpc(error),
+        None => fatal_grpc(error),
     }
 }
 
@@ -1158,6 +1202,10 @@ async fn finish_local_apply(
     let mut outcome =
         decoded_outcome.unwrap_or_else(|| fallback_apply_outcome(instance.status.clone()));
 
+    if outcome.failure.is_some() {
+        fatal_failed_apply(&service_name, None, &outcome);
+    }
+
     if start_requested {
         let was_running = outcome.final_status.is_running();
         let start_error = client
@@ -1216,6 +1264,11 @@ async fn finish_remote_apply(
             ),
         },
     };
+    let device_name = resolved_device_display_name(device);
+
+    if outcome.failure.is_some() {
+        fatal_failed_apply(&service_name, Some(&device_name), &outcome);
+    }
 
     if start_requested {
         let was_running = outcome.final_status.is_running();
@@ -1252,7 +1305,6 @@ async fn finish_remote_apply(
         }
     }
 
-    let device_name = resolved_device_display_name(device);
     print_service_apply_outcome(&service_name, Some(&device_name), &outcome);
     print_remote_apply_next_steps(&service_name, device, start_requested);
 }
@@ -1275,7 +1327,7 @@ async fn apply_created_service(
             Ok(resp) => {
                 finish_remote_apply(client, &device, resp.into_inner(), created.start_now).await;
             }
-            Err(error) => fatal_remote_device_grpc(error),
+            Err(error) => fatal_apply_grpc(error, Some(&device)),
         }
     } else {
         let req = PullServiceRequest {
@@ -1286,7 +1338,7 @@ async fn apply_created_service(
             Ok(resp) => {
                 finish_local_apply(client, resp.into_inner(), created.start_now).await;
             }
-            Err(error) => fatal_grpc(error),
+            Err(error) => fatal_apply_grpc(error, None),
         }
     }
 }
@@ -3111,6 +3163,25 @@ mod tests {
             &status,
             Some("listener synchronization failed")
         ));
+    }
+
+    #[test]
+    fn apply_failure_message_reports_internal_restart_and_final_state() {
+        let outcome = ServiceApplyOutcome {
+            manifest_change: ServiceManifestChange::Changed,
+            workload_action: ServiceWorkloadAction::None,
+            final_status: ServiceStatus::stopped(),
+            failure: Some(fungi_daemon::ServiceApplyFailure {
+                stage: fungi_daemon::ServiceApplyFailureStage::Restart,
+                message: "Failed to spawn fungi WASI process".to_string(),
+            }),
+        };
+
+        let message = apply_failure_message("demo", &outcome);
+
+        assert!(message.contains("Service manifest applied for demo"));
+        assert!(message.contains("restart failed"));
+        assert!(message.contains("Final state: stopped"));
     }
 
     #[test]

--- a/fungi/tests/cli_smoke.rs
+++ b/fungi/tests/cli_smoke.rs
@@ -210,7 +210,86 @@ fn service_apply_dry_run_prints_resolved_intent() {
             .stdout
             .contains("$fungi.root exposes the full Fungi user root")
     );
-    assert!(output.stdout.contains("After apply: start service"));
+    assert!(
+        output
+            .stdout
+            .contains("After apply: ensure service is running")
+    );
+}
+
+#[test]
+fn service_apply_start_reports_and_preserves_the_final_running_state() {
+    let home = TempDir::new().unwrap();
+    let rpc = reserve_port();
+    let swarm = reserve_port();
+    let target = reserve_port();
+
+    init_fungi_dir(home.path(), rpc, swarm);
+    let _daemon = start_daemon(home.path());
+    let _peer = wait_peer_id(home.path());
+    let manifest = write_existing_tcp_service_manifest(home.path(), "apply-start", target, "raw");
+    let manifest_path = manifest.to_string_lossy();
+
+    let first = run_cli_result(
+        home.path(),
+        [
+            "service",
+            "apply",
+            "apply-start",
+            "--yes",
+            "--start",
+            manifest_path.as_ref(),
+        ],
+        "",
+    );
+    assert!(
+        first.status.success(),
+        "first apply failed\nstdout:\n{}\nstderr:\n{}",
+        first.stdout,
+        first.stderr
+    );
+    assert!(first.stdout.contains("Service applied: apply-start"));
+    assert!(first.stdout.contains("Manifest: created"));
+    assert!(first.stdout.contains("Workload: none"));
+    assert!(first.stdout.contains("Final phase: running"));
+
+    let second = run_cli_result(
+        home.path(),
+        [
+            "service",
+            "apply",
+            "apply-start",
+            "--yes",
+            "--start",
+            manifest_path.as_ref(),
+        ],
+        "",
+    );
+    assert!(
+        second.status.success(),
+        "second apply failed\nstdout:\n{}\nstderr:\n{}",
+        second.stdout,
+        second.stderr
+    );
+    assert!(second.stdout.contains("Manifest: unchanged"));
+    assert!(second.stdout.contains("Workload: none"));
+    assert!(second.stdout.contains("Final phase: running"));
+}
+
+#[test]
+fn service_apply_help_explains_state_aware_start_behavior() {
+    let home = TempDir::new().unwrap();
+    let output = run_cli_result(home.path(), ["service", "apply", "--help"], "");
+
+    assert!(output.status.success(), "{}", output.stderr);
+    assert!(
+        output
+            .stdout
+            .contains("Ensure the service is running after applying it")
+    );
+    assert!(output.stdout.contains("First deployment"));
+    assert!(output.stdout.contains("Running service update"));
+    assert!(output.stdout.contains("Stopped service update"));
 }
 
 #[test]
@@ -526,6 +605,26 @@ fn cli_can_create_and_access_remote_tcp_service() {
     );
 
     run_cli(a.path(), ["service", "start", "test-tcp@b"]);
+    let reapplied = run_cli(
+        a.path(),
+        [
+            "service",
+            "apply",
+            "test-tcp@b",
+            "--yes",
+            "--start",
+            manifest_path.as_ref(),
+        ],
+    );
+    assert!(
+        reapplied
+            .stdout
+            .contains("Remote service applied: test-tcp@b")
+    );
+    assert!(reapplied.stdout.contains("Manifest: unchanged"));
+    assert!(reapplied.stdout.contains("Workload: none"));
+    assert!(reapplied.stdout.contains("Final phase: running"));
+
     let output = run_cli(a.path(), ["test-tcp@b"]);
     let local_addr = extract_local_address(&output.stdout);
     assert!(


### PR DESCRIPTION
## Summary

- make `fungi service apply --start` report success based on the verified final state
- report manifest, workload, and final phase outcomes for local and remote apply operations
- close the misleading Wasmtime `already running` failure

Closes #76

## Changes

- make Wasmtime start idempotent and reconcile post-apply start results with inspect
- carry backward-compatible structured apply outcomes through local gRPC and remote service-control
- emit explicit partial outcomes when apply succeeds but the final running state cannot be verified
- clarify first deploy, running update, and stopped update behavior in CLI help
- add local, remote, protocol compatibility, and Wasmtime restage regressions

## Verification

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --all`
- `cargo clippy --workspace --all-targets -- -D warnings` reports the existing `clippy::items_after_test_module` finding in `crates/daemon/src/runtime/providers.rs`

## AI assistance

- Codex (GPT-5)
