### PR TITLE
refactor(wasmtime): remove serve and use run-only services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,25 +532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "capstone"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f442ae0f2f3f1b923334b4a5386c95c69c1cfa072bafa23d6fae6d9682eb1dd4"
-dependencies = [
- "capstone-sys",
- "static_assertions",
-]
-
-[[package]]
-name = "capstone-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,16 +635,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
-]
-
-[[package]]
-name = "clap_complete"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
-dependencies = [
- "clap",
 ]
 
 [[package]]
@@ -837,9 +808,7 @@ version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
- "anyhow",
  "bumpalo",
- "capstone",
  "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
@@ -1557,6 +1526,7 @@ dependencies = [
  "log",
  "multiaddr",
  "rand 0.8.6",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5050,16 +5020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5839,41 +5799,28 @@ checksum = "ecbb7ede0fb533d605674047f066936ee535a62946f0bcdb7d117bfcf7f6d838"
 dependencies = [
  "async-trait",
  "bytes",
- "capstone",
  "cfg-if",
  "clap",
- "clap_complete",
- "cranelift-codegen",
  "futures",
- "gimli 0.33.0",
- "http",
- "http-body-util",
  "hyper",
  "listenfd",
  "log",
- "object",
- "pin-project-lite",
- "pulley-interpreter",
  "rustix 1.1.4",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
  "target-lexicon",
- "tempfile",
- "termcolor",
  "tokio",
  "tracing",
  "wasi-common",
  "wasmparser 0.251.0",
- "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-debugger",
- "wasmtime-internal-explorer",
  "wasmtime-internal-unwinder",
  "wasmtime-wasi",
  "wasmtime-wasi-config",
@@ -6026,22 +5973,6 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
-]
-
-[[package]]
-name = "wasmtime-internal-explorer"
-version = "46.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fb31d435f8f645fb5a8c9edd5e644b53605f3b98c0e217d099d036ddc25e4a"
-dependencies = [
- "capstone",
- "serde",
- "serde_derive",
- "serde_json",
- "target-lexicon",
- "wasmprinter",
- "wasmtime",
- "wasmtime-environ",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,38 @@ tonic-prost-build = "0.14.2"
 typed-path = "0.12"
 ulid = "1"
 void = "1"
-wasmtime-cli = "46.0.1"
+wasmtime-cli = { version = "46.0.1", default-features = false, features = [
+    "run",
+    "wasi-nn",
+    "wasi-threads",
+    "wasi-http",
+    "wasi-config",
+    "wasi-keyvalue",
+    "wasi-tls",
+    "backtrace",
+    "wat",
+    "parallel-compilation",
+    "pooling-allocator",
+    "cache",
+    "logging",
+    "demangle",
+    "cranelift",
+    "profiling",
+    "coredump",
+    "addr2line",
+    "debug-builtins",
+    "component-model",
+    "component-model-async",
+    "threads",
+    "gc",
+    "gc-copying",
+    "gc-drc",
+    "gc-null",
+    "stack-switching",
+    "winch",
+    "pulley",
+    "debug",
+] }
 webpki-roots = "1"
 libp2p = { version = "0.56", features = [
     "macros",

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Start with the quick starts:
 
 Full documentation: [fungi.rs/docs](https://fungi.rs/docs/intro).
 
+For existing Wasmtime HTTP services, see the [run migration guide](WASMTIME-RUN-MIGRATION.md).
+
 ## Platform Support
 
 | Platform | Status         |

--- a/WASMTIME-RUN-MIGRATION.md
+++ b/WASMTIME-RUN-MIGRATION.md
@@ -1,0 +1,66 @@
+# Upgrading Wasmtime services to run
+
+Fungi now launches Wasmtime services only through `fungi run`. The `fungi serve`
+command and `run.mode` manifest field have been removed. Services must export
+`wasi:cli/run` and own their TCP listener, including its address and port. Outgoing
+`wasi:http` requests, including host HTTPS, remain available through `run`.
+
+## Existing installations
+
+Core 0.7.1 persisted HTTP services with `run.mode: http` in
+`services/<local_service_id>/service.yaml`. After upgrading, these services appear
+with `status.phase: unknown` and a `configuration error` in `status.detail`.
+They do not start automatically or prevent the daemon and healthy services from
+starting. `service inspect` explains the error; `service start` reports the same
+reason. Local and remote service management use the same status path.
+
+Use the original instance name when applying the upgraded recipe:
+
+```sh
+fungi service inspect my-files
+fungi service apply my-files --recipe filebrowser-lite --refresh --start
+```
+
+Run this after the run-compatible recipe and component release are published.
+For a local updated service file, use:
+
+```sh
+fungi service apply my-files ./updated.fungi.md --start
+```
+
+A successful apply rewrites `service.yaml` and `state.json`, clears the error,
+restages the component, and reuses the local service ID and
+`appdata/services/<local_service_id>`. Failed configurations are upgraded into a
+stopped state unless `--start` is requested. An existing known recipe definition
+ID must still match. Removing only `run.mode` does not convert an
+incoming-handler-only component into a command component.
+
+For pre-0.7 `services-state.json` installations, the normal backed-up directory
+migration preserves the old HTTP service's instance name and data, and records a
+`configuration_error` in its `state.json`. The old format did not have a recipe
+definition ID; that identity remains unspecified until the user applies an
+updated recipe. The migrated HTTP manifest is intentionally not executable.
+
+## Other configuration errors
+
+Malformed or unsupported service manifests and service state files use the same
+per-service error path. The daemon leaves their files unchanged during loading.
+If the instance name cannot be recovered, the entry is shown under its local
+service ID. Duplicate names are also isolated and addressed by local service ID
+so applying a recipe cannot silently pick the wrong data directory.
+
+Correct saved files and restart the daemon, apply a supported definition, or
+remove the entry with `fungi service remove <name>`. Removing a service preserves
+its appdata. For an unreadable configuration, removal clears the saved service
+entry without guessing how to operate a runtime from invalid configuration.
+Directory-wide I/O failures and invalid daemon configuration still require
+repair before startup.
+
+## Release order
+
+1. Merge and release the run versions of filebrowser-lite and webdav-wasi.
+2. Publish the official recipes pointing at those released artifacts.
+3. Release this core change; align the app's bundled core version when updating it.
+
+Updating the recipe catalog alone does not rewrite an installed service. Users
+of the old HTTP components must apply the upgraded recipe explicitly.

--- a/crates/config-migrate/src/services.rs
+++ b/crates/config-migrate/src/services.rs
@@ -61,6 +61,9 @@ pub(crate) fn migrate_legacy_services_state(staging_root: &Path, live_root: &Pat
         let new_service_artifacts_dir = artifacts_root.join(&local_service_id);
         move_or_create_service_data_dir(&old_service_data_dir, &new_service_appdata_dir)?;
 
+        let configuration_error = (persisted_service.manifest._runtime == LegacyRuntimeKind::Wasmtime
+            && !persisted_service.manifest.ports.is_empty()).then(||
+                "Legacy Wasmtime HTTP service requires an upgraded run-compatible component. Apply an updated service recipe using the same instance name; the original component cannot be assumed to support wasi:cli/run.".to_string());
         let manifest_document = migrate_legacy_service_manifest(
             persisted_service.manifest,
             &old_live_service_data_dir,
@@ -89,6 +92,7 @@ pub(crate) fn migrate_legacy_services_state(staging_root: &Path, live_root: &Pat
             local_service_id: local_service_id.clone(),
             updated_at: legacy_updated_at.clone(),
             desired_state: persisted_service.desired_state.into(),
+            configuration_error,
         };
         let state_bytes = serde_json::to_vec_pretty(&state_file)
             .context("Failed to encode migrated managed service state.json")?;
@@ -256,7 +260,9 @@ fn migrate_legacy_service_manifest(
 
     Ok(CurrentServiceManifestDocument {
         fungi: "service/v1".to_string(),
-        id: manifest.name,
+        // Legacy HTTP services had an instance name but no recipe definition identity.
+        id: (runtime != LegacyRuntimeKind::Wasmtime).then(|| manifest.name.clone()),
+        instance: (runtime == LegacyRuntimeKind::Wasmtime).then_some(manifest.name),
         run,
         publish,
     })
@@ -467,6 +473,8 @@ impl From<LegacyDesiredServiceState> for CurrentDesiredServiceState {
 
 #[derive(Debug, Serialize)]
 struct CurrentServiceStateFile {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    configuration_error: Option<String>,
     schema_version: u32,
     local_service_id: String,
     updated_at: String,
@@ -476,7 +484,10 @@ struct CurrentServiceStateFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CurrentServiceManifestDocument {
     fungi: String,
-    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<String>,
     run: CurrentServiceRun,
     publish: BTreeMap<String, CurrentServicePublishEntry>,
 }

--- a/crates/config-migrate/src/services.rs
+++ b/crates/config-migrate/src/services.rs
@@ -241,8 +241,6 @@ fn migrate_legacy_service_manifest(
 
     let run = CurrentServiceRun {
         provider: runtime.into(),
-        mode: (runtime == LegacyRuntimeKind::Wasmtime && !publish.is_empty())
-            .then_some(CurrentServiceRunMode::Http),
         source,
         args: manifest.command,
         env: manifest.env,
@@ -502,8 +500,6 @@ impl From<LegacyRuntimeKind> for CurrentServiceProvider {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CurrentServiceRun {
     provider: CurrentServiceProvider,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mode: Option<CurrentServiceRunMode>,
     source: CurrentServiceSource,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     args: Vec<String>,
@@ -511,12 +507,6 @@ struct CurrentServiceRun {
     env: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     mounts: Vec<CurrentServiceMount>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum CurrentServiceRunMode {
-    Http,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/config-migrate/src/tests.rs
+++ b/crates/config-migrate/src/tests.rs
@@ -642,7 +642,7 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
     assert_eq!(manifest["fungi"], "service/v1");
     assert_eq!(manifest["id"], "demo");
     assert_eq!(manifest["run"]["provider"], "wasmtime");
-    assert_eq!(manifest["run"]["mode"], "http");
+    assert!(manifest["run"]["mode"].is_null());
     assert_eq!(
         manifest["run"]["source"]["file"],
         "$fungi.service.artifacts/component.wasm"

--- a/crates/config-migrate/src/tests.rs
+++ b/crates/config-migrate/src/tests.rs
@@ -640,9 +640,20 @@ fn migrates_legacy_service_state_into_local_service_id_layout_and_moves_service_
 
     let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_yaml).unwrap();
     assert_eq!(manifest["fungi"], "service/v1");
-    assert_eq!(manifest["id"], "demo");
+    assert!(manifest["id"].is_null());
+    assert_eq!(manifest["instance"], "demo");
     assert_eq!(manifest["run"]["provider"], "wasmtime");
     assert!(manifest["run"]["mode"].is_null());
+    let state: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(manifest_path.with_file_name("state.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        state["configuration_error"]
+            .as_str()
+            .unwrap()
+            .contains("run-compatible")
+    );
     assert_eq!(
         manifest["run"]["source"]["file"],
         "$fungi.service.artifacts/component.wasm"

--- a/crates/daemon/scripts/real-wasi-runtime-smoke.sh
+++ b/crates/daemon/scripts/real-wasi-runtime-smoke.sh
@@ -4,19 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 TMP_ROOT="$(mktemp -d /tmp/fungi-wasi-smoke.XXXXXX)"
 DATA_DIR="$TMP_ROOT/data"
-WASM_FILE="$TMP_ROOT/spore-box.wasm"
 PROVIDER_PORT="${FUNGI_WASI_PROVIDER_PORT:-18081}"
-DIRECT_PORT="${FUNGI_WASI_DIRECT_PORT:-18082}"
 NAME="${FUNGI_WASI_SMOKE_NAME:-fungi-wasi-smoke}"
-WASM_URL="${FUNGI_WASI_WASM_URL:-https://github.com/enbop/spore-box/releases/download/v0.2.0/spore-box.wasm}"
+WASM_URL="${FUNGI_WASI_WASM_URL:-https://github.com/enbop/socks5-wasip2/releases/download/v0.1.1/socks5-wasip2.wasm}"
 WAIT_SECS="${FUNGI_WASI_WAIT_SECS:-10}"
-DIRECT_PID=""
 
 cleanup() {
-  if [[ -n "$DIRECT_PID" ]]; then
-    kill "$DIRECT_PID" >/dev/null 2>&1 || true
-    wait "$DIRECT_PID" >/dev/null 2>&1 || true
-  fi
   rm -rf "$TMP_ROOT"
 }
 trap cleanup EXIT
@@ -24,7 +17,6 @@ trap cleanup EXIT
 cd "$ROOT_DIR"
 
 mkdir -p "$DATA_DIR"
-curl -L "$WASM_URL" -o "$WASM_FILE"
 
 echo "== building binaries =="
 cargo build -q -p fungi -p fungi-daemon
@@ -38,21 +30,6 @@ cargo run -q -p fungi-daemon --bin test_wasi_runtime -- \
   --mount-dir "$DATA_DIR" \
   --mount-target data \
   --port "$PROVIDER_PORT" \
-  --wait-secs "$WAIT_SECS"
-echo
-
-echo "== direct fungi serve compare =="
-(
-  cd "$TMP_ROOT"
-  "$ROOT_DIR/target/debug/fungi" serve --addr="127.0.0.1:$DIRECT_PORT" -Scli --dir data "$WASM_FILE"
-) >"$TMP_ROOT/direct-serve.log" 2>&1 &
-DIRECT_PID="$!"
-sleep 2
-
-echo "== curl direct fungi serve =="
-curl -fsS "http://127.0.0.1:$DIRECT_PORT/?device=smoke"
-echo
-echo
-
-echo "== direct fungi serve logs =="
-cat "$TMP_ROOT/direct-serve.log"
+  --wait-secs "$WAIT_SECS" \
+  -- \
+  --listen "127.0.0.1:$PROVIDER_PORT"

--- a/crates/daemon/src/api/service_access.rs
+++ b/crates/daemon/src/api/service_access.rs
@@ -108,7 +108,7 @@ mod tests {
     use crate::{
         RuntimeKind, ServiceExpose, ServiceExposeTransport, ServiceExposeTransportKind,
         ServiceExposeUsage, ServiceExposeUsageKind, ServiceManifest, ServiceMount, ServicePort,
-        ServicePortAllocation, ServicePortProtocol, ServiceRunMode, ServiceSource,
+        ServicePortAllocation, ServicePortProtocol, ServiceSource,
         test_support::{TestDaemon, spawn_connected_pair},
     };
     use libp2p::swarm::dial_opts::DialOpts;
@@ -477,7 +477,6 @@ mod tests {
             name: service_name.to_string(),
             definition_id: None,
             runtime: RuntimeKind::External,
-            run_mode: ServiceRunMode::Command,
             source: ServiceSource::ExistingTcp {
                 host: "127.0.0.1".to_string(),
                 port: first_port,

--- a/crates/daemon/src/bin/test_wasi_runtime.rs
+++ b/crates/daemon/src/bin/test_wasi_runtime.rs
@@ -1,16 +1,9 @@
 use clap::Parser;
 use fungi_daemon::{
     RuntimeControl, RuntimeKind, ServiceLogsOptions, ServiceManifest, ServiceMount, ServicePort,
-    ServicePortProtocol, ServiceRunMode, ServiceSource,
+    ServicePortProtocol, ServiceSource,
 };
-use std::{
-    collections::BTreeMap,
-    fs,
-    io::{Read, Write},
-    net::TcpStream,
-    path::PathBuf,
-    time::Duration,
-};
+use std::{collections::BTreeMap, fs, net::TcpStream, path::PathBuf, time::Duration};
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -32,6 +25,8 @@ struct Args {
     mount_target: String,
     #[arg(long, default_value_t = 10)]
     wait_secs: u64,
+    #[arg(last = true)]
+    component_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -70,7 +65,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         name: args.name.clone(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Http,
         source,
         expose: None,
         env: BTreeMap::new(),
@@ -85,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             service_port: args.port,
             protocol: ServicePortProtocol::Tcp,
         }],
-        command: Vec::new(),
+        command: args.component_args,
         entrypoint: Vec::new(),
         working_dir: None,
         labels: BTreeMap::new(),
@@ -114,8 +108,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     println!("logs.text:\n{}", logs.text);
 
-    let response = http_get(args.port)?;
-    println!("http.get:\n{response}");
+    TcpStream::connect(("127.0.0.1", args.port))?;
+    println!("tcp.connect: ok");
 
     runtime.stop(RuntimeKind::Wasmtime, &args.name).await?;
     println!("stop: ok");
@@ -126,15 +120,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     runtime.remove(RuntimeKind::Wasmtime, &args.name).await?;
     println!("remove: ok");
     Ok(())
-}
-
-fn http_get(port: u16) -> Result<String, Box<dyn std::error::Error>> {
-    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.write_all(
-        b"GET /?device=smoke HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
-    )?;
-    let mut response = String::new();
-    stream.read_to_string(&mut response)?;
-    Ok(response)
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -43,9 +43,9 @@ pub use runtime::{
     ServiceExposeEndpointBinding, ServiceExposeTransport, ServiceExposeTransportKind,
     ServiceExposeUsage, ServiceExposeUsageKind, ServiceInstance, ServiceLogs, ServiceLogsOptions,
     ServiceManifest, ServiceMount, ServicePhase, ServicePort, ServicePortAllocation,
-    ServicePortProtocol, ServiceRunMode, ServiceSource, ServiceStatus,
-    load_service_manifest_yaml_file, parse_service_manifest_yaml, peek_service_manifest_name,
-    service_expose_endpoint_bindings, service_manifest_with_instance_name,
+    ServicePortProtocol, ServiceSource, ServiceStatus, load_service_manifest_yaml_file,
+    parse_service_manifest_yaml, peek_service_manifest_name, service_expose_endpoint_bindings,
+    service_manifest_with_instance_name,
 };
 pub use service_accesses::ServiceAccesses;
 pub use service_control::{

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use anyhow::{Result, bail};
@@ -34,6 +34,15 @@ pub struct RuntimeControl {
     service_index: Arc<Mutex<HashMap<String, RuntimeKind>>>,
     service_manifests: Arc<Mutex<HashMap<String, ServiceManifest>>>,
     service_state: Arc<Mutex<ServiceStateStore>>,
+    service_operations: Arc<Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>>,
+    pending_cleanup: Arc<Mutex<HashMap<String, PendingRuntimeCleanup>>>,
+}
+
+#[derive(Clone)]
+struct PendingRuntimeCleanup {
+    local_service_id: String,
+    instance: ServiceInstance,
+    apply_error: String,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +75,8 @@ impl RuntimeControl {
             service_index: Arc::new(Mutex::new(HashMap::new())),
             service_manifests: Arc::new(Mutex::new(HashMap::new())),
             service_state: Arc::new(Mutex::new(ServiceStateStore::load(service_state_file)?)),
+            service_operations: Arc::default(),
+            pending_cleanup: Arc::default(),
         })
     }
 
@@ -82,6 +93,8 @@ impl RuntimeControl {
             service_index: Arc::new(Mutex::new(HashMap::new())),
             service_manifests: Arc::new(Mutex::new(HashMap::new())),
             service_state: Arc::new(Mutex::new(ServiceStateStore::load(service_state_file)?)),
+            service_operations: Arc::default(),
+            pending_cleanup: Arc::default(),
         })
     }
 
@@ -99,13 +112,11 @@ impl RuntimeControl {
     }
 
     pub async fn pull(&self, manifest: &ServiceManifest) -> Result<ServiceInstance> {
-        Ok(self
-            .apply_with_local_service_id(manifest, None)
-            .await?
-            .instance)
+        Ok(self.apply(manifest).await?.instance)
     }
 
     pub async fn apply(&self, manifest: &ServiceManifest) -> Result<AppliedService> {
+        let _operation = self.lock_service_operation(&manifest.name).await;
         self.apply_with_local_service_id(manifest, None).await
     }
 
@@ -125,6 +136,7 @@ impl RuntimeControl {
         local_service_id: Option<&str>,
     ) -> Result<AppliedService> {
         self.ensure_runtime_enabled(manifest.runtime)?;
+        self.retry_pending_cleanup(&manifest.name).await?;
 
         let previous_service = { self.service_state.lock().persisted_service(&manifest.name) };
         let failed_service = { self.service_state.lock().failed_service(&manifest.name) };
@@ -210,7 +222,27 @@ impl RuntimeControl {
             RuntimeKind::External => Ok(self.external_instance_from_manifest(manifest, false)),
         }?;
 
-        self.persist_service(manifest, desired_state, Some(&resolved_local_service_id))?;
+        if let Err(error) =
+            self.persist_service(manifest, desired_state, Some(&resolved_local_service_id))
+        {
+            let mut failed = enrich_instance_from_manifest(instance, manifest);
+            failed.status =
+                ServiceStatus::unknown().with_detail(format!("apply persistence error: {error:#}"));
+            self.pending_cleanup.lock().insert(
+                manifest.name.clone(),
+                PendingRuntimeCleanup {
+                    local_service_id: resolved_local_service_id,
+                    instance: failed,
+                    apply_error: format!("{error:#}"),
+                },
+            );
+            return match self.retry_pending_cleanup(&manifest.name).await {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => {
+                    Err(error.context(format!("Runtime rollback also failed: {cleanup_error:#}")))
+                }
+            };
+        }
         self.service_index
             .lock()
             .insert(manifest.name.clone(), manifest.runtime);
@@ -220,8 +252,10 @@ impl RuntimeControl {
 
         let mut instance = enrich_instance_from_manifest(instance, manifest);
         if desired_state == DesiredServiceState::Running {
-            self.start(manifest.runtime, &manifest.name).await?;
-            instance = self.inspect(manifest.runtime, &manifest.name).await?;
+            self.start_locked(manifest.runtime, &manifest.name).await?;
+            instance = self
+                .inspect_locked(manifest.runtime, &manifest.name)
+                .await?;
         }
 
         Ok(AppliedService {
@@ -239,6 +273,7 @@ impl RuntimeControl {
         policy: &ManifestResolutionPolicy,
     ) -> Result<AppliedService> {
         let manifest_name = peek_service_manifest_name(content)?;
+        let _operation = self.lock_service_operation(&manifest_name).await;
         let local_service_id = {
             self.service_state
                 .lock()
@@ -288,6 +323,11 @@ impl RuntimeControl {
     }
 
     pub async fn start(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
+        self.start_locked(runtime, name).await
+    }
+
+    async fn start_locked(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
         self.ensure_service_configuration_loaded(name)?;
         self.ensure_runtime_enabled(runtime)?;
         self.ensure_runtime_service(runtime, name).await?;
@@ -305,6 +345,11 @@ impl RuntimeControl {
     }
 
     pub async fn stop(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
+        self.stop_locked(runtime, name).await
+    }
+
+    async fn stop_locked(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
         self.ensure_service_configuration_loaded(name)?;
         let _ = self.ensure_runtime_service(runtime, name).await;
         let stop_result = match runtime {
@@ -335,8 +380,20 @@ impl RuntimeControl {
     }
 
     pub async fn remove(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
+        self.remove_locked(runtime, name).await
+    }
+
+    async fn remove_locked(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        let had_pending_cleanup = self.pending_cleanup.lock().contains_key(name);
+        self.retry_pending_cleanup(name).await?;
         if self.service_state.lock().failed_service(name).is_some() {
             return self.service_state.lock().remove_service(name);
+        }
+        if had_pending_cleanup && self.service_state.lock().persisted_service(name).is_none() {
+            self.service_index.lock().remove(name);
+            self.service_manifests.lock().remove(name);
+            return Ok(());
         }
         let remove_result = match runtime {
             RuntimeKind::Unknown => bail!("unknown service runtime"),
@@ -374,8 +431,9 @@ impl RuntimeControl {
     }
 
     pub async fn start_by_name(&self, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
-        self.start(runtime, name).await
+        self.start_locked(runtime, name).await
     }
 
     pub fn get_service_manifest(&self, name: &str) -> Option<ServiceManifest> {
@@ -383,18 +441,21 @@ impl RuntimeControl {
     }
 
     pub async fn stop_by_name(&self, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
-        self.stop(runtime, name).await
+        self.stop_locked(runtime, name).await
     }
 
     pub async fn remove_by_name(&self, name: &str) -> Result<()> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
-        self.remove(runtime, name).await
+        self.remove_locked(runtime, name).await
     }
 
     pub async fn inspect_by_name(&self, name: &str) -> Result<ServiceInstance> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
-        self.inspect(runtime, name).await
+        self.inspect_locked(runtime, name).await
     }
 
     pub async fn logs_by_name(
@@ -402,8 +463,9 @@ impl RuntimeControl {
         name: &str,
         options: &ServiceLogsOptions,
     ) -> Result<ServiceLogs> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
-        self.logs(runtime, name, options).await
+        self.logs_locked(runtime, name, options).await
     }
 
     pub(crate) async fn logs_text_by_name_bounded(
@@ -412,6 +474,7 @@ impl RuntimeControl {
         tail: usize,
         max_bytes: usize,
     ) -> Result<BoundedLogText> {
+        let _operation = self.lock_service_operation(name).await;
         let runtime = self.resolve_runtime(name)?;
         self.ensure_service_configuration_loaded(name)?;
         self.ensure_runtime_enabled(runtime)?;
@@ -516,11 +579,24 @@ impl RuntimeControl {
             services.push(enrich_instance_from_manifest(instance, &manifest));
         }
 
+        for pending in self.pending_cleanup.lock().values() {
+            services.retain(|service| service.name != pending.instance.name);
+            services.push(pending.instance.clone());
+        }
+
         services.sort_by(|left, right| left.name.cmp(&right.name));
         Ok(services)
     }
 
     pub async fn inspect(&self, runtime: RuntimeKind, name: &str) -> Result<ServiceInstance> {
+        let _operation = self.lock_service_operation(name).await;
+        self.inspect_locked(runtime, name).await
+    }
+
+    async fn inspect_locked(&self, runtime: RuntimeKind, name: &str) -> Result<ServiceInstance> {
+        if let Some(pending) = self.pending_cleanup.lock().get(name) {
+            return Ok(pending.instance.clone());
+        }
         if let Some(failed) = self.service_state.lock().failed_service(name) {
             return Ok(failed);
         }
@@ -585,6 +661,16 @@ impl RuntimeControl {
     }
 
     pub async fn logs(
+        &self,
+        runtime: RuntimeKind,
+        name: &str,
+        options: &ServiceLogsOptions,
+    ) -> Result<ServiceLogs> {
+        let _operation = self.lock_service_operation(name).await;
+        self.logs_locked(runtime, name, options).await
+    }
+
+    async fn logs_locked(
         &self,
         runtime: RuntimeKind,
         name: &str,
@@ -723,6 +809,9 @@ impl RuntimeControl {
     }
 
     fn resolve_runtime(&self, name: &str) -> Result<RuntimeKind> {
+        if let Some(pending) = self.pending_cleanup.lock().get(name) {
+            return Ok(pending.instance.runtime);
+        }
         if let Some(failed) = self.service_state.lock().failed_service(name) {
             return Ok(failed.runtime);
         }
@@ -738,8 +827,51 @@ impl RuntimeControl {
     }
 
     fn ensure_service_configuration_loaded(&self, name: &str) -> Result<()> {
+        if let Some(pending) = self.pending_cleanup.lock().get(name) {
+            bail!(
+                "service '{}': {}",
+                name,
+                pending.instance.status.state_label()
+            );
+        }
         if let Some(failed) = self.service_state.lock().failed_service(name) {
             bail!("service '{}': {}", name, failed.status.state_label());
+        }
+        Ok(())
+    }
+
+    async fn lock_service_operation(&self, name: &str) -> tokio::sync::OwnedMutexGuard<()> {
+        let operation = {
+            let mut operations = self.service_operations.lock();
+            operations.retain(|_, operation| operation.strong_count() > 0);
+            match operations.get(name).and_then(Weak::upgrade) {
+                Some(operation) => operation,
+                None => {
+                    let operation = Arc::new(tokio::sync::Mutex::new(()));
+                    operations.insert(name.to_string(), Arc::downgrade(&operation));
+                    operation
+                }
+            }
+        };
+        operation.lock_owned().await
+    }
+
+    async fn retry_pending_cleanup(&self, name: &str) -> Result<()> {
+        let pending = { self.pending_cleanup.lock().get(name).cloned() };
+        if let Some(pending) = pending {
+            if let Err(error) = self
+                .remove_runtime_only(pending.instance.runtime, name, &pending.local_service_id)
+                .await
+            {
+                let mut failed = pending;
+                failed.instance.status = ServiceStatus::unknown().with_detail(format!(
+                    "apply persistence error: {}; runtime cleanup error: {error:#}; fix the filesystem/runtime problem and retry apply or remove",
+                    failed.apply_error,
+                ));
+                self.pending_cleanup.lock().insert(name.to_string(), failed);
+                return Err(error);
+            }
+            self.pending_cleanup.lock().remove(name);
         }
         Ok(())
     }
@@ -878,5 +1010,116 @@ fn ensure_matching_definition_id(
             previous_id
         ),
         _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod rollback_tests {
+    use super::*;
+    use std::fs;
+
+    #[tokio::test]
+    async fn cleanup_failure_remains_visible_and_allows_retry_or_remove() {
+        for retry_apply in [true, false] {
+            let temp = tempfile::TempDir::new().unwrap();
+            let home = temp.path();
+            fs::write(home.join("component.wasm"), b"component").unwrap();
+            let manifest = super::super::parse_service_manifest_yaml(
+                "fungi: service/v1\nid: demo\nrun:\n  provider: wasmtime\n  source:\n    file: component.wasm\npublish:\n  main:\n    tcp:\n      port: 8082\n", home, home,
+            ).unwrap();
+            let provider = WasmtimeRuntimeProvider::new(
+                home.join("runtime"),
+                PathBuf::from("unused"),
+                home.to_path_buf(),
+                vec![home.to_path_buf()],
+            );
+            let control = RuntimeControl::with_wasmtime_provider(
+                provider.clone(),
+                None,
+                home.join("services"),
+                true,
+            )
+            .unwrap();
+            let instance = provider
+                .pull_with_local_service_id(&manifest, "svc_pending")
+                .await
+                .unwrap();
+            // Replay the state immediately after registration succeeds and persistence fails.
+            control.pending_cleanup.lock().insert(
+                "demo".to_string(),
+                PendingRuntimeCleanup {
+                    local_service_id: "svc_pending".into(),
+                    instance,
+                    apply_error: "test persistence failure".into(),
+                },
+            );
+            if !retry_apply {
+                control.seed_in_memory_service_for_test(manifest.clone());
+            }
+            let artifacts = home.join("artifacts/services/svc_pending");
+            fs::remove_file(artifacts.join("component.wasm")).unwrap();
+            fs::remove_dir(&artifacts).unwrap();
+            fs::write(&artifacts, b"blocked").unwrap();
+            assert!(control.remove_by_name("demo").await.is_err());
+            assert!(!provider.has_service("demo"));
+            let listed = control.list_services().await.unwrap();
+            assert_eq!(listed.len(), 1);
+            assert!(
+                listed[0]
+                    .status
+                    .state_label()
+                    .contains("runtime cleanup error")
+            );
+            assert_eq!(
+                control.inspect_by_name("demo").await.unwrap().status.phase,
+                ServicePhase::Unknown
+            );
+            assert!(control.start_by_name("demo").await.is_err());
+
+            fs::remove_file(&artifacts).unwrap();
+            if retry_apply {
+                control.apply(&manifest).await.unwrap();
+                assert!(provider.has_service("demo"));
+                assert!(control.pending_cleanup.lock().is_empty());
+            }
+            control.remove_by_name("demo").await.unwrap();
+            assert!(control.list_services().await.unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn service_operation_serialization_does_not_block_other_services() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let home = temp.path();
+        let control = RuntimeControl::new(
+            home.join("runtime"),
+            PathBuf::from("unused"),
+            home.to_path_buf(),
+            None,
+            home.join("services"),
+            vec![],
+            false,
+        )
+        .unwrap();
+        let manifest = super::super::parse_service_manifest_yaml(
+            "fungi: service/v1\nid: demo\npublish:\n  main:\n    tcp:\n      port: 54321\n",
+            home,
+            home,
+        )
+        .unwrap();
+        let operation = control.lock_service_operation("demo").await;
+        let apply = control.apply(&manifest);
+        tokio::pin!(apply);
+        tokio::select! {
+            biased;
+            result = &mut apply => panic!("apply bypassed the service operation lock: {result:?}"),
+            _ = std::future::ready(()) => {}
+        }
+        let mut other = manifest.clone();
+        other.name = "other".into();
+        control.apply(&other).await.unwrap();
+        drop(operation);
+        apply.await.unwrap();
+        assert_eq!(control.list_services().await.unwrap().len(), 2);
     }
 }

--- a/crates/daemon/src/runtime/control.rs
+++ b/crates/daemon/src/runtime/control.rs
@@ -87,6 +87,7 @@ impl RuntimeControl {
 
     pub fn supports(&self, runtime: RuntimeKind) -> bool {
         match runtime {
+            RuntimeKind::Unknown => false,
             RuntimeKind::Docker => self.docker.is_some(),
             RuntimeKind::Wasmtime => self.wasmtime_enabled,
             RuntimeKind::External => true,
@@ -126,6 +127,14 @@ impl RuntimeControl {
         self.ensure_runtime_enabled(manifest.runtime)?;
 
         let previous_service = { self.service_state.lock().persisted_service(&manifest.name) };
+        let failed_service = { self.service_state.lock().failed_service(&manifest.name) };
+        if let Some(failed) = &failed_service {
+            ensure_matching_definition_id(
+                &manifest.name,
+                failed.definition_id.as_deref(),
+                manifest.definition_id.as_deref(),
+            )?;
+        }
         let in_memory_manifest = self.service_manifests.lock().get(&manifest.name).cloned();
         let in_memory_runtime = self.service_index.lock().get(&manifest.name).copied();
         let previous_manifest = previous_service
@@ -140,8 +149,10 @@ impl RuntimeControl {
             .as_ref()
             .map(|manifest| manifest.runtime)
             .or(in_memory_runtime);
-        let replacing_existing =
-            previous_service.is_some() || previous_manifest.is_some() || previous_runtime.is_some();
+        let replacing_existing = previous_service.is_some()
+            || previous_manifest.is_some()
+            || previous_runtime.is_some()
+            || failed_service.is_some();
 
         if let Some(previous_manifest) = previous_manifest.as_ref() {
             ensure_definition_id_compatible(previous_manifest, manifest)?;
@@ -179,6 +190,7 @@ impl RuntimeControl {
         }
 
         let instance = match manifest.runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .pull_with_container_name(manifest, &resolved_local_service_id)
@@ -198,13 +210,13 @@ impl RuntimeControl {
             RuntimeKind::External => Ok(self.external_instance_from_manifest(manifest, false)),
         }?;
 
+        self.persist_service(manifest, desired_state, Some(&resolved_local_service_id))?;
         self.service_index
             .lock()
             .insert(manifest.name.clone(), manifest.runtime);
         self.service_manifests
             .lock()
             .insert(manifest.name.clone(), manifest.clone());
-        self.persist_service(manifest, desired_state, Some(&resolved_local_service_id))?;
 
         let mut instance = enrich_instance_from_manifest(instance, manifest);
         if desired_state == DesiredServiceState::Running {
@@ -276,9 +288,11 @@ impl RuntimeControl {
     }
 
     pub async fn start(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        self.ensure_service_configuration_loaded(name)?;
         self.ensure_runtime_enabled(runtime)?;
         self.ensure_runtime_service(runtime, name).await?;
         match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .start(&self.docker_runtime_handle_or_name(name))
@@ -291,8 +305,10 @@ impl RuntimeControl {
     }
 
     pub async fn stop(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        self.ensure_service_configuration_loaded(name)?;
         let _ = self.ensure_runtime_service(runtime, name).await;
         let stop_result = match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .stop(&self.docker_runtime_handle_or_name(name))
@@ -319,7 +335,11 @@ impl RuntimeControl {
     }
 
     pub async fn remove(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        if self.service_state.lock().failed_service(name).is_some() {
+            return self.service_state.lock().remove_service(name);
+        }
         let remove_result = match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .remove(&self.docker_runtime_handle_or_name(name))
@@ -393,6 +413,7 @@ impl RuntimeControl {
         max_bytes: usize,
     ) -> Result<BoundedLogText> {
         let runtime = self.resolve_runtime(name)?;
+        self.ensure_service_configuration_loaded(name)?;
         self.ensure_runtime_enabled(runtime)?;
         self.ensure_runtime_service(runtime, name).await?;
         match runtime {
@@ -412,6 +433,7 @@ impl RuntimeControl {
             }
             RuntimeKind::Wasmtime => self.wasmtime.logs_text_bounded(name, tail, max_bytes),
             RuntimeKind::External => bail!("external TCP services do not have runtime logs"),
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
         }
     }
 
@@ -475,7 +497,7 @@ impl RuntimeControl {
             .cloned()
             .collect::<Vec<_>>();
 
-        let mut services = Vec::new();
+        let mut services = self.service_state.lock().failed_services();
         for manifest in manifests {
             let instance = match self.inspect(manifest.runtime, &manifest.name).await {
                 Ok(instance) => instance,
@@ -485,7 +507,10 @@ impl RuntimeControl {
                         manifest.name,
                         error
                     );
-                    missing_instance_from_manifest(&manifest)
+                    let mut instance = missing_instance_from_manifest(&manifest);
+                    instance.status =
+                        ServiceStatus::unknown().with_detail(format!("runtime error: {error:#}"));
+                    instance
                 }
             };
             services.push(enrich_instance_from_manifest(instance, &manifest));
@@ -496,6 +521,9 @@ impl RuntimeControl {
     }
 
     pub async fn inspect(&self, runtime: RuntimeKind, name: &str) -> Result<ServiceInstance> {
+        if let Some(failed) = self.service_state.lock().failed_service(name) {
+            return Ok(failed);
+        }
         if let Err(error) = self.ensure_runtime_service(runtime, name).await {
             if let Some(manifest) = self.get_service_manifest(name) {
                 log::warn!(
@@ -503,12 +531,16 @@ impl RuntimeControl {
                     name,
                     error
                 );
-                return Ok(missing_instance_from_manifest(&manifest));
+                let mut instance = missing_instance_from_manifest(&manifest);
+                instance.status =
+                    ServiceStatus::unknown().with_detail(format!("restore error: {error:#}"));
+                return Ok(instance);
             }
             return Err(error);
         }
 
         let inspect_result = match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .inspect(&self.docker_runtime_handle_or_name(name))
@@ -558,6 +590,7 @@ impl RuntimeControl {
         name: &str,
         options: &ServiceLogsOptions,
     ) -> Result<ServiceLogs> {
+        self.ensure_service_configuration_loaded(name)?;
         self.ensure_runtime_enabled(runtime)?;
         self.ensure_runtime_service(runtime, name).await?;
         match runtime {
@@ -568,6 +601,7 @@ impl RuntimeControl {
             }
             RuntimeKind::Wasmtime => self.wasmtime.logs(name, options).await,
             RuntimeKind::External => bail!("external TCP services do not have runtime logs"),
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
         }
     }
 
@@ -631,6 +665,7 @@ impl RuntimeControl {
 
     fn ensure_runtime_enabled(&self, runtime: RuntimeKind) -> Result<()> {
         match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 if self.docker.is_none() {
                     bail!("docker runtime is not available");
@@ -654,6 +689,7 @@ impl RuntimeControl {
     }
 
     async fn ensure_runtime_service(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
+        self.ensure_service_configuration_loaded(name)?;
         if runtime != RuntimeKind::Wasmtime || self.wasmtime.has_service(name) {
             return Ok(());
         }
@@ -687,6 +723,9 @@ impl RuntimeControl {
     }
 
     fn resolve_runtime(&self, name: &str) -> Result<RuntimeKind> {
+        if let Some(failed) = self.service_state.lock().failed_service(name) {
+            return Ok(failed.runtime);
+        }
         self.service_index
             .lock()
             .get(name)
@@ -696,6 +735,13 @@ impl RuntimeControl {
 
     fn reserved_host_ports(&self) -> BTreeSet<u16> {
         self.reserved_host_ports_except("")
+    }
+
+    fn ensure_service_configuration_loaded(&self, name: &str) -> Result<()> {
+        if let Some(failed) = self.service_state.lock().failed_service(name) {
+            bail!("service '{}': {}", name, failed.status.state_label());
+        }
+        Ok(())
     }
 
     fn reserved_host_ports_except(&self, service_name: &str) -> BTreeSet<u16> {
@@ -709,6 +755,7 @@ impl RuntimeControl {
 
     async fn stop_runtime_only(&self, runtime: RuntimeKind, name: &str) -> Result<()> {
         let stop_result = match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => {
                 self.docker_provider()?
                     .stop(&self.docker_runtime_handle_or_name(name))
@@ -751,6 +798,7 @@ impl RuntimeControl {
         local_service_id: &str,
     ) -> Result<()> {
         let remove_result = match runtime {
+            RuntimeKind::Unknown => bail!("unknown service runtime"),
             RuntimeKind::Docker => self.docker_provider()?.remove(local_service_id).await,
             RuntimeKind::Wasmtime => {
                 self.wasmtime
@@ -805,19 +853,28 @@ fn ensure_definition_id_compatible(
     previous: &ServiceManifest,
     next: &ServiceManifest,
 ) -> Result<()> {
-    match (
+    ensure_matching_definition_id(
+        &next.name,
         previous.definition_id.as_deref(),
         next.definition_id.as_deref(),
-    ) {
+    )
+}
+
+fn ensure_matching_definition_id(
+    name: &str,
+    previous: Option<&str>,
+    next: Option<&str>,
+) -> Result<()> {
+    match (previous, next) {
         (Some(previous_id), Some(next_id)) if previous_id != next_id => bail!(
             "service '{}' was created from definition id '{}' and cannot be overwritten with definition id '{}'; use a different service name or remove the existing service first",
-            next.name,
+            name,
             previous_id,
             next_id
         ),
         (Some(previous_id), None) => bail!(
             "service '{}' was created from definition id '{}' and cannot be overwritten by a manifest without a definition id; use a matching .fungi.md service file or remove the existing service first",
-            next.name,
+            name,
             previous_id
         ),
         _ => Ok(()),

--- a/crates/daemon/src/runtime/helpers.rs
+++ b/crates/daemon/src/runtime/helpers.rs
@@ -271,20 +271,9 @@ pub(crate) fn build_wasmtime_command(
         command.env("HOME", &wasmtime_home);
     }
 
-    if should_serve_wasmtime_http(&state.manifest) {
-        let port = state
-            .manifest
-            .ports
-            .iter()
-            .find(|port| port.protocol == ServicePortProtocol::Tcp)
-            .map(|port| port.host_port)
-            .ok_or_else(|| anyhow::anyhow!("wasmtime http mode requires at least one TCP port"))?;
-        command.arg("serve");
-        command.arg(format!("--addr=127.0.0.1:{port}"));
-    } else {
-        command.arg("run");
-    }
+    command.arg("run");
     command.arg("-Scli");
+    command.arg("-Shttp");
     if has_tcp_ports(&state.manifest) {
         command.arg("-Stcp");
         command.arg("-Sinherit-network");
@@ -312,10 +301,6 @@ pub(crate) fn build_wasmtime_command(
     }
     command.envs(&state.manifest.env);
     Ok(command)
-}
-
-fn should_serve_wasmtime_http(manifest: &ServiceManifest) -> bool {
-    manifest.run_mode == ServiceRunMode::Http
 }
 
 fn has_tcp_ports(manifest: &ServiceManifest) -> bool {

--- a/crates/daemon/src/runtime/helpers.rs
+++ b/crates/daemon/src/runtime/helpers.rs
@@ -405,6 +405,7 @@ pub(crate) fn enrich_instance_from_manifest(
 
 fn service_instance_id(runtime: RuntimeKind, name: &str) -> String {
     let runtime_name = match runtime {
+        RuntimeKind::Unknown => "unknown",
         RuntimeKind::Docker => "docker",
         RuntimeKind::Wasmtime => "wasmtime",
         RuntimeKind::External => "external",

--- a/crates/daemon/src/runtime/manifest.rs
+++ b/crates/daemon/src/runtime/manifest.rs
@@ -642,6 +642,7 @@ fn parse_fungi_publish_entry(
     }
 
     match runtime {
+        RuntimeKind::Unknown => bail!("unknown service runtime"),
         RuntimeKind::Docker => {
             if entry.tcp.host.is_some() {
                 bail!("publish.{name}.tcp.host is not used with provider: docker; omit it");

--- a/crates/daemon/src/runtime/manifest.rs
+++ b/crates/daemon/src/runtime/manifest.rs
@@ -115,7 +115,6 @@ pub fn service_manifest_to_yaml(manifest: &ServiceManifest) -> Result<String> {
     let run = match &manifest.source {
         ServiceSource::Docker { image } => Some(FungiServiceRun {
             provider: FungiServiceProvider::Docker,
-            mode: None,
             source: FungiServiceSource {
                 image: Some(image.clone()),
                 ..FungiServiceSource::default()
@@ -126,7 +125,6 @@ pub fn service_manifest_to_yaml(manifest: &ServiceManifest) -> Result<String> {
         }),
         ServiceSource::WasmtimeFile { component } => Some(FungiServiceRun {
             provider: FungiServiceProvider::Wasmtime,
-            mode: (manifest.run_mode == ServiceRunMode::Http).then_some(FungiServiceRunMode::Http),
             source: FungiServiceSource {
                 file: Some(component.display().to_string()),
                 ..FungiServiceSource::default()
@@ -137,7 +135,6 @@ pub fn service_manifest_to_yaml(manifest: &ServiceManifest) -> Result<String> {
         }),
         ServiceSource::WasmtimeUrl { url } => Some(FungiServiceRun {
             provider: FungiServiceProvider::Wasmtime,
-            mode: (manifest.run_mode == ServiceRunMode::Http).then_some(FungiServiceRunMode::Http),
             source: FungiServiceSource {
                 url: Some(url.clone()),
                 ..FungiServiceSource::default()
@@ -246,7 +243,6 @@ fn manifest_client_to_fungi(expose: Option<&ServiceExpose>) -> Option<FungiServi
 
 struct RuntimeAndSource {
     runtime: RuntimeKind,
-    run_mode: ServiceRunMode,
     source: ServiceSource,
 }
 
@@ -272,8 +268,6 @@ struct FungiServiceDocument {
 #[serde(deny_unknown_fields)]
 struct FungiServiceRun {
     provider: FungiServiceProvider,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    mode: Option<FungiServiceRunMode>,
     source: FungiServiceSource,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     args: Vec<String>,
@@ -288,12 +282,6 @@ struct FungiServiceRun {
 enum FungiServiceProvider {
     Docker,
     Wasmtime,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum FungiServiceRunMode {
-    Http,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -519,7 +507,6 @@ impl FungiServiceDocument {
             name: service_name,
             definition_id: Some(definition_id),
             runtime: runtime_and_source.runtime,
-            run_mode: runtime_and_source.run_mode,
             source: runtime_and_source.source,
             expose,
             env,
@@ -547,13 +534,9 @@ fn parse_fungi_run(
 
     match run.provider {
         FungiServiceProvider::Docker => {
-            if run.mode.is_some() {
-                bail!("run.mode is currently supported only with provider: wasmtime");
-            }
             let image = exactly_one_source(&run.source, "run.source", SourceField::Image)?;
             Ok(RuntimeAndSource {
                 runtime: RuntimeKind::Docker,
-                run_mode: ServiceRunMode::Command,
                 source: ServiceSource::Docker { image },
             })
         }
@@ -577,10 +560,6 @@ fn parse_fungi_run(
             };
             Ok(RuntimeAndSource {
                 runtime: RuntimeKind::Wasmtime,
-                run_mode: match run.mode {
-                    Some(FungiServiceRunMode::Http) => ServiceRunMode::Http,
-                    None => ServiceRunMode::Command,
-                },
                 source,
             })
         }
@@ -632,7 +611,6 @@ fn parse_fungi_existing_tcp_run(
     }
     Ok(RuntimeAndSource {
         runtime: RuntimeKind::External,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::ExistingTcp {
             host,
             port: entry.tcp.port,

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeKind {
+    Unknown,
     Docker,
     Wasmtime,
     External,

--- a/crates/daemon/src/runtime/model.rs
+++ b/crates/daemon/src/runtime/model.rs
@@ -16,8 +16,6 @@ pub struct ServiceManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub definition_id: Option<String>,
     pub runtime: RuntimeKind,
-    #[serde(default)]
-    pub run_mode: ServiceRunMode,
     pub source: ServiceSource,
     pub expose: Option<ServiceExpose>,
     pub env: BTreeMap<String, String>,
@@ -27,14 +25,6 @@ pub struct ServiceManifest {
     pub entrypoint: Vec<String>,
     pub working_dir: Option<String>,
     pub labels: BTreeMap<String, String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum ServiceRunMode {
-    #[default]
-    Command,
-    Http,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/daemon/src/runtime/tests.rs
+++ b/crates/daemon/src/runtime/tests.rs
@@ -1092,6 +1092,208 @@ publish:
 }
 
 #[tokio::test]
+async fn invalid_persisted_services_are_isolated_and_can_be_upgraded_or_removed() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let component = temp.path().join("upgraded.wasm");
+    fs::write(&component, b"upgraded component").unwrap();
+    let manifest = format!(
+        "fungi: service/v1\nid: filebrowser-lite\ninstance: files\nrun:\n  provider: wasmtime\n  source:\n    file: {}\n  mounts:\n    - from: $fungi.service.data\n      to: /data\npublish:\n  http:\n    tcp:\n      port: 8082\n",
+        component.display()
+    );
+    let legacy = manifest.replace("  provider: wasmtime", "  provider: wasmtime\n  mode: http");
+    let service_dir = home.join("services/svc_old");
+    fs::create_dir_all(&service_dir).unwrap();
+    fs::write(service_dir.join("service.yaml"), &legacy).unwrap();
+    fs::write(
+        service_dir.join("state.json"),
+        r#"{"schema_version":2,"local_service_id":"svc_old","desired_state":"running"}"#,
+    )
+    .unwrap();
+    let data = home.join("appdata/services/svc_old");
+    fs::create_dir_all(&data).unwrap();
+    fs::write(data.join("keep.txt"), "user data").unwrap();
+    let broken_dir = home.join("services/svc_broken");
+    fs::create_dir_all(&broken_dir).unwrap();
+    fs::write(broken_dir.join("service.yaml"), "fungi: [invalid YAML").unwrap();
+
+    let control = RuntimeControl::new(
+        home.join("runtime"),
+        create_fake_launcher(temp.path()).unwrap(),
+        home.clone(),
+        None,
+        home.join("services"),
+        vec![temp.path().to_path_buf()],
+        true,
+    )
+    .unwrap();
+    control.restore_persisted_state().await.unwrap();
+    assert!(control.desired_running_service_manifests().is_empty());
+    let listed = control.list_services().await.unwrap();
+    assert_eq!(listed.len(), 2);
+    let failed = control.inspect_by_name("files").await.unwrap();
+    assert_eq!(failed.status.phase, ServicePhase::Unknown);
+    assert_eq!(failed.definition_id.as_deref(), Some("filebrowser-lite"));
+    assert!(failed.status.detail.unwrap().contains("run-compatible"));
+    assert!(
+        control
+            .start_by_name("files")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("configuration error")
+    );
+    assert!(control.stop_by_name("files").await.is_err());
+    assert_eq!(
+        fs::read_to_string(service_dir.join("service.yaml")).unwrap(),
+        legacy
+    );
+    assert!(
+        control
+            .list_published_device_services()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    let mismatch = manifest.replace("id: filebrowser-lite", "id: different");
+    assert!(
+        control
+            .apply_manifest_yaml(&mismatch, temp.path(), &home, &ManifestResolutionPolicy)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("definition id")
+    );
+    assert!(
+        control
+            .apply_manifest_yaml(&legacy, temp.path(), &home, &ManifestResolutionPolicy)
+            .await
+            .is_err()
+    );
+
+    let applied = control
+        .apply_manifest_yaml(&manifest, temp.path(), &home, &ManifestResolutionPolicy)
+        .await
+        .unwrap();
+    assert_eq!(applied.instance.status.phase, ServicePhase::Stopped);
+    assert_eq!(
+        fs::read_to_string(data.join("keep.txt")).unwrap(),
+        "user data"
+    );
+    assert_eq!(
+        fs::read(home.join("artifacts/services/svc_old/component.wasm")).unwrap(),
+        b"upgraded component"
+    );
+    let saved = fs::read_to_string(service_dir.join("service.yaml")).unwrap();
+    assert!(!saved.contains("mode:"));
+    assert_eq!(
+        control.get_service_manifest("files").unwrap().mounts[0].host_path,
+        data
+    );
+    control.start_by_name("files").await.unwrap();
+    assert!(
+        control
+            .inspect_by_name("files")
+            .await
+            .unwrap()
+            .status
+            .is_running()
+    );
+    control.stop_by_name("files").await.unwrap();
+    control.remove_by_name("svc_broken").await.unwrap();
+    assert!(!broken_dir.exists());
+    assert_eq!(control.list_services().await.unwrap().len(), 1);
+
+    let reloaded = crate::service_state::ServiceStateStore::load(home.join("services")).unwrap();
+    assert!(reloaded.failed_services().is_empty());
+    assert_eq!(reloaded.local_service_id("files").unwrap(), "svc_old");
+}
+
+#[tokio::test]
+async fn state_errors_do_not_block_healthy_services_and_apply_clears_migration_error() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let manifest = "fungi: service/v1\nid: demo\npublish:\n  main:\n    tcp:\n      port: 54321\n";
+    for (id, name, state) in [
+        (
+            "svc_migrated",
+            "migrated",
+            r#"{"schema_version":2,"local_service_id":"svc_migrated","desired_state":"running","configuration_error":"Legacy Wasmtime HTTP service requires a run-compatible component"}"#,
+        ),
+        (
+            "svc_future",
+            "future",
+            r#"{"schema_version":999,"local_service_id":"svc_future","desired_state":"running"}"#,
+        ),
+        ("svc_bad_state", "bad-state", "not json"),
+        (
+            "svc_healthy",
+            "healthy",
+            r#"{"schema_version":2,"local_service_id":"svc_healthy","desired_state":"running"}"#,
+        ),
+    ] {
+        let dir = home.join("services").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("service.yaml"),
+            manifest.replace("id: demo", &format!("id: {name}")),
+        )
+        .unwrap();
+        fs::write(dir.join("state.json"), state).unwrap();
+    }
+    let control = RuntimeControl::new(
+        home.join("runtime"),
+        PathBuf::from("unused"),
+        home.to_path_buf(),
+        None,
+        home.join("services"),
+        vec![],
+        false,
+    )
+    .unwrap();
+    control.restore_persisted_state().await.unwrap();
+    assert_eq!(control.list_services().await.unwrap().len(), 4);
+    assert!(
+        control
+            .inspect_by_name("healthy")
+            .await
+            .unwrap()
+            .status
+            .is_running()
+    );
+    for name in ["migrated", "future", "bad-state"] {
+        assert_eq!(
+            control.inspect_by_name(name).await.unwrap().status.phase,
+            ServicePhase::Unknown
+        );
+        assert!(
+            control
+                .start_by_name(name)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("configuration error")
+        );
+    }
+    let updated = manifest
+        .replace("id: demo", "id: migrated")
+        .replace("54321", "54322");
+    control
+        .apply_manifest_yaml(&updated, home, home, &ManifestResolutionPolicy)
+        .await
+        .unwrap();
+    let state = fs::read_to_string(home.join("services/svc_migrated/state.json")).unwrap();
+    assert!(!state.contains("configuration_error"));
+    assert!(
+        crate::service_state::ServiceStateStore::load(home.join("services"))
+            .unwrap()
+            .persisted_service("migrated")
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn runtime_control_apply_uses_in_memory_manifest_when_persisted_state_is_missing() {
     let temp_dir = TempDir::new().unwrap();
     let fungi_home = temp_dir.path().join("fungi-home");

--- a/crates/daemon/src/runtime/tests.rs
+++ b/crates/daemon/src/runtime/tests.rs
@@ -31,7 +31,6 @@ fn docker_manifest_maps_to_container_spec() {
         name: "filebrowser".into(),
         definition_id: None,
         runtime: RuntimeKind::Docker,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::Docker {
             image: "filebrowser/filebrowser:latest".into(),
         },
@@ -66,7 +65,6 @@ fn docker_manifest_can_use_internal_container_name() {
         name: "c".into(),
         definition_id: Some("code-server".into()),
         runtime: RuntimeKind::Docker,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::Docker {
             image: "ghcr.io/coder/code-server:latest".into(),
         },
@@ -94,7 +92,6 @@ fn ensure_manifest_mount_dirs_creates_missing_host_paths() {
         name: "mount-test".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::WasmtimeFile {
             component: temp_dir.path().join("demo.wasm"),
         },
@@ -146,7 +143,6 @@ fn docker_manifest_rejects_wrong_source_type() {
         name: "bad".into(),
         definition_id: None,
         runtime: RuntimeKind::Docker,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::WasmtimeFile {
             component: PathBuf::from("/tmp/app.wasm"),
         },
@@ -180,7 +176,6 @@ async fn wasmtime_provider_runs_fake_launcher_and_collects_logs() {
         name: "demo-service".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Http,
         source: ServiceSource::WasmtimeFile {
             component: component.clone(),
         },
@@ -242,7 +237,9 @@ async fn wasmtime_provider_runs_fake_launcher_and_collects_logs() {
         sleep(Duration::from_millis(100)).await;
     }
     assert!(logs.text.contains("fake-launcher"));
-    assert!(logs.text.contains("serve"));
+    assert!(logs.text.contains("run"));
+    assert!(!logs.text.contains("serve"));
+    assert!(logs.text.contains("-Shttp"));
     assert!(logs.text.contains("-Stcp"));
     assert!(logs.text.contains("-Sinherit-network"));
     assert!(logs.text.contains("-Sallow-ip-name-lookup"));
@@ -263,7 +260,6 @@ fn wasmtime_tcp_entry_runs_command_with_network_permissions() {
         name: "tcp-service".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::WasmtimeFile {
             component: component.clone(),
         },
@@ -312,6 +308,7 @@ fn wasmtime_tcp_entry_runs_command_with_network_permissions() {
     assert!(args.iter().any(|arg| arg == "run"));
     assert!(!args.iter().any(|arg| arg == "serve"));
     assert!(args.iter().any(|arg| arg == "-Scli"));
+    assert!(args.iter().any(|arg| arg == "-Shttp"));
     assert!(args.iter().any(|arg| arg == "-Stcp"));
     assert!(args.iter().any(|arg| arg == "-Sinherit-network"));
     assert!(args.iter().any(|arg| arg == "-Sallow-ip-name-lookup"));
@@ -326,7 +323,6 @@ fn wasmtime_command_android_home_override_matches_target_behavior() {
         name: "android-home".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::WasmtimeFile {
             component: component.clone(),
         },
@@ -372,14 +368,13 @@ fn wasmtime_command_android_home_override_matches_target_behavior() {
 }
 
 #[test]
-fn wasmtime_http_mode_without_tcp_port_returns_error() {
+fn wasmtime_command_without_tcp_ports_omits_network_permissions() {
     let temp_dir = TempDir::new().unwrap();
     let component = temp_dir.path().join("demo.wasm");
     let manifest = ServiceManifest {
         name: "http-service".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Http,
         source: ServiceSource::WasmtimeFile {
             component: component.clone(),
         },
@@ -412,10 +407,19 @@ fn wasmtime_http_mode_without_tcp_port_returns_error() {
         last_exit_code: None,
     };
 
-    let error = build_wasmtime_command(Path::new("/bin/fungi"), temp_dir.path(), &state)
-        .expect_err("http mode without a TCP port should be rejected");
+    let command = build_wasmtime_command(Path::new("/bin/fungi"), temp_dir.path(), &state).unwrap();
+    let args = command
+        .as_std()
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
 
-    assert!(error.to_string().contains("requires at least one TCP port"));
+    assert!(args.iter().any(|arg| arg == "run"));
+    assert!(!args.iter().any(|arg| arg == "serve"));
+    assert!(args.iter().any(|arg| arg == "-Shttp"));
+    assert!(!args.iter().any(|arg| arg == "-Stcp"));
+    assert!(!args.iter().any(|arg| arg == "-Sinherit-network"));
+    assert!(!args.iter().any(|arg| arg == "-Sallow-ip-name-lookup"));
 }
 
 #[test]
@@ -540,7 +544,6 @@ publish:
 
     assert_eq!(manifest.name, "code-server");
     assert_eq!(manifest.runtime, RuntimeKind::Docker);
-    assert_eq!(manifest.run_mode, ServiceRunMode::Command);
     assert_eq!(manifest.mounts[0].host_path, paths.user_home());
     assert_eq!(manifest.ports[0].service_port, 8080);
     assert_eq!(
@@ -561,7 +564,7 @@ publish:
 }
 
 #[test]
-fn fungi_service_file_maps_wasmtime_http_mode_to_serve_intent() {
+fn fungi_service_file_rejects_removed_wasmtime_http_mode() {
     let content = r#"
 fungi: service/v1
 id: filebrowser-lite
@@ -579,11 +582,41 @@ publish:
       path: /
 "#;
 
+    let error = parse_service_manifest_yaml(content, Path::new("."), Path::new("/tmp/fungi-home"))
+        .unwrap_err();
+
+    assert!(error.to_string().contains("unknown field `mode`"));
+}
+
+#[test]
+fn fungi_service_file_maps_wasmtime_listener_to_run_args() {
+    let content = r#"
+fungi: service/v1
+id: filebrowser-lite
+run:
+  provider: wasmtime
+  source:
+    url: https://example.test/filebrowser.wasm
+  args:
+    - --listen
+    - 127.0.0.1:8082
+publish:
+  http:
+    tcp:
+      port: 8082
+    client:
+      kind: web
+      path: /
+"#;
+
     let manifest =
         parse_service_manifest_yaml(content, Path::new("."), Path::new("/tmp/fungi-home")).unwrap();
 
     assert_eq!(manifest.runtime, RuntimeKind::Wasmtime);
-    assert_eq!(manifest.run_mode, ServiceRunMode::Http);
+    assert_eq!(
+        manifest.command,
+        ["--listen".to_string(), "127.0.0.1:8082".to_string()]
+    );
     assert_eq!(manifest.ports[0].host_port, 8082);
     assert_eq!(
         manifest.ports[0].host_port_allocation,
@@ -928,7 +961,6 @@ async fn wasmtime_provider_downloads_remote_component() {
         name: "download-service".into(),
         definition_id: None,
         runtime: RuntimeKind::Wasmtime,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::WasmtimeUrl {
             url: server.url.clone(),
         },
@@ -1415,7 +1447,6 @@ fn existing_tcp_manifest(name: &str, host: &str, port: u16) -> ServiceManifest {
         name: name.to_string(),
         definition_id: None,
         runtime: RuntimeKind::External,
-        run_mode: ServiceRunMode::Command,
         source: ServiceSource::ExistingTcp {
             host: host.to_string(),
             port,

--- a/crates/daemon/src/runtime/tests.rs
+++ b/crates/daemon/src/runtime/tests.rs
@@ -1092,6 +1092,131 @@ publish:
 }
 
 #[tokio::test]
+async fn first_apply_persistence_failure_can_be_retried_without_restart() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let component = home.join("component.wasm");
+    fs::write(&component, b"component").unwrap();
+    let manifest = parse_service_manifest_yaml(&format!(
+        "fungi: service/v1\nid: retryable\nrun:\n  provider: wasmtime\n  source:\n    file: {}\npublish:\n  main:\n    tcp:\n      port: 8082\n", component.display()
+    ), home, home).unwrap();
+    let provider = WasmtimeRuntimeProvider::new(
+        home.join("runtime"),
+        create_fake_launcher(home).unwrap(),
+        home.to_path_buf(),
+        vec![home.to_path_buf()],
+    );
+    let services = home.join("services");
+    let control =
+        RuntimeControl::with_wasmtime_provider(provider.clone(), None, services.clone(), true)
+            .unwrap();
+
+    // A non-directory obstruction fails identically for root and non-root test runners.
+    fs::remove_dir(&services).unwrap();
+    fs::write(&services, b"blocked").unwrap();
+    let error = control.apply(&manifest).await.unwrap_err();
+    assert!(format!("{error:#}").contains("Failed to create managed service directory"));
+    assert!(!provider.has_service("retryable"));
+    assert!(control.list_services().await.unwrap().is_empty());
+    assert_eq!(
+        fs::read_dir(home.join("artifacts/services"))
+            .unwrap()
+            .count(),
+        0
+    );
+
+    fs::remove_file(&services).unwrap();
+    fs::create_dir(&services).unwrap();
+    control.apply(&manifest).await.unwrap();
+    control.start_by_name("retryable").await.unwrap();
+    assert!(
+        control
+            .inspect_by_name("retryable")
+            .await
+            .unwrap()
+            .status
+            .is_running()
+    );
+    control.remove_by_name("retryable").await.unwrap();
+    assert!(!provider.has_service("retryable"));
+}
+
+#[tokio::test]
+async fn failed_upgrade_restores_manifest_and_remains_retryable() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let component = home.join("component.wasm");
+    fs::write(&component, b"upgraded").unwrap();
+    let yaml = format!(
+        "fungi: service/v1\nid: demo\nrun:\n  provider: wasmtime\n  source:\n    file: {}\npublish:\n  main:\n    tcp:\n      port: 8082\n",
+        component.display()
+    );
+    let legacy = yaml.replace("  provider: wasmtime", "  provider: wasmtime\n  mode: http");
+    let saved = home.join("services/svc_old");
+    fs::create_dir_all(&saved).unwrap();
+    fs::write(saved.join("service.yaml"), &legacy).unwrap();
+    let old_state =
+        br#"{"schema_version":2,"local_service_id":"svc_old","desired_state":"running"}"#;
+    fs::write(saved.join("state.json"), old_state).unwrap();
+    let data = home.join("appdata/services/svc_old");
+    fs::create_dir_all(&data).unwrap();
+    fs::write(data.join("keep.txt"), b"user data").unwrap();
+    let provider = WasmtimeRuntimeProvider::new(
+        home.join("runtime"),
+        create_fake_launcher(home).unwrap(),
+        home.to_path_buf(),
+        vec![home.to_path_buf()],
+    );
+    let control =
+        RuntimeControl::with_wasmtime_provider(provider.clone(), None, home.join("services"), true)
+            .unwrap();
+    control.restore_persisted_state().await.unwrap();
+
+    fs::rename(saved.join("state.json"), saved.join("state.backup")).unwrap();
+    fs::create_dir(saved.join("state.json")).unwrap();
+    let error = control
+        .apply_manifest_yaml(&yaml, home, home, &ManifestResolutionPolicy)
+        .await
+        .unwrap_err();
+    assert!(format!("{error:#}").contains("Failed to persist service state file"));
+    assert_eq!(
+        fs::read_to_string(saved.join("service.yaml")).unwrap(),
+        legacy
+    );
+    assert!(!provider.has_service("demo"));
+    assert!(
+        control
+            .inspect_by_name("demo")
+            .await
+            .unwrap()
+            .status
+            .state_label()
+            .contains("configuration error")
+    );
+    assert!(control.start_by_name("demo").await.is_err());
+    assert_eq!(fs::read(data.join("keep.txt")).unwrap(), b"user data");
+
+    fs::remove_dir(saved.join("state.json")).unwrap();
+    fs::rename(saved.join("state.backup"), saved.join("state.json")).unwrap();
+    assert_eq!(fs::read(saved.join("state.json")).unwrap(), old_state);
+    control
+        .apply_manifest_yaml(&yaml, home, home, &ManifestResolutionPolicy)
+        .await
+        .unwrap();
+    control.start_by_name("demo").await.unwrap();
+    assert!(
+        control
+            .inspect_by_name("demo")
+            .await
+            .unwrap()
+            .status
+            .is_running()
+    );
+    control.remove_by_name("demo").await.unwrap();
+    assert_eq!(fs::read(data.join("keep.txt")).unwrap(), b"user data");
+}
+
+#[tokio::test]
 async fn invalid_persisted_services_are_isolated_and_can_be_upgraded_or_removed() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/crates/daemon/src/service_state.rs
+++ b/crates/daemon/src/service_state.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::Write,
     path::{Path, PathBuf},
@@ -13,7 +13,8 @@ use tempfile::NamedTempFile;
 use ulid::Ulid;
 
 use crate::runtime::{
-    ServiceManifest, parse_managed_service_manifest_yaml, service_manifest_to_yaml,
+    RuntimeKind, ServiceInstance, ServiceManifest, ServiceStatus,
+    parse_managed_service_manifest_yaml, service_manifest_to_yaml,
 };
 
 const SERVICE_STATE_SCHEMA_VERSION: u32 = 2;
@@ -34,6 +35,8 @@ pub struct PersistedService {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ServiceStateFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    configuration_error: Option<String>,
     #[serde(default = "default_schema_version")]
     schema_version: u32,
     local_service_id: String,
@@ -45,6 +48,7 @@ struct ServiceStateFile {
 impl ServiceStateFile {
     fn default_for_local_service_id(local_service_id: String) -> Self {
         Self {
+            configuration_error: None,
             schema_version: SERVICE_STATE_SCHEMA_VERSION,
             local_service_id,
             updated_at: String::new(),
@@ -57,6 +61,8 @@ pub struct ServiceStateStore {
     services_root: PathBuf,
     state: BTreeMap<String, PersistedService>,
     name_index: BTreeMap<String, String>,
+    failures: BTreeMap<String, ServiceInstance>,
+    ambiguous_names: BTreeMap<String, BTreeSet<String>>,
 }
 
 impl ServiceStateStore {
@@ -74,80 +80,139 @@ impl ServiceStateStore {
         })?;
 
         let mut state = BTreeMap::new();
-        let mut name_index = BTreeMap::new();
+        let mut failures = BTreeMap::new();
 
-        for entry in fs::read_dir(&services_root).with_context(|| {
-            format!(
-                "Failed to read services directory: {}",
-                services_root.display()
-            )
-        })? {
-            let entry = entry?;
+        let mut entries = fs::read_dir(&services_root)
+            .with_context(|| {
+                format!(
+                    "Failed to read services directory: {}",
+                    services_root.display()
+                )
+            })?
+            .collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
             let service_dir = entry.path();
             if !service_dir.is_dir() {
                 continue;
             }
 
             let manifest_path = service_dir.join("service.yaml");
-            if !manifest_path.exists() {
+            if !manifest_path.exists() && !service_dir.join("state.json").exists() {
                 continue;
             }
 
-            let manifest_yaml = fs::read_to_string(&manifest_path).with_context(|| {
-                format!(
-                    "Failed to read managed service manifest: {}",
-                    manifest_path.display()
+            let loaded = (|| -> Result<PersistedService> {
+                let manifest_yaml = fs::read_to_string(&manifest_path).with_context(|| {
+                    format!(
+                        "Failed to read managed service manifest: {}",
+                        manifest_path.display()
+                    )
+                })?;
+                let state_file =
+                    load_service_state_file(&service_dir.join("state.json"), &service_dir)?;
+                if let Some(error) = &state_file.configuration_error {
+                    bail!("{error}");
+                }
+                let manifest = parse_managed_service_manifest_yaml(
+                    &manifest_yaml,
+                    &service_dir,
+                    &fungi_home,
+                    &state_file.local_service_id,
                 )
-            })?;
-            let state_file =
-                load_service_state_file(&service_dir.join("state.json"), &service_dir)?;
-            let manifest = parse_managed_service_manifest_yaml(
-                &manifest_yaml,
-                &service_dir,
-                &fungi_home,
-                &state_file.local_service_id,
-            )
-            .with_context(|| {
-                format!(
-                    "Failed to parse managed service manifest: {}",
-                    manifest_path.display()
-                )
-            })?;
+                .with_context(|| {
+                    format!(
+                        "Failed to parse managed service manifest: {}",
+                        manifest_path.display()
+                    )
+                })?;
 
-            if let Some(existing_local_service_id) =
-                name_index.insert(manifest.name.clone(), state_file.local_service_id.clone())
-            {
-                bail!(
-                    "Duplicate managed service name '{}' for local ids '{}' and '{}'",
-                    manifest.name,
-                    existing_local_service_id,
-                    state_file.local_service_id
-                );
+                Ok(PersistedService {
+                    local_service_id: state_file.local_service_id,
+                    manifest,
+                    desired_state: state_file.desired_state,
+                })
+            })();
+            match loaded {
+                Ok(service) => {
+                    state.insert(service.local_service_id.clone(), service);
+                }
+                Err(error) => {
+                    let failure = failed_service_instance(&service_dir, &error);
+                    log::warn!("{}: {}", failure.name, failure.status.state_label());
+                    failures.insert(failure.id.clone(), failure);
+                }
             }
+        }
 
-            if state
-                .insert(
-                    state_file.local_service_id.clone(),
-                    PersistedService {
-                        local_service_id: state_file.local_service_id,
-                        manifest,
-                        desired_state: state_file.desired_state,
-                    },
-                )
-                .is_some()
+        // Ambiguous names must never select an arbitrary service's data for an apply.
+        let mut counts = BTreeMap::<String, usize>::new();
+        for service in state.values() {
+            *counts.entry(service.manifest.name.clone()).or_default() += 1;
+        }
+        for failure in failures.values() {
+            *counts.entry(failure.name.clone()).or_default() += 1;
+        }
+        let duplicate_ids = state
+            .values()
+            .filter(|service| {
+                counts[&service.manifest.name] > 1
+                    || services_root.join(&service.manifest.name).exists()
+                        && service.manifest.name != service.local_service_id
+            })
+            .map(|service| service.local_service_id.clone())
+            .collect::<Vec<_>>();
+        for id in duplicate_ids {
+            state.remove(&id);
+            failures.insert(
+                id.clone(),
+                failed_service_instance(
+                    &services_root.join(&id),
+                    &anyhow::anyhow!("duplicate managed service name"),
+                ),
+            );
+        }
+        let mut name_index = BTreeMap::new();
+        let mut ambiguous_names = BTreeMap::<String, BTreeSet<String>>::new();
+        for service in state.values() {
+            name_index.insert(
+                service.manifest.name.clone(),
+                service.local_service_id.clone(),
+            );
+        }
+        for failure in failures.values_mut() {
+            if counts.get(&failure.name).copied().unwrap_or(0) > 1
+                || name_index.contains_key(&failure.name)
+                || services_root.join(&failure.name).exists() && failure.name != failure.id
             {
-                bail!(
-                    "Duplicate managed service local id in {}",
-                    services_root.display()
-                );
+                ambiguous_names
+                    .entry(failure.name.clone())
+                    .or_default()
+                    .insert(failure.id.clone());
+                failure.status = failure.status.clone().with_detail(format!(
+                    "{} The instance name '{}' is ambiguous; use local service id '{}' to inspect/remove this entry.",
+                    failure.status.state_label(), failure.name, failure.id
+                ));
+                failure.name = failure.id.clone();
             }
+            name_index.insert(failure.name.clone(), failure.id.clone());
         }
 
         Ok(Self {
             services_root,
             state,
             name_index,
+            failures,
+            ambiguous_names,
         })
+    }
+
+    pub fn failed_services(&self) -> Vec<ServiceInstance> {
+        self.failures.values().cloned().collect()
+    }
+
+    pub fn failed_service(&self, name: &str) -> Option<ServiceInstance> {
+        self.failures.get(self.name_index.get(name)?).cloned()
     }
 
     pub fn persisted_services(&self) -> Vec<PersistedService> {
@@ -167,6 +232,7 @@ impl ServiceStateStore {
     }
 
     pub fn preview_local_service_id(&self, service_name: &str) -> Result<String> {
+        self.ensure_unambiguous_name(service_name)?;
         if let Some(local_service_id) = self.name_index.get(service_name) {
             return Ok(local_service_id.clone());
         }
@@ -186,9 +252,10 @@ impl ServiceStateStore {
     ) -> Result<String> {
         let local_service_id =
             self.resolve_upsert_local_service_id(&manifest.name, requested_local_service_id)?;
-        self.name_index
+        let previous_index = self
+            .name_index
             .insert(manifest.name.clone(), local_service_id.clone());
-        self.state.insert(
+        let previous_service = self.state.insert(
             local_service_id.clone(),
             PersistedService {
                 local_service_id: local_service_id.clone(),
@@ -196,7 +263,27 @@ impl ServiceStateStore {
                 desired_state,
             },
         );
-        self.save_service(&local_service_id)?;
+        if let Err(error) = self.save_service(&local_service_id) {
+            match previous_service {
+                Some(service) => {
+                    self.state.insert(local_service_id.clone(), service);
+                }
+                None => {
+                    self.state.remove(&local_service_id);
+                }
+            }
+            match previous_index {
+                Some(id) => {
+                    self.name_index.insert(manifest.name.clone(), id);
+                }
+                None => {
+                    self.name_index.remove(&manifest.name);
+                }
+            }
+            return Err(error);
+        }
+        self.failures.remove(&local_service_id);
+        self.clear_ambiguous_id(&local_service_id);
         Ok(local_service_id)
     }
 
@@ -215,11 +302,10 @@ impl ServiceStateStore {
     }
 
     pub fn remove_service(&mut self, service_name: &str) -> Result<()> {
-        let Some(local_service_id) = self.name_index.remove(service_name) else {
+        let Some(local_service_id) = self.name_index.get(service_name).cloned() else {
             return Ok(());
         };
 
-        self.state.remove(&local_service_id);
         let service_dir = self.service_dir(&local_service_id);
         if service_dir.exists() {
             fs::remove_dir_all(&service_dir).with_context(|| {
@@ -229,6 +315,10 @@ impl ServiceStateStore {
                 )
             })?;
         }
+        self.name_index.remove(service_name);
+        self.state.remove(&local_service_id);
+        self.failures.remove(&local_service_id);
+        self.clear_ambiguous_id(&local_service_id);
         Ok(())
     }
 
@@ -250,6 +340,7 @@ impl ServiceStateStore {
         atomic_write(&service_dir.join("service.yaml"), manifest_yaml.as_bytes())?;
 
         let state_file = ServiceStateFile {
+            configuration_error: None,
             schema_version: SERVICE_STATE_SCHEMA_VERSION,
             local_service_id: local_service_id.to_string(),
             updated_at: Utc::now().to_rfc3339(),
@@ -294,6 +385,7 @@ impl ServiceStateStore {
         service_name: &str,
         requested_local_service_id: Option<&str>,
     ) -> Result<String> {
+        self.ensure_unambiguous_name(service_name)?;
         let requested_local_service_id = requested_local_service_id
             .map(|value| normalize_local_service_id(value, "local_service_id"))
             .transpose()?;
@@ -313,6 +405,13 @@ impl ServiceStateStore {
         }
 
         if let Some(requested_local_service_id) = requested_local_service_id {
+            if let Some(failure) = self.failures.get(&requested_local_service_id) {
+                bail!(
+                    "local_service_id '{}' is already assigned to service '{}'",
+                    requested_local_service_id,
+                    failure.name
+                );
+            }
             if let Some(existing_service) = self.state.get(&requested_local_service_id)
                 && existing_service.manifest.name != service_name
             {
@@ -331,12 +430,76 @@ impl ServiceStateStore {
     fn generate_unique_local_service_id(&self) -> Result<String> {
         for _ in 0..16 {
             let candidate = format!("svc_{}", Ulid::new().to_string().to_ascii_lowercase());
-            if !self.state.contains_key(&candidate) {
+            if !self.services_root.join(&candidate).exists() {
                 return Ok(candidate);
             }
         }
 
         bail!("failed to allocate unique local_service_id")
+    }
+
+    fn ensure_unambiguous_name(&self, name: &str) -> Result<()> {
+        if self.ambiguous_names.contains_key(name) {
+            bail!(
+                "duplicate managed service name '{name}'; inspect/remove the conflicting services by their local service ids before applying again"
+            );
+        }
+        Ok(())
+    }
+
+    fn clear_ambiguous_id(&mut self, id: &str) {
+        self.ambiguous_names.retain(|_, ids| {
+            ids.remove(id);
+            !ids.is_empty()
+        });
+    }
+}
+
+fn failed_service_instance(service_dir: &Path, error: &anyhow::Error) -> ServiceInstance {
+    let id = service_dir
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned();
+    let document = fs::read_to_string(service_dir.join("service.yaml"))
+        .ok()
+        .and_then(|content| serde_yaml::from_str::<serde_yaml::Value>(&content).ok())
+        .unwrap_or_default();
+    let field = |key: &str| {
+        document[key]
+            .as_str()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    let definition_id = field("id");
+    let name = field("instance")
+        .or_else(|| definition_id.clone())
+        .unwrap_or_else(|| id.clone());
+    let runtime = match document["run"]["provider"].as_str() {
+        Some("wasmtime") => RuntimeKind::Wasmtime,
+        Some("docker") => RuntimeKind::Docker,
+        None if document["run"].is_null() && document["publish"].is_mapping() => {
+            RuntimeKind::External
+        }
+        _ => RuntimeKind::Unknown,
+    };
+    let hint = if document["run"]["mode"].as_str() == Some("http") {
+        "The legacy Wasmtime HTTP serve runtime is no longer supported. Apply an upgraded run-compatible service recipe using the same instance name; removing run.mode alone does not convert the component."
+    } else {
+        "Correct the saved configuration or apply a supported service recipe using the same instance name."
+    };
+    ServiceInstance {
+        id,
+        name,
+        definition_id,
+        runtime,
+        source: service_dir.join("service.yaml").display().to_string(),
+        labels: BTreeMap::new(),
+        ports: Vec::new(),
+        exposed_endpoints: Vec::new(),
+        status: ServiceStatus::unknown()
+            .with_detail(format!("configuration error: {error:#}. {hint}")),
     }
 }
 
@@ -428,7 +591,11 @@ fn local_service_id_from_service_dir(service_dir: &Path) -> Result<String> {
                 service_dir.display()
             )
         })?;
-    normalize_local_service_id(value, "service directory name")
+    let normalized = normalize_local_service_id(value, "service directory name")?;
+    if normalized != value {
+        bail!("service directory name must not contain surrounding whitespace");
+    }
+    Ok(normalized)
 }
 
 #[cfg(test)]
@@ -438,6 +605,50 @@ mod tests {
         RuntimeKind, ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceSource,
     };
     use fungi_config::paths::FungiPaths;
+
+    #[test]
+    fn duplicate_names_are_quarantined_without_rebinding_service_data() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("services");
+        for id in ["svc_a", "svc_b"] {
+            let path = root.join(id);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(
+                path.join("service.yaml"),
+                "fungi: service/v1\nid: demo\npublish:\n  main:\n    tcp:\n      port: 54321\n",
+            )
+            .unwrap();
+        }
+        let mut store = ServiceStateStore::load(root).unwrap();
+        assert!(store.persisted_services().is_empty());
+        assert_eq!(store.failed_services().len(), 2);
+        assert!(store.preview_local_service_id("demo").is_err());
+        assert_eq!(store.failed_service("svc_a").unwrap().id, "svc_a");
+        store.remove_service("svc_a").unwrap();
+        assert!(store.preview_local_service_id("demo").is_err());
+        store.remove_service("svc_b").unwrap();
+        assert!(store.preview_local_service_id("demo").is_ok());
+    }
+
+    #[test]
+    fn missing_manifest_is_reported_and_can_be_removed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("services");
+        let service_dir = root.join("svc_missing");
+        fs::create_dir_all(&service_dir).unwrap();
+        fs::write(service_dir.join("state.json"), "{}").unwrap();
+        let mut store = ServiceStateStore::load(root).unwrap();
+        let failure = store.failed_service("svc_missing").unwrap();
+        assert_eq!(failure.runtime, RuntimeKind::Unknown);
+        assert!(
+            failure
+                .status
+                .state_label()
+                .contains("Failed to read managed service manifest")
+        );
+        store.remove_service("svc_missing").unwrap();
+        assert!(!service_dir.exists());
+    }
 
     #[test]
     fn round_trips_persisted_services() {

--- a/crates/daemon/src/service_state.rs
+++ b/crates/daemon/src/service_state.rs
@@ -297,8 +297,13 @@ impl ServiceStateStore {
             .state
             .get_mut(&local_service_id)
             .ok_or_else(|| anyhow::anyhow!("persisted service not found: {service_name}"))?;
+        let previous = service.desired_state;
         service.desired_state = desired_state;
-        self.save_service(&local_service_id)
+        if let Err(error) = self.save_service(&local_service_id) {
+            self.state.get_mut(&local_service_id).unwrap().desired_state = previous;
+            return Err(error);
+        }
+        Ok(())
     }
 
     pub fn remove_service(&mut self, service_name: &str) -> Result<()> {
@@ -337,7 +342,15 @@ impl ServiceStateStore {
         self.ensure_service_appdata_dir(local_service_id)?;
 
         let manifest_yaml = service_manifest_to_yaml(&service.manifest)?;
-        atomic_write(&service_dir.join("service.yaml"), manifest_yaml.as_bytes())?;
+        let manifest_path = service_dir.join("service.yaml");
+        let previous_manifest = match fs::read(&manifest_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to back up {}", manifest_path.display()));
+            }
+        };
 
         let state_file = ServiceStateFile {
             configuration_error: None,
@@ -348,7 +361,21 @@ impl ServiceStateStore {
         };
         let state_bytes =
             serde_json::to_vec_pretty(&state_file).context("Failed to encode service state")?;
-        atomic_write(&service_dir.join("state.json"), &state_bytes)
+        atomic_write(&manifest_path, manifest_yaml.as_bytes())?;
+        if let Err(error) = atomic_write(&service_dir.join("state.json"), &state_bytes) {
+            let rollback = match previous_manifest {
+                Some(bytes) => atomic_write(&manifest_path, &bytes),
+                None => fs::remove_file(&manifest_path)
+                    .context("Failed to remove uncommitted service manifest"),
+            };
+            return match rollback {
+                Ok(()) => Err(error),
+                Err(rollback_error) => {
+                    Err(error.context(format!("Manifest rollback also failed: {rollback_error:#}")))
+                }
+            };
+        }
+        Ok(())
     }
 
     fn service_dir(&self, local_service_id: &str) -> PathBuf {

--- a/crates/daemon/src/service_state.rs
+++ b/crates/daemon/src/service_state.rs
@@ -435,8 +435,7 @@ fn local_service_id_from_service_dir(service_dir: &Path) -> Result<String> {
 mod tests {
     use super::*;
     use crate::runtime::{
-        RuntimeKind, ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceRunMode,
-        ServiceSource,
+        RuntimeKind, ServicePort, ServicePortAllocation, ServicePortProtocol, ServiceSource,
     };
     use fungi_config::paths::FungiPaths;
 
@@ -450,7 +449,6 @@ mod tests {
             name: "demo".into(),
             definition_id: Some("demo-definition".into()),
             runtime: RuntimeKind::Docker,
-            run_mode: ServiceRunMode::Command,
             source: ServiceSource::Docker {
                 image: "nginx:latest".into(),
             },
@@ -523,7 +521,6 @@ mod tests {
             name: "demo".into(),
             definition_id: None,
             runtime: RuntimeKind::Docker,
-            run_mode: ServiceRunMode::Command,
             source: ServiceSource::Docker {
                 image: "nginx:latest".into(),
             },

--- a/crates/tests/src/bin/test_service_remote_wasm_cli.rs
+++ b/crates/tests/src/bin/test_service_remote_wasm_cli.rs
@@ -457,7 +457,7 @@ fn http_get(port: u16) -> Result<String> {
 fn write_manifest_file(dir: &Path, wasm_url: &str) -> Result<PathBuf> {
     let manifest_path = dir.join("filebrowser-lite-wasi.service.yaml");
     let manifest_yaml = format!(
-        "fungi: service/v1\nid: {service_name}\nrun:\n  provider: wasmtime\n  mode: http\n  source:\n    url: {wasm_url}\n  mounts:\n    - from: $fungi.workspace\n      to: data\npublish:\n  http:\n    tcp:\n      port: {service_port}\n    client:\n      kind: web\n      path: /\n      iconUrl: https://raw.githubusercontent.com/filebrowser/logo/master/icon.svg\n",
+        "fungi: service/v1\nid: {service_name}\nrun:\n  provider: wasmtime\n  source:\n    url: {wasm_url}\n  mounts:\n    - from: $fungi.workspace\n      to: data\npublish:\n  http:\n    tcp:\n      port: {service_port}\n    client:\n      kind: web\n      path: /\n      iconUrl: https://raw.githubusercontent.com/filebrowser/logo/master/icon.svg\n",
         service_name = SERVICE_NAME,
         service_port = SERVICE_PORT,
     );

--- a/fungi/Cargo.toml
+++ b/fungi/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "fungi"
 
 [features]
 default = ["wasi"]
-wasi = ["dep:wasmtime-cli"]
+wasi = ["dep:rustls", "dep:wasmtime-cli"]
 
 [dependencies]
 log = { workspace = true }
@@ -34,6 +34,7 @@ futures = { workspace = true }
 interprocess = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
+rustls = { workspace = true, optional = true, features = ["ring"] }
 wasmtime-cli = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -1953,15 +1953,7 @@ fn print_service_apply_dry_run(created: &CreatedServiceManifest, args: &CommonAr
         println!("  runtime: {}", runtime_kind_label(manifest.runtime));
     }
     if manifest.runtime == RuntimeKind::Wasmtime {
-        println!("  mode: {}", wasmtime_run_mode_label(manifest.run_mode));
-        println!(
-            "  invocation: {}",
-            if manifest.run_mode == fungi_daemon::ServiceRunMode::Http {
-                "serve"
-            } else {
-                "run"
-            }
-        );
+        println!("  invocation: run");
     }
     if !manifest.mounts.is_empty() {
         println!("Mounts:");
@@ -1989,18 +1981,21 @@ fn print_service_apply_dry_run(created: &CreatedServiceManifest, args: &CommonAr
             }
         );
     }
-    if manifest.runtime == RuntimeKind::Wasmtime
-        && manifest
+    if manifest.runtime == RuntimeKind::Wasmtime {
+        println!("Runtime grants:");
+        println!("  - outgoing HTTP/HTTPS");
+        if manifest
             .ports
             .iter()
             .any(|port| port.protocol == ServicePortProtocol::Tcp)
-    {
-        println!("Runtime grants:");
-        println!("  - tcp");
-        println!("  - inherited network");
-        println!("  - DNS lookup");
-        warnings
-            .push("Wasmtime TCP services currently receive broad host network access.".to_string());
+        {
+            println!("  - tcp");
+            println!("  - inherited network");
+            println!("  - DNS lookup");
+            warnings.push(
+                "Wasmtime TCP services currently receive broad host network access.".to_string(),
+            );
+        }
     }
     if !warnings.is_empty() {
         println!("Warnings:");
@@ -2012,13 +2007,6 @@ fn print_service_apply_dry_run(created: &CreatedServiceManifest, args: &CommonAr
         println!("After apply: start service");
     } else {
         println!("After apply: leave service stopped unless it was already running");
-    }
-}
-
-fn wasmtime_run_mode_label(mode: fungi_daemon::ServiceRunMode) -> &'static str {
-    match mode {
-        fungi_daemon::ServiceRunMode::Command => "command (default)",
-        fungi_daemon::ServiceRunMode::Http => "http",
     }
 }
 

--- a/fungi/src/commands/fungi_control/service.rs
+++ b/fungi/src/commands/fungi_control/service.rs
@@ -2192,6 +2192,7 @@ fn print_existing_apply_notice(
 
 fn runtime_kind_label(runtime: RuntimeKind) -> &'static str {
     match runtime {
+        RuntimeKind::Unknown => "unknown",
         RuntimeKind::Docker => "docker",
         RuntimeKind::Wasmtime => "wasmtime",
         RuntimeKind::External => "external",

--- a/fungi/src/commands/mod.rs
+++ b/fungi/src/commands/mod.rs
@@ -115,9 +115,6 @@ pub enum Commands {
     #[cfg(feature = "wasi")]
     /// [WASI runtime] Run a WebAssembly module (re-exported wasmtime command)
     Run(wasmtime_cli::commands::RunCommand),
-    #[cfg(feature = "wasi")]
-    /// [WASI runtime] Serve wasi-http requests (re-exported wasmtime command)
-    Serve(wasmtime_cli::commands::ServeCommand),
     /// Invoke a service by name
     #[command(external_subcommand)]
     Dynamic(Vec<String>),

--- a/fungi/src/logging.rs
+++ b/fungi/src/logging.rs
@@ -13,7 +13,7 @@ const DEFAULT_LOG_SPEC: &str = "info,libp2p_mdns::behaviour=warn";
 
 pub fn init_logging(fungi_args: &FungiArgs) -> Result<()> {
     #[cfg(feature = "wasi")]
-    if matches!(&fungi_args.command, Commands::Run(_) | Commands::Serve(_)) {
+    if matches!(&fungi_args.command, Commands::Run(_)) {
         return Ok(());
     }
 

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -17,9 +17,17 @@ fn main() -> Result<()> {
         #[cfg(feature = "wasi")]
         // wasmtime commands
         // env_logger and tokio runtime have been initialized in wasmtime commands
-        Commands::Run(c) => c.execute()?,
-        #[cfg(feature = "wasi")]
-        Commands::Serve(c) => c.execute()?,
+        Commands::Run(c) => {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "Rustls crypto provider was initialized before Wasmtime startup"
+                    )
+                })?;
+            c.execute()
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?
+        }
 
         // fungi commands
         Commands::Daemon(args) => block_on(fungi_daemon::execute(fungi_args.common.clone(), args))?,
@@ -55,7 +63,7 @@ fn main() -> Result<()> {
 
 fn run_migration_preflight(fungi_args: &FungiArgs) -> Result<()> {
     #[cfg(feature = "wasi")]
-    if matches!(&fungi_args.command, Commands::Run(_) | Commands::Serve(_)) {
+    if matches!(&fungi_args.command, Commands::Run(_)) {
         return Ok(());
     }
 

--- a/fungi/src/main.rs
+++ b/fungi/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
                     )
                 })?;
             c.execute()
-                .map_err(|error| anyhow::anyhow!(error.to_string()))?
+                .map_err(|error| anyhow::Error::from_boxed(error.into_boxed_dyn_error()))?
         }
 
         // fungi commands

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -9,6 +9,7 @@ use fungi::commands::{
 };
 
 #[test]
+#[cfg(feature = "wasi")]
 fn exposes_only_wasmtime_run_command() {
     let command = FungiArgs::command();
     let subcommands = command

--- a/fungi/tests/commands.rs
+++ b/fungi/tests/commands.rs
@@ -9,6 +9,18 @@ use fungi::commands::{
 };
 
 #[test]
+fn exposes_only_wasmtime_run_command() {
+    let command = FungiArgs::command();
+    let subcommands = command
+        .get_subcommands()
+        .map(|command| command.get_name())
+        .collect::<Vec<_>>();
+
+    assert!(subcommands.contains(&"run"));
+    assert!(!subcommands.contains(&"serve"));
+}
+
+#[test]
 fn parses_service_apply_with_device() {
     let args = FungiArgs::try_parse_from([
         "fungi",

--- a/fungi/tests/migrate_cli.rs
+++ b/fungi/tests/migrate_cli.rs
@@ -411,6 +411,44 @@ fn current_fungi_bin() -> &'static Path {
 }
 
 #[test]
+fn cli_apply_recovers_after_persistence_failure_without_daemon_restart() {
+    let home = TempDir::new().unwrap();
+    let binary = current_fungi_bin();
+    run_cli(binary, home.path(), &["init"]);
+    let component = home.path().join("component.wasm");
+    fs::write(&component, b"component used only for apply").unwrap();
+    let manifest = home.path().join("retryable.yaml");
+    fs::write(&manifest, format!(
+        "fungi: service/v1\nid: retryable\nrun:\n  provider: wasmtime\n  source:\n    file: {}\npublish:\n  main:\n    tcp:\n      port: {}\n",
+        component.display(), reserve_tcp_port()
+    )).unwrap();
+    let _daemon = start_daemon(binary, home.path());
+    let services = home.path().join("services");
+    fs::remove_dir(&services).unwrap();
+    fs::write(&services, b"blocked").unwrap();
+    let apply_args = [
+        "service",
+        "apply",
+        "retryable",
+        manifest.to_str().unwrap(),
+        "--yes",
+    ];
+    assert!(try_run_cli(binary, home.path(), &apply_args).is_none());
+    assert!(try_run_cli(binary, home.path(), &["service", "inspect", "retryable"]).is_none());
+    fs::remove_file(&services).unwrap();
+    fs::create_dir(&services).unwrap();
+    run_cli(binary, home.path(), &apply_args);
+    let inspect = run_cli(binary, home.path(), &["service", "inspect", "retryable"]);
+    assert!(
+        inspect.stdout.contains("\"phase\": \"stopped\""),
+        "{}",
+        inspect.stdout
+    );
+    run_cli(binary, home.path(), &["service", "remove", "retryable"]);
+    assert_eq!(fs::read_dir(&services).unwrap().count(), 0);
+}
+
+#[test]
 fn cli_keeps_legacy_http_services_manageable_after_upgrade() {
     for legacy_layout in [false, true] {
         let home = TempDir::new().unwrap();

--- a/fungi/tests/migrate_cli.rs
+++ b/fungi/tests/migrate_cli.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use fungi_config::{FungiConfig, devices::DevicesConfig};
-use fungi_daemon::{ServicePortAllocation, ServiceSource, load_service_manifest_yaml_file};
+use fungi_daemon::load_service_manifest_yaml_file;
 use libp2p::PeerId;
 use serde_json::json;
 use tempfile::TempDir;
@@ -194,20 +194,11 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert!(manifest_yaml.contains("$fungi.service.data/cache"));
     assert!(manifest_yaml.contains("$fungi.service.artifacts/component.wasm"));
 
-    let manifest = load_service_manifest_yaml_file(&manifest_path, home.path()).unwrap();
-    assert_eq!(manifest.name, "demo");
-    assert_eq!(manifest.working_dir, None);
-    assert_eq!(manifest.mounts.len(), 1);
-    assert_eq!(manifest.ports[0].host_port, 18080);
-    assert_eq!(manifest.ports[0].service_port, 18080);
-    assert_eq!(
-        manifest.ports[0].host_port_allocation,
-        ServicePortAllocation::Fixed
-    );
-    match &manifest.source {
-        ServiceSource::WasmtimeFile { .. } => {}
-        other => panic!("unexpected migrated manifest source: {other:?}"),
-    }
+    assert!(load_service_manifest_yaml_file(&manifest_path, home.path()).is_err());
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_yaml).unwrap();
+    assert_eq!(manifest["instance"], "demo");
+    assert!(manifest["id"].is_null());
+    assert_eq!(manifest["publish"]["http"]["tcp"]["port"], 18080);
 
     let state_value: serde_json::Value = serde_json::from_str(
         &fs::read_to_string(
@@ -222,6 +213,12 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
     assert_eq!(state_value["schema_version"], 2);
     assert_eq!(state_value["local_service_id"], local_service_id);
     assert_eq!(state_value["desired_state"], "stopped");
+    assert!(
+        state_value["configuration_error"]
+            .as_str()
+            .unwrap()
+            .contains("run-compatible")
+    );
 
     let second_migrate = run_cli(current_fungi_bin(), home.path(), &["migrate"]);
     assert!(second_migrate.stdout.contains("already at version 3"));
@@ -400,7 +397,9 @@ spec:
         let _daemon = start_daemon(current, home.path());
         let inspect = run_cli(current, home.path(), &["service", "inspect", "cli-demo"]);
         assert!(inspect.stdout.contains("\"name\": \"cli-demo\""));
-        assert!(inspect.stdout.contains("\"phase\": \"stopped\""));
+        assert!(inspect.stdout.contains("\"phase\": \"unknown\""));
+        assert!(inspect.stdout.contains("configuration error"));
+        assert!(inspect.stdout.contains("run-compatible"));
     }
 
     let second_migrate = run_cli(current, home.path(), &["migrate"]);
@@ -409,6 +408,108 @@ spec:
 
 fn current_fungi_bin() -> &'static Path {
     Path::new(env!("CARGO_BIN_EXE_fungi"))
+}
+
+#[test]
+fn cli_keeps_legacy_http_services_manageable_after_upgrade() {
+    for legacy_layout in [false, true] {
+        let home = TempDir::new().unwrap();
+        let binary = current_fungi_bin();
+        run_cli(binary, home.path(), &["init"]);
+        let port = reserve_tcp_port();
+        let upgraded_component = home.path().join("upgraded.wasm");
+        fs::write(&upgraded_component, b"replacement component").unwrap();
+        let manifest = format!(
+            "fungi: service/v1\nid: official-recipe\ninstance: demo\nrun:\n  provider: wasmtime\n  source:\n    file: {}\npublish:\n  http:\n    tcp:\n      port: {port}\n",
+            upgraded_component.display()
+        );
+        if legacy_layout {
+            let old_dir = home.path().join("services/demo");
+            fs::create_dir_all(&old_dir).unwrap();
+            fs::write(old_dir.join("keep.txt"), "user data").unwrap();
+            fs::write(home.path().join("services-state.json"), serde_json::to_vec(&json!({
+                "schema_version": 1, "services": {"demo": {
+                    "manifest": {"name": "demo", "runtime": "wasmtime",
+                        "source": {"WasmtimeFile": {"component": upgraded_component}},
+                        "ports": [{"host_port": port, "service_port": port, "protocol": "tcp"}]},
+                    "desired_state": "running"
+                }}
+            })).unwrap()).unwrap();
+        } else {
+            let saved = home.path().join("services/svc_old");
+            fs::create_dir_all(&saved).unwrap();
+            fs::write(
+                saved.join("service.yaml"),
+                manifest.replace("  provider: wasmtime", "  provider: wasmtime\n  mode: http"),
+            )
+            .unwrap();
+            fs::write(
+                saved.join("state.json"),
+                r#"{"schema_version":2,"local_service_id":"svc_old","desired_state":"running"}"#,
+            )
+            .unwrap();
+            let data = home.path().join("appdata/services/svc_old");
+            fs::create_dir_all(&data).unwrap();
+            fs::write(data.join("keep.txt"), "user data").unwrap();
+        }
+        let upgraded_manifest = home.path().join("upgraded.service.yaml");
+        fs::write(&upgraded_manifest, &manifest).unwrap();
+        run_cli(binary, home.path(), &["migrate"]);
+        let daemon = start_daemon(binary, home.path());
+        let inspect = run_cli(binary, home.path(), &["service", "inspect", "demo"]);
+        assert!(
+            inspect.stdout.contains("configuration error"),
+            "{}",
+            inspect.stdout
+        );
+        assert!(inspect.stdout.contains("run-compatible"));
+        assert!(try_run_cli(binary, home.path(), &["service", "start", "demo"]).is_none());
+        let entries = fs::read_dir(home.path().join("services"))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        let id = entries[0].file_name();
+        let data = home
+            .path()
+            .join("appdata/services")
+            .join(&id)
+            .join("keep.txt");
+        run_cli(
+            binary,
+            home.path(),
+            &[
+                "service",
+                "apply",
+                "demo",
+                upgraded_manifest.to_str().unwrap(),
+                "--yes",
+            ],
+        );
+        assert_eq!(fs::read_to_string(&data).unwrap(), "user data");
+        assert!(
+            !fs::read_to_string(entries[0].path().join("service.yaml"))
+                .unwrap()
+                .contains("mode:")
+        );
+        assert!(
+            !fs::read_to_string(entries[0].path().join("state.json"))
+                .unwrap()
+                .contains("configuration_error")
+        );
+        assert_eq!(
+            fs::read_dir(home.path().join("services")).unwrap().count(),
+            1
+        );
+        drop(daemon);
+        let _restarted = start_daemon(binary, home.path());
+        let inspect = run_cli(binary, home.path(), &["service", "inspect", "demo"]);
+        assert!(
+            inspect.stdout.contains("\"phase\": \"stopped\""),
+            "{}",
+            inspect.stdout
+        );
+    }
 }
 
 fn legacy_fungi_bin() -> &'static Path {
@@ -546,6 +647,7 @@ fn reserve_udp_port() -> u16 {
 }
 
 fn start_daemon(binary: &Path, fungi_dir: &Path) -> RunningDaemon {
+    let stderr_path = fungi_dir.join("test-daemon.stderr");
     let mut child = Command::new(binary)
         .arg("--fungi-dir")
         .arg(fungi_dir)
@@ -553,22 +655,31 @@ fn start_daemon(binary: &Path, fungi_dir: &Path) -> RunningDaemon {
         .arg("--exit-on-stdin-close")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(fs::File::create(&stderr_path).unwrap())
         .spawn()
         .unwrap();
     let stdin = child.stdin.take().unwrap();
-    let daemon = RunningDaemon {
+    let mut daemon = RunningDaemon {
         child,
         _stdin: stdin,
     };
 
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
+        if let Some(status) = daemon.child.try_wait().unwrap() {
+            panic!(
+                "daemon exited with {status}: {}",
+                fs::read_to_string(&stderr_path).unwrap()
+            );
+        }
         if try_run_cli(binary, fungi_dir, &["info", "version"]).is_some() {
             return daemon;
         }
         if Instant::now() >= deadline {
-            panic!("daemon did not become ready");
+            panic!(
+                "daemon did not become ready: {}",
+                fs::read_to_string(&stderr_path).unwrap()
+            );
         }
         thread::sleep(Duration::from_millis(100));
     }

--- a/fungi/tests/migrate_cli.rs
+++ b/fungi/tests/migrate_cli.rs
@@ -9,9 +9,7 @@ use std::{
 };
 
 use fungi_config::{FungiConfig, devices::DevicesConfig};
-use fungi_daemon::{
-    ServicePortAllocation, ServiceRunMode, ServiceSource, load_service_manifest_yaml_file,
-};
+use fungi_daemon::{ServicePortAllocation, ServiceSource, load_service_manifest_yaml_file};
 use libp2p::PeerId;
 use serde_json::json;
 use tempfile::TempDir;
@@ -198,7 +196,6 @@ fn cli_migrate_upgrades_real_v061_home_with_legacy_address_book_and_service_stat
 
     let manifest = load_service_manifest_yaml_file(&manifest_path, home.path()).unwrap();
     assert_eq!(manifest.name, "demo");
-    assert_eq!(manifest.run_mode, ServiceRunMode::Http);
     assert_eq!(manifest.working_dir, None);
     assert_eq!(manifest.mounts.len(), 1);
     assert_eq!(manifest.ports[0].host_port, 18080);

--- a/fungi/tests/wasmtime_errors.rs
+++ b/fungi/tests/wasmtime_errors.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "wasi")]
+
+use std::{fs, process::Command};
+
+#[test]
+fn run_preserves_missing_command_export_and_import_causes() {
+    let temp = tempfile::TempDir::new().unwrap();
+    for (name, wat, cause) in [
+        ("non-command", "(component)", "wasi:cli/run@"),
+        (
+            "missing-import",
+            r#"(module (import "missing" "function" (func)) (func (export "_start")))"#,
+            "unknown import: missing::function has not been defined",
+        ),
+    ] {
+        let path = temp.path().join(format!("{name}.wat"));
+        fs::write(&path, wat).unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_fungi"))
+            .args(["run", "-Ccache=n"])
+            .arg(&path)
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr).replace('`', "");
+        assert!(stderr.contains("failed to run main module"), "{stderr}");
+        assert!(stderr.contains(cause), "{stderr}");
+    }
+}


### PR DESCRIPTION
## Summary

Wasmtime services now run as long-lived command components that own their TCP listeners and shared application state. Fungi no longer exposes or compiles Wasmtime `serve`, and `run.mode` is removed from the service manifest schema.

Existing HTTP services remain visible and manageable after upgrading. A saved `run.mode: http`, malformed manifest, or unsupported service state file produces a per-service configuration error instead of aborting daemon startup. Users apply a run-compatible recipe under the same instance name to rewrite the saved configuration and preserve its local service ID and appdata.

## Changes

- Execute Wasmtime services exclusively through `run`, with WASI outgoing HTTP/HTTPS and TCP permissions for published TCP endpoints. Explicitly install Ring for the Wasmtime command to avoid ambiguity with the daemon's AWS-LC dependency.
- Isolate service configuration failures from healthy services and report them through the existing `status.phase` / `status.detail` path, shared by CLI, RPC and app clients. Failed entries cannot autostart; inspect/start show actionable errors, and remove remains available. Unrecoverable identities fall back to local service IDs; duplicate names cannot silently select another entry's data.
- Preserve pre-0.7 HTTP services as non-executable migration entries with a persisted `configuration_error`. Preserve their instance names without inventing a recipe definition ID. A successful explicit apply clears the error and rewrites both saved files. Failed entries remain stopped unless the user requests start.
- Keep definition-ID checks for identified services, preserve errors when persistence fails, and expose runtime restore/inspection errors in status details.
- Roll back runtime creation when apply persistence fails, using the shared Wasmtime/Docker cleanup path. If cleanup also fails, expose it through service status and let apply/remove retry it. Serialize operations on the same service so rollback cannot remove a concurrent registration; unrelated services use separate locks.
- Restore the previous `service.yaml` if writing `state.json` fails, and keep the in-memory desired state unchanged on a failed save. Report the original and rollback errors if recovery also fails. This handles returned I/O errors without introducing a crash-atomic multi-file storage format.
- Preserve Wasmtime's underlying error chain through a boxed conversion into `anyhow::Error`, including missing command exports and unresolved imports.
- Add the [upgrade guide](https://github.com/enbop-dev/fungi/blob/refactor/wasmtime-run-only/WASMTIME-RUN-MIGRATION.md) and regression coverage for both historical layouts, healthy-service restoration, corrupt/unsupported state, duplicate names, and same-instance upgrades preserving data.

The AI review's legacy migration failure is confirmed and addressed: an old incoming-handler component is never silently treated as a runnable command. Removing `run.mode` alone is not an application upgrade. Directory-wide I/O failures and invalid daemon configuration remain startup errors.

## Verification

- `cargo fmt --all -- --check`
- `cargo build --offline`
- `cargo test --all --offline`
- `cargo test -p fungi --no-default-features --test commands --offline`
- Local run-compatible filebrowser-lite component: `GET /api/health` returns 200; WebDAV component: `PROPFIND /` returns 207.
- A WASIp2 outgoing request to `https://example.com/` through `fungi run -Shttp` returns `200 OK`.
- Real CLI/daemon regression: migrate both pre-0.7 state and 0.7.1 HTTP manifests, inspect the configuration error, reject start, apply an upgraded definition under the same instance name, preserve appdata/local ID, and restart successfully. This test uses inert component bytes for persistence checks; runtime start is covered separately with the fake-launcher lifecycle tests.

The existing two release-download migration tests and two daemon doctests remain ignored. macOS emits the existing `__eh_frame` linker warning.

Latest follow-up verification: 313 tests passed, 0 failed, 4 existing ignored tests/doctests. The no-WASI commands suite passed 38 tests and correctly excluded the Wasmtime error test.

New tests cover first-apply failure followed by a successful retry without daemon restart, failed upgrades retaining the old manifest/error and appdata, cleanup failures remaining inspectable and supporting retry/remove, and per-service operation serialization. A real CLI/daemon test exercises the persistence-failure retry, and actual `fungi run` WAT fixtures assert that missing command-export/import causes remain in stderr.

The Docker rollback branch was audited but not exercised against a real engine because the current account cannot access `/var/run/docker.sock`.

## Release order

1. Merge [filebrowser-lite #3](https://github.com/enbop/filebrowser-lite/pull/3) and [webdav-wasi #2](https://github.com/enbop/webdav-wasi/pull/2), then publish their run-compatible artifacts.
2. Publish [recipes #9](https://github.com/enbop/fungi-service-recipes/pull/9), using `lite-v0.4.0` and WebDAV `v0.2.0`.
3. Release this core change and align the app's bundled core version when updating it. Existing installed HTTP services require an explicit apply; updating the catalog does not rewrite them.

Tracked by [design issue #48](https://github.com/spore-bot/fungi-dev-docs/issues/48). Unifying TLS providers on Ring remains a low-priority follow-up in [issue #56](https://github.com/spore-bot/fungi-dev-docs/issues/56).

## AI assistance

- Codex; this follow-up was implemented and audited with GPT-6.

